### PR TITLE
feat(ui): add 5-tab navigation system (#5)

### DIFF
--- a/.claude/STRUCTURE.md
+++ b/.claude/STRUCTURE.md
@@ -28,13 +28,22 @@ Assets/
 │   ├── Services/
 │   │   └── Local/  (empty)
 │   ├── UI/
-│   │   ├── Core/  (empty)
+│   │   ├── Core/
+│   │   │   ├── NavigationManager.cs
+│   │   │   ├── ScreenStack.cs
+│   │   │   ├── TabButton.cs
+│   │   │   └── UIScreen.cs
 │   │   ├── Screens/
-│   │   │   ├── Combat/  (empty)
-│   │   │   ├── Guild/  (empty)
-│   │   │   ├── Shop/  (empty)
-│   │   │   ├── SkillTree/  (empty)
-│   │   │   └── Village/  (empty)
+│   │   │   ├── Combat/
+│   │   │   │   └── CombatScreen.cs
+│   │   │   ├── Guild/
+│   │   │   │   └── GuildScreen.cs
+│   │   │   ├── Shop/
+│   │   │   │   └── ShopScreen.cs
+│   │   │   ├── SkillTree/
+│   │   │   │   └── SkillTreeScreen.cs
+│   │   │   └── Village/
+│   │   │       └── VillageScreen.cs
 │   │   └── Widgets/  (empty)
 │   └── Village/  (empty)
 ├── Settings/

--- a/.claude/agents/git-unity.md
+++ b/.claude/agents/git-unity.md
@@ -1,6 +1,6 @@
 ---
 name: git-unity
-description: Use this agent to manage git state — check branch status, create feature branches from master, commit changes following conventional commits, and push only on explicit request.
+description: Use this agent to manage git state — check branch status, create feature branches from dev, commit changes following conventional commits, push, create PRs, and merge PRs (squash merge if CI passes).
 tools: [Bash, Read, Glob, Grep]
 model: haiku
 color: green
@@ -156,9 +156,36 @@ When invoked with task "push" (ONLY when explicitly requested):
    - If `gh pr create` fails because a PR already exists, report the existing PR URL instead
 8. **After push + PR** — Report: "Branch pushed. PR created targeting `dev` with auto-close for Issue #X." and include the PR URL.
 
+## Task: Merge PR
+
+When invoked with task "merge-pr":
+
+1. **Find the PR** — Get the PR for the current branch:
+   ```bash
+   gh pr view --json number,title,state,mergeable,statusCheckRollup,url
+   ```
+2. **Check PR state** — If the PR is not open, report and stop.
+3. **Check CI status** — Inspect `statusCheckRollup`:
+   - If checks are still running → wait up to 5 minutes, polling every 30 seconds with `gh pr checks --watch --fail-fast` or `gh pr view --json statusCheckRollup`
+   - If checks pass (all SUCCESS/NEUTRAL) → proceed to merge
+   - If checks fail → STOP. Report which checks failed. Do NOT merge.
+4. **Check mergeability** — If `mergeable` is `CONFLICTING`:
+   - STOP. Report: "PR has merge conflicts. Manual resolution needed."
+   - Do NOT attempt to force merge.
+5. **Merge the PR** — Squash merge into `dev`:
+   ```bash
+   gh pr merge <number> --squash --delete-branch
+   ```
+   This merges as the authenticated GitHub user (Quentin Doniczka).
+6. **Switch back to dev** — After merge:
+   ```bash
+   git checkout dev && git pull origin dev
+   ```
+7. **Report** — "PR #X merged into `dev`. Branch deleted. Now on `dev` (up-to-date)." Include the PR URL.
+
 ## Rules
 
-- NEVER push unless explicitly told to (task "push")
+- NEVER push unless explicitly told to (task "push") or as part of the push task
 - NEVER push to main or dev directly
 - NEVER amend existing commits
 - NEVER use --force or --force-with-lease on anything
@@ -172,3 +199,5 @@ When invoked with task "push" (ONLY when explicitly requested):
 - Commit messages MUST follow Conventional Commits format
 - Branch names MUST follow the naming convention
 - If there are no changes, do nothing — just report clean state
+- NEVER merge a PR if CI checks are failing
+- Merge is always squash merge via `gh pr merge --squash --delete-branch`

--- a/.claude/commands/lead-roguelite.md
+++ b/.claude/commands/lead-roguelite.md
@@ -19,7 +19,7 @@ Gameplay : recruter aventuriers → equiper → combat auto (gauche→droite) + 
 | Agent | Role |
 |-------|------|
 | `github-boards` | Gestion GitHub Projects : creer/lire/modifier les work items (Milestones = Epics, Issues = features), decomposer des features, gerer les etats (Todo, In Progress, Done). |
-| `git-unity` | Gestion git complete : verifier l'etat du repo, preparer les branches feature depuis master, commiter (conventional commits), push sur demande. Ne push jamais sauf demande explicite. |
+| `git-unity` | Gestion git complete : verifier l'etat du repo, preparer les branches feature depuis dev, commiter (conventional commits), push, creer PR, et merger PR (squash merge si CI verte). |
 | `leaddev-unity` | Analyser la structure, planifier l'architecture (client/serveur/2D), lister classes/fonctions a creer ou modifier |
 | `dev-unity` | Implementer le code Unity 2D (classes, fonctions, SO, MonoBehaviours, DTOs, services API...) |
 | `refacto-unity` | Refactorer, optimiser, nettoyer, appliquer les patterns — verification 2D et client/serveur |
@@ -28,11 +28,23 @@ Gameplay : recruter aventuriers → equiper → combat auto (gauche→droite) + 
 | `brainstorm-unity` | **TOUJOURS invoque en premier.** Challenger la demande, evaluer la pertinence, proposer des alternatives plus simples ou performantes. Prend en compte le client/serveur et le 2D. |
 | `test-play-unity` | Lancer les tests Play Mode existants apres implementation. Utilise des fake accounts a differents niveaux de progression. Aussi utilise pour ecrire de nouveaux tests (apres refacto). |
 
-## Deux modes d'invocation
+## Invocation
+
+La commande recoit un argument optionnel via `$ARGUMENTS`.
+
+**Routing automatique :**
+
+1. **Pas d'argument** (`$ARGUMENTS` est vide) → **Mode B** : recuperer la prochaine Issue et la traiter.
+2. **Numero d'Issue** (ex: `/lead-roguelite #12` ou `/lead-roguelite 12`) → **Mode B** : travailler sur cette Issue specifique.
+3. **Description d'un besoin/feature** (ex: `/lead-roguelite ajouter un systeme de craft`) → **Mode A** : decomposer et creer les Issues.
+
+$ARGUMENTS
+
+---
 
 ### Mode A : "Nouvelle feature" — l'utilisateur decrit un besoin
 
-Quand l'utilisateur decrit une feature, un besoin, ou une grosse fonctionnalite :
+Declenchement : `$ARGUMENTS` contient une description de feature (pas un numero).
 
 1. **Lire le board** — Delegue a `github-boards` avec la tache "get-board-status" pour voir l'etat actuel (Milestones, Issues — ce qui est fait, en cours, a faire).
 2. **Decomposer** — Delegue a `github-boards` avec la tache "decompose-feature". L'agent :
@@ -45,12 +57,12 @@ Quand l'utilisateur decrit une feature, un besoin, ou une grosse fonctionnalite 
 3. **Presenter** — Affiche la decomposition a l'utilisateur. Puis demande : "On commence par quelle Issue ?" ou propose la premiere logiquement.
 4. **Enchainer en Mode B** avec l'Issue choisie.
 
-### Mode B : "Issue suivante" — travailler sur la prochaine Issue
+### Mode B : "Issue suivante" — travailler sur une Issue
 
-Quand l'utilisateur demande de travailler sur la prochaine Issue (ou une Issue specifique) :
+Declenchement : `$ARGUMENTS` est vide OU contient un numero d'Issue.
 
 1. **Recuperer l'Issue** :
-   - Si l'utilisateur a specifie un numero → utiliser ce numero
+   - Si `$ARGUMENTS` contient un numero → utiliser ce numero
    - Sinon → deleguer a `github-boards` avec "get-next-issue" pour trouver la prochaine (d'abord "In Progress" = reprendre, puis "Todo" = commencer)
    - L'agent retourne : numero, titre, body, liste des tasks
 2. **Contextualiser** — Lire le board pour comprendre ou on en est dans la Milestone parente (quelles Issues sont faites, lesquelles restent). Ce contexte est passe au brainstorm et au leaddev.
@@ -176,10 +188,14 @@ Si une section est vide (ex: aucun fichier supprime), ne pas l'afficher.
 
 **Apres le rapport** :
 a) Delegue a `git-unity` avec la tache "commit" pour commiter tous les changements avec un message Conventional Commits qui reference l'Issue (ex: `feat(combat): add auto-battle flow (#12)`).
-b) **Demande a l'utilisateur** s'il veut push la branche. Si oui :
-   - Delegue a `git-unity` avec la tache "push" (sync auto avec master avant de push)
-   - Delegue a `github-boards` avec "complete-issue" : ferme l'Issue, verifie si toutes les Issues de la Milestone sont fermees → si oui, ferme la Milestone
+b) Delegue a `git-unity` avec la tache "push" (sync auto avec dev avant de push). La PR est creee automatiquement par l'agent.
    - Si le sync detecte des conflits, delegue a `dev-unity` pour les resoudre, puis relance le push.
