### PR TITLE
fix(editor): move setup menu to Roguelite top menu (#33)

### DIFF
--- a/Assets/Scripts/Editor/SetupNavigationSceneEditor.cs
+++ b/Assets/Scripts/Editor/SetupNavigationSceneEditor.cs
@@ -42,7 +42,7 @@ namespace RogueliteAutoBattler.Editor
         private static readonly Color ModalOverlayColor = (Color)new Color32(0, 0, 0, 150);
         private static readonly Color TransparentWhite = new(1f, 1f, 1f, 0f);
 
-        [MenuItem("GameObject/UI/Setup Navigation UI")]
+        [MenuItem("Roguelite/Setup Navigation UI")]
         private static void SetupNavigationUI()
         {
             Canvas existingCanvas = Object.FindFirstObjectByType<Canvas>(FindObjectsInactive.Include);


### PR DESCRIPTION
Closes #33

Move the navigation setup MenuItem from hidden GameObject/UI submenu to a dedicated Roguelite top-level menu for better discoverability.