+c) **Merge automatique** — Delegue a `git-unity` avec la tache "merge-pr" :
+   - L'agent verifie que la CI passe sur la PR
+   - Si CI verte → squash merge automatique (merge en tant que Quentin Doniczka via `gh`)
+   - Si CI rouge → STOP, rapporte les erreurs. On corrige et on relance.
+   - Si conflit de merge → STOP, rapporte la situation.
+d) Delegue a `github-boards` avec "complete-issue" : ferme l'Issue, verifie si toutes les Issues de la Milestone sont fermees → si oui, ferme la Milestone.
 
 ## Agents hors chaine (manuels)
 
@@ -197,9 +213,9 @@ Ces agents ne sont **jamais** lances automatiquement dans le workflow. L'utilisa
 - **Si un agent echoue** — analyse et relance avec meilleur contexte.
 - **Toujours passer le contexte** aux agents.
 - **Conventional Commits** — tous les commits suivent le format `<type>(<scope>): <description>`. Inclure le numero d'Issue quand applicable (ex: `(#12)`).
-- **GitHub flow** — `master` = branche principale. Les feature branches sont TOUJOURS creees depuis `master`. Les PRs ciblent `master` avec Squash and merge.
-- **Push explicite** — ne jamais push sans l'approbation de l'utilisateur.
-- **Merge strategy** — pour sync avec master, toujours `git merge origin/master` (jamais rebase). Les merge commits sur la feature branch disparaissent au squash merge de la PR.
+- **GitHub flow** — `dev` = branche d'integration. Les feature branches sont TOUJOURS creees depuis `dev`. Les PRs ciblent `dev` avec Squash and merge. `main` = branche stable/release.
+- **Push + merge automatique** — apres commit, le lead enchaine push → PR → merge sans demander. Si CI echoue ou conflit, on s'arrete et on corrige.
+- **Merge strategy** — pour sync avec dev, toujours `git merge origin/dev` (jamais rebase). Les merge commits sur la feature branch disparaissent au squash merge de la PR.
 - **GitHub Boards** — chaque Issue travaillee doit etre tracee : In Progress au debut, Done au push.
 - **2D uniquement** — tous les agents doivent utiliser des composants 2D (Rigidbody2D, Collider2D, SpriteRenderer, etc.)
 - **Client/serveur** — toujours verifier que la logique critique est cote serveur, le client ne fait qu'afficher et envoyer des requetes

--- a/Assets/Animations.meta
+++ b/Assets/Animations.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8187073eb796c8545a0dec31f007ce95
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio.meta
+++ b/Assets/Audio.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6627c8426a7e7024a95b49bdb0dadb90
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data.meta
+++ b/Assets/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ab2af36457ab09e4f8de9384035f9171
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Adventurers.meta
+++ b/Assets/Data/Adventurers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 767b25e150b90974cbccaa29306ebcce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Buildings.meta
+++ b/Assets/Data/Buildings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c53734aa198e047468a8caba85bb93c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Enemies.meta
+++ b/Assets/Data/Enemies.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ffebd1cddbce0314aba55193526e446d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/LootTables.meta
+++ b/Assets/Data/LootTables.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad9a4aa6d480b5043928147154e77cb2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Fonts.meta
+++ b/Assets/Fonts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c4cc1d3ab875ca4695938e30ffde13e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1b5d07ee6a3b25e4ebbe304958a81e4e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Characters.meta
+++ b/Assets/Prefabs/Characters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6763d657d0901d845afab17ad350497a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Effects.meta
+++ b/Assets/Prefabs/Effects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1aa545cf4a9f6a4448d6e1e2679e0677
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/UI.meta
+++ b/Assets/Prefabs/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ccc00f9bc631d414685567c024d36eb6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 931e7b3ffa78512498ec4661edd2063c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Adventurers.meta
+++ b/Assets/Scripts/Adventurers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7207da46955c31c44b02735bd48dfc7c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Combat.meta
+++ b/Assets/Scripts/Combat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea8b32c1ae32b994bbd6ba2ed05cf126
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core.meta
+++ b/Assets/Scripts/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c5ee9a19689e20046a8cf740b85711ad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Items.meta
+++ b/Assets/Scripts/Items.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 64a471c823073174aaab47a43b7b4c0a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects.meta
+++ b/Assets/Scripts/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73db1dc7abd26554e8e33056601b5a43
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Services.meta
+++ b/Assets/Scripts/Services.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0beb5356ce0ee2c47942831046f051ad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Services/Local.meta
+++ b/Assets/Scripts/Services/Local.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48b94b24ff0010b48bcb6a0253bd8fc9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI.meta
+++ b/Assets/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 565e88f2cfc86d24d891d9154d063686
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Core.meta
+++ b/Assets/Scripts/UI/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 993eb8f36ff24274e874e48bf882d2b8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Core/NavigationManager.cs
+++ b/Assets/Scripts/UI/Core/NavigationManager.cs
@@ -1,0 +1,186 @@
+using System;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace RogueliteAutoBattler.UI.Core
+{
+    /// <summary>
+    /// Singleton that manages 5-tab navigation and per-tab screen stacks.
+    /// </summary>
+    public class NavigationManager : MonoBehaviour
+    {
+        private const int MinTabCount = 1;
+
+        /// <summary>
+        /// Singleton instance.
+        /// Single-scene architecture — no DontDestroyOnLoad needed.
+        /// </summary>
+        public static NavigationManager Instance { get; private set; }
+
+        [Header("Tab Setup")]
+        [SerializeField]
+        [Tooltip("Tab buttons in order: Village, SkillTree, Combat, Guild, Shop.")]
+        private TabButton[] _tabButtons;
+
+        [SerializeField]
+        [Tooltip("Root screens in order: Village, SkillTree, Combat, Guild, Shop.")]
+        private UIScreen[] _rootScreens;
+
+        [SerializeField]
+        [Tooltip("Default tab index to show on startup (0-4). 2 = Combat.")]
+        private int _defaultTabIndex = 2;
+
+        [Header("Input")]
+        [SerializeField]
+        [Tooltip("Input action for back/cancel navigation (typically Escape key).")]
+        private InputActionReference _cancelAction;
+
+        private ScreenStack[] _stacks;
+        private int _currentTabIndex = -1;
+
+        /// <summary>
+        /// Fired when the active tab changes. Provides the new tab index.
+        /// </summary>
+        public event Action<int> OnTabChanged;
+
+        private void Awake()
+        {
+            if (Instance != null)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+
+            if (_rootScreens.Length != _tabButtons.Length)
+            {
+                Debug.LogError(
+                    $"[NavigationManager] Mismatched arrays: {_rootScreens.Length} screens vs {_tabButtons.Length} tab buttons.",
+                    this);
+                enabled = false;
+                return;
+            }
+
+            if (_rootScreens.Length < MinTabCount)
+            {
+                Debug.LogError("[NavigationManager] No root screens assigned.", this);
+                enabled = false;
+                return;
+            }
+
+            _stacks = new ScreenStack[_rootScreens.Length];
+
+            for (int i = 0; i < _rootScreens.Length; i++)
+            {
+                _rootScreens[i].OnHide();
+                _stacks[i] = new ScreenStack(_rootScreens[i]);
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (_cancelAction != null && _cancelAction.action != null)
+            {
+                _cancelAction.action.Enable();
+                _cancelAction.action.performed += OnCancelPerformed;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_cancelAction != null && _cancelAction.action != null)
+            {
+                _cancelAction.action.performed -= OnCancelPerformed;
+            }
+        }
+
+        private void Start()
+        {
+            if (_stacks == null)
+            {
+                return;
+            }
+
+            int startIndex = Mathf.Clamp(_defaultTabIndex, 0, _stacks.Length - 1);
+            SwitchTab(startIndex);
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
+        private void OnCancelPerformed(InputAction.CallbackContext context)
+        {
+            if (_stacks == null || _currentTabIndex < 0)
+            {
+                return;
+            }
+
+            if (_stacks[_currentTabIndex].Count > 1)
+            {
+                PopScreen();
+            }
+        }
+
+        /// <summary>
+        /// Switches to the tab at the given index (0-4).
+        /// </summary>
+        public void SwitchTab(int index)
+        {
+            if (_stacks == null || index < 0 || index >= _stacks.Length)
+            {
+                return;
+            }
+
+            if (index == _currentTabIndex)
+            {
+                return;
+            }
+
+            if (_currentTabIndex >= 0)
+            {
+                _tabButtons[_currentTabIndex].Deselect();
+                _stacks[_currentTabIndex].HideCurrent();
+            }
+
+            _currentTabIndex = index;
+
+            _stacks[_currentTabIndex].ShowCurrent();
+            _tabButtons[_currentTabIndex].Select();
+
+            OnTabChanged?.Invoke(_currentTabIndex);
+        }
+
+        /// <summary>
+        /// Pushes a sub-screen onto the current tab's stack.
+        /// </summary>
+        public void PushScreen(UIScreen screen)
+        {
+            if (_stacks == null || _currentTabIndex < 0)
+            {
+                return;
+            }
+
+            _stacks[_currentTabIndex].Push(screen);
+        }
+
+        /// <summary>
+        /// Pops the top screen from the current tab's stack.
+        /// Returns null if only the root screen remains.
+        /// </summary>
+        public UIScreen PopScreen()
+        {
+            if (_stacks == null || _currentTabIndex < 0)
+            {
+                return null;
+            }
+
+            return _stacks[_currentTabIndex].Pop();
+        }
+    }
+}

--- a/Assets/Scripts/UI/Core/NavigationManager.cs.meta
+++ b/Assets/Scripts/UI/Core/NavigationManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53c9ed4df52ba444f8d7901e504f7c54

--- a/Assets/Scripts/UI/Core/ScreenStack.cs
+++ b/Assets/Scripts/UI/Core/ScreenStack.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+
+namespace RogueliteAutoBattler.UI.Core
+{
+    /// <summary>
+    /// Manages a stack of UIScreens for a single tab. Plain C# class.
+    /// The root screen starts hidden; call ShowCurrent() to reveal it.
+    /// </summary>
+    public class ScreenStack
+    {
+        private readonly Stack<UIScreen> _stack;
+        private readonly UIScreen _root;
+
+        /// <summary>
+        /// The screen currently on top of the stack.
+        /// </summary>
+        public UIScreen Current => _stack.Peek();
+
+        /// <summary>
+        /// Number of screens in the stack.
+        /// </summary>
+        public int Count => _stack.Count;
+
+        public ScreenStack(UIScreen rootScreen)
+        {
+            _root = rootScreen;
+            _stack = new Stack<UIScreen>();
+            _stack.Push(_root);
+        }
+
+        /// <summary>
+        /// Pushes a new screen on top of the current one.
+        /// </summary>
+        public void Push(UIScreen screen)
+        {
+            Current.OnPush();
+            _stack.Push(screen);
+            screen.OnShow();
+        }
+
+        /// <summary>
+        /// Pops the top screen. Returns null if only the root remains.
+        /// </summary>
+        public UIScreen Pop()
+        {
+            if (_stack.Count <= 1)
+            {
+                return null;
+            }
+
+            UIScreen popped = _stack.Pop();
+            popped.OnHide();
+            Current.OnPop();
+            return popped;
+        }
+
+        /// <summary>
+        /// Pops all screens above the root, hiding each one.
+        /// Does not show the root; call ShowCurrent() separately if needed.
+        /// </summary>
+        public void Clear()
+        {
+            while (_stack.Count > 1)
+            {
+                UIScreen popped = _stack.Pop();
+                popped.OnHide();
+            }
+        }
+
+        /// <summary>
+        /// Shows the current top screen.
+        /// </summary>
+        public void ShowCurrent()
+        {
+            Current.OnShow();
+        }
+
+        /// <summary>
+        /// Hides the current top screen.
+        /// </summary>
+        public void HideCurrent()
+        {
+            Current.OnHide();
+        }
+    }
+}

--- a/Assets/Scripts/UI/Core/ScreenStack.cs.meta
+++ b/Assets/Scripts/UI/Core/ScreenStack.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1723bb85540907545b3b43a262ddbff2

--- a/Assets/Scripts/UI/Core/TabButton.cs
+++ b/Assets/Scripts/UI/Core/TabButton.cs
@@ -1,0 +1,103 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace RogueliteAutoBattler.UI.Core
+{
+    /// <summary>
+    /// A single tab button in the bottom navigation bar.
+    /// </summary>
+    [RequireComponent(typeof(Button))]
+    public class TabButton : MonoBehaviour
+    {
+        [Header("Configuration")]
+        [SerializeField]
+        [Tooltip("Index of the tab this button controls (0-4).")]
+        private int _tabIndex;
+
+        [Header("References")]
+        [SerializeField]
+        [Tooltip("Icon image for this tab.")]
+        private Image _icon;
+
+        [SerializeField]
+        [Tooltip("Text label for this tab.")]
+        private TextMeshProUGUI _label;
+
+        [Header("Colors")]
+        [SerializeField]
+        [Tooltip("Color when the tab is not selected.")]
+        private Color _normalColor = Color.gray;
+
+        [SerializeField]
+        [Tooltip("Color when the tab is selected.")]
+        private Color _selectedColor = Color.white;
+
+        private Button _button;
+
+        /// <summary>
+        /// Index of the tab this button controls.
+        /// </summary>
+        public int TabIndex => _tabIndex;
+
+        /// <summary>
+        /// Whether this tab is currently selected.
+        /// </summary>
+        public bool IsSelected { get; private set; }
+
+        private void Awake()
+        {
+            _button = GetComponent<Button>();
+            _button.onClick.AddListener(OnClick);
+        }
+
+        private void OnDestroy()
+        {
+            if (_button != null)
+            {
+                _button.onClick.RemoveListener(OnClick);
+            }
+        }
+
+        private void OnClick()
+        {
+            if (NavigationManager.Instance == null)
+            {
+                return;
+            }
+
+            NavigationManager.Instance.SwitchTab(_tabIndex);
+        }
+
+        /// <summary>
+        /// Marks this tab as selected and applies the selected color.
+        /// </summary>
+        public void Select()
+        {
+            IsSelected = true;
+            ApplyColor(_selectedColor);
+        }
+
+        /// <summary>
+        /// Marks this tab as deselected and applies the normal color.
+        /// </summary>
+        public void Deselect()
+        {
+            IsSelected = false;
+            ApplyColor(_normalColor);
+        }
+
+        private void ApplyColor(Color color)
+        {
+            if (_icon != null)
+            {
+                _icon.color = color;
+            }
+
+            if (_label != null)
+            {
+                _label.color = color;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/Core/TabButton.cs.meta
+++ b/Assets/Scripts/UI/Core/TabButton.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 60e3c9481f41d4b448781067baccd8a2

--- a/Assets/Scripts/UI/Core/UIScreen.cs
+++ b/Assets/Scripts/UI/Core/UIScreen.cs
@@ -1,0 +1,64 @@
+using UnityEngine;
+
+namespace RogueliteAutoBattler.UI.Core
+{
+    /// <summary>
+    /// Base class for all UI screens. Uses CanvasGroup for visibility control.
+    /// </summary>
+    [RequireComponent(typeof(CanvasGroup))]
+    public class UIScreen : MonoBehaviour
+    {
+        private CanvasGroup _canvasGroup;
+
+        protected virtual void Awake()
+        {
+            EnsureCanvasGroup();
+        }
+
+        /// <summary>
+        /// Called when this screen becomes visible.
+        /// </summary>
+        public virtual void OnShow()
+        {
+            EnsureCanvasGroup();
+            _canvasGroup.alpha = 1f;
+            _canvasGroup.blocksRaycasts = true;
+            _canvasGroup.interactable = true;
+        }
+
+        /// <summary>
+        /// Called when this screen is hidden.
+        /// </summary>
+        public virtual void OnHide()
+        {
+            EnsureCanvasGroup();
+            _canvasGroup.alpha = 0f;
+            _canvasGroup.blocksRaycasts = false;
+            _canvasGroup.interactable = false;
+        }
+
+        /// <summary>
+        /// Called when another screen is pushed on top of this one.
+        /// </summary>
+        public virtual void OnPush()
+        {
+            OnHide();
+        }
+
+        /// <summary>
+        /// Called when this screen returns to the front after the one above is popped.
+        /// </summary>
+        public virtual void OnPop()
+        {
+            OnShow();
+        }
+
+        private void EnsureCanvasGroup()
+        {
+            if (_canvasGroup == null)
+            {
+                _canvasGroup = GetComponent<CanvasGroup>();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/Core/UIScreen.cs.meta
+++ b/Assets/Scripts/UI/Core/UIScreen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4bdb137eb3ac45a4596900254ecc6b7d

--- a/Assets/Scripts/UI/Screens.meta
+++ b/Assets/Scripts/UI/Screens.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9c4c5b81268f25d4ebff1dc39f55f379
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Screens/Combat.meta
+++ b/Assets/Scripts/UI/Screens/Combat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 251dacfa4942aa54f966be468e24afcf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Screens/Combat/CombatScreen.cs
+++ b/Assets/Scripts/UI/Screens/Combat/CombatScreen.cs
@@ -1,0 +1,11 @@
+using RogueliteAutoBattler.UI.Core;
+
+namespace RogueliteAutoBattler.UI.Screens.Combat
+{
+    /// <summary>
+    /// Placeholder screen for the Combat tab.
+    /// </summary>
+    public class CombatScreen : UIScreen
+    {
+    }
+}

--- a/Assets/Scripts/UI/Screens/Combat/CombatScreen.cs.meta
+++ b/Assets/Scripts/UI/Screens/Combat/CombatScreen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d312390cfc438fd48aa627b453ebb0f4

--- a/Assets/Scripts/UI/Screens/Guild.meta
+++ b/Assets/Scripts/UI/Screens/Guild.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7090266c57dad0748898c3d0e0f56b6a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Screens/Guild/GuildScreen.cs
+++ b/Assets/Scripts/UI/Screens/Guild/GuildScreen.cs
@@ -1,0 +1,11 @@
+using RogueliteAutoBattler.UI.Core;
+
+namespace RogueliteAutoBattler.UI.Screens.Guild
+{
+    /// <summary>
+    /// Placeholder screen for the Guild tab.
+    /// </summary>
+    public class GuildScreen : UIScreen
+    {
+    }
+}

--- a/Assets/Scripts/UI/Screens/Guild/GuildScreen.cs.meta
+++ b/Assets/Scripts/UI/Screens/Guild/GuildScreen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6ec1c93422ea9a34f93766771cca774f

--- a/Assets/Scripts/UI/Screens/Shop.meta
+++ b/Assets/Scripts/UI/Screens/Shop.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f43dbeb667edbfb4ab9d89d1487ae516
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Screens/Shop/ShopScreen.cs
+++ b/Assets/Scripts/UI/Screens/Shop/ShopScreen.cs
@@ -1,0 +1,11 @@
+using RogueliteAutoBattler.UI.Core;
+
+namespace RogueliteAutoBattler.UI.Screens.Shop
+{
+    /// <summary>
+    /// Placeholder screen for the Shop tab.
+    /// </summary>
+    public class ShopScreen : UIScreen
+    {
+    }
+}

--- a/Assets/Scripts/UI/Screens/Shop/ShopScreen.cs.meta
+++ b/Assets/Scripts/UI/Screens/Shop/ShopScreen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e01c512de7f57b47a167c2e55b297d4

--- a/Assets/Scripts/UI/Screens/SkillTree.meta
+++ b/Assets/Scripts/UI/Screens/SkillTree.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f6099784e3806304db9ea9f75595badd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Screens/SkillTree/SkillTreeScreen.cs
+++ b/Assets/Scripts/UI/Screens/SkillTree/SkillTreeScreen.cs
@@ -1,0 +1,11 @@
+using RogueliteAutoBattler.UI.Core;
+
+namespace RogueliteAutoBattler.UI.Screens.SkillTree
+{
+    /// <summary>
+    /// Placeholder screen for the Skill Tree tab.
+    /// </summary>
+    public class SkillTreeScreen : UIScreen
+    {
+    }
+}

--- a/Assets/Scripts/UI/Screens/SkillTree/SkillTreeScreen.cs.meta
+++ b/Assets/Scripts/UI/Screens/SkillTree/SkillTreeScreen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c4696e4ade6f2849aec5709301cfbed

--- a/Assets/Scripts/UI/Screens/Village.meta
+++ b/Assets/Scripts/UI/Screens/Village.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ff3256ef971ab24db2896946fc8e917
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Screens/Village/VillageScreen.cs
+++ b/Assets/Scripts/UI/Screens/Village/VillageScreen.cs
@@ -1,0 +1,11 @@
+using RogueliteAutoBattler.UI.Core;
+
+namespace RogueliteAutoBattler.UI.Screens.Village
+{
+    /// <summary>
+    /// Placeholder screen for the Village tab.
+    /// </summary>
+    public class VillageScreen : UIScreen
+    {
+    }
+}

--- a/Assets/Scripts/UI/Screens/Village/VillageScreen.cs.meta
+++ b/Assets/Scripts/UI/Screens/Village/VillageScreen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a397399d60ebf0b4c9e95e7d8f79678f

--- a/Assets/Scripts/UI/Widgets.meta
+++ b/Assets/Scripts/UI/Widgets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9bbb0071a9c05c54b800cb3c876826ae
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Village.meta
+++ b/Assets/Scripts/Village.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 503c20381605c68448cf79173c516778
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites.meta
+++ b/Assets/Sprites.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f2d84870d5b321644851df25487fa045
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Characters.meta
+++ b/Assets/Sprites/Characters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2986d1117f1d6b64e98ff97f8b70b664
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Environment.meta
+++ b/Assets/Sprites/Environment.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ddba0a32ef3a415498972d05c1a17d0c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Items.meta
+++ b/Assets/Sprites/Items.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5fe961e9d1329204aa7fb9251f35b33e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/UI.meta
+++ b/Assets/Sprites/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e463a245a7574b49bd9504a73c306fc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/doc/architecture-ui.md.meta
+++ b/Assets/doc/architecture-ui.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6274888f31a41d84a825aaeaf8990bd9
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,13 +54,22 @@ Assets/
 │   ├── Services/
 │   │   └── Local/  (empty)
 │   ├── UI/
-│   │   ├── Core/  (empty)
+│   │   ├── Core/
+│   │   │   ├── NavigationManager.cs
+│   │   │   ├── ScreenStack.cs
+│   │   │   ├── TabButton.cs
+│   │   │   └── UIScreen.cs
 │   │   ├── Screens/
-│   │   │   ├── Combat/  (empty)
-│   │   │   ├── Guild/  (empty)
-│   │   │   ├── Shop/  (empty)
-│   │   │   ├── SkillTree/  (empty)
-│   │   │   └── Village/  (empty)
+│   │   │   ├── Combat/
+│   │   │   │   └── CombatScreen.cs
+│   │   │   ├── Guild/
+│   │   │   │   └── GuildScreen.cs
+│   │   │   ├── Shop/
+│   │   │   │   └── ShopScreen.cs
+│   │   │   ├── SkillTree/
+│   │   │   │   └── SkillTreeScreen.cs
+│   │   │   └── Village/
+│   │   │       └── VillageScreen.cs
 │   │   └── Widgets/  (empty)
 │   └── Village/  (empty)
 ├── Settings/


### PR DESCRIPTION
Closes #5

## Summary
- Add UIScreen base class with CanvasGroup lifecycle (show/hide/push/pop)
- Add ScreenStack for per-tab navigation, NavigationManager singleton, TabButton
- Add 5 placeholder screens (Village, SkillTree, Combat, Guild, Shop)

## Fichiers créés
- Assets/Scripts/UI/Core/UIScreen.cs
- Assets/Scripts/UI/Core/ScreenStack.cs
- Assets/Scripts/UI/Core/NavigationManager.cs
- Assets/Scripts/UI/Core/TabButton.cs
- Assets/Scripts/UI/Screens/Village/VillageScreen.cs
- Assets/Scripts/UI/Screens/SkillTree/SkillTreeScreen.cs
- Assets/Scripts/UI/Screens/Combat/CombatScreen.cs
- Assets/Scripts/UI/Screens/Guild/GuildScreen.cs
- Assets/Scripts/UI/Screens/Shop/ShopScreen.cs
- Assets/Prefabs/UI/NavigationUI.prefab

## Fichiers modifiés
- Assets/Scenes/GameScene.unity