### PR TITLE
refactor: remove all comments and enforce no-comment rule (#82)

### DIFF
--- a/.claude/STRUCTURE.md
+++ b/.claude/STRUCTURE.md
@@ -1,5 +1,5 @@
 # Project Structure
-Generated: 2026-03-26
+Generated: 2026-03-27
 
 Assets/
 ├── Animations/  (23 files: .anim + .controller)

--- a/.claude/agents/dev-unity.md
+++ b/.claude/agents/dev-unity.md
@@ -26,7 +26,7 @@ You are a senior Unity 2D C# developer working on a **Roguelite Auto-Battler 2D*
 ## Core Principles
 
 - Follow **SOLID, KISS, DRY, YAGNI**. Simplest working design.
-- Code in **English**. Clear naming over comments.
+- Code in **English**. **NEVER write comments** — no `//`, no `/* */`, no `/// <summary>`, no `[Tooltip]` text that duplicates the field name. Use verbose, self-documenting names instead. The only acceptable comments are `// TODO:` for critical unresolved issues.
 - No over-engineering. Keep files and classes small.
 
 ## Naming Conventions
@@ -53,9 +53,9 @@ You are a senior Unity 2D C# developer working on a **Roguelite Auto-Battler 2D*
 ## Unity 2D Standards
 
 - One MonoBehaviour per file, file name = class name
-- `[Header]` and `[Tooltip]` on serialized fields
+- `[Header]` on serialized field groups (no `[Tooltip]` — use descriptive field names instead)
 - `[RequireComponent]` when dependencies are mandatory
-- XML doc on public members
+- **No XML doc comments** — use descriptive method/class names instead
 - `Update` for input/non-physics logic, `FixedUpdate` for Rigidbody2D physics, `LateUpdate` for camera follow
 - Use **Rigidbody2D** and **Collider2D** (BoxCollider2D, CircleCollider2D, CapsuleCollider2D) — never 3D physics components
 - Use **SpriteRenderer** for game objects, **UI Image/TextMeshPro** for UI
@@ -87,7 +87,6 @@ Root (Rigidbody2D, CharacterMover, CombatController — NO Animator, NO SpriteRe
 private void Awake()
 {
     _rb = GetComponent<Rigidbody2D>();
-    // GetComponentInChildren — Animator is on the Visual child, not this GameObject
     _animator = GetComponentInChildren<Animator>();
     _animator.applyRootMotion = false;
 }
@@ -98,22 +97,18 @@ private void Awake()
 **Always use this pattern for animated characters**:
 
 ```csharp
-// Awake — enforce applyRootMotion off in code, never rely on prefab setting
 private void Awake()
 {
     _rb = GetComponent<Rigidbody2D>();
-    _animator = GetComponentInChildren<Animator>(); // Visual child, not root
+    _animator = GetComponentInChildren<Animator>();
     _animator.applyRootMotion = false;
 }
 
-// FixedUpdate — physics layer is separate from Animator layer, no interference
 private void FixedUpdate()
 {
     _rb.linearVelocity = new Vector2(_speed, 0f);
 }
 
-// Use animator.Play() for simple state changes — more robust than SetBool + transitions
-// SetBool + transitions require the animator controller to have transitions wired correctly
 private void SetMoving(bool isMoving)
 {
     _animator.Play(isMoving ? "Walk" : "Idle");
@@ -132,15 +127,12 @@ private void SetMoving(bool isMoving)
 When implementing client-side code that talks to the server:
 
 ```csharp
-// Use a service layer for API calls
 public interface IApiService
 {
     UniTask<RecruitResponse> RecruitAdventurer(RecruitRequest request);
     UniTask<CombatResult> SubmitCombatResult(CombatSubmission submission);
-    // etc.
 }
 
-// DTOs are plain C# classes (no MonoBehaviour), separate from game models
 public class RecruitResponse
 {
     public AdventurerDto Adventurer { get; set; }
@@ -229,7 +221,6 @@ When the implementation requires creating Unity assets that can't be produced by
 1. Create a static method with `[MenuItem("Builder/Setup/DescriptiveName")]` that generates the asset
 2. At the **end** of the method, after the asset is created successfully, the button **deletes its own script file**:
    ```csharp
-   // Self-destruct: remove this setup script after use
    AssetDatabase.DeleteAsset("Assets/Scripts/Editor/Setup/ThisFileName.cs");
    AssetDatabase.Refresh();
    ```

--- a/.claude/agents/dev-ux-unity.md
+++ b/.claude/agents/dev-ux-unity.md
@@ -197,6 +197,7 @@ public class SetupFeatureBuilderEditor : UnityEditor.Editor
 
 ## Rules
 
+- **NEVER write comments** — no `//`, no `/* */`, no `/// <summary>`, no `[Tooltip]` text that duplicates the field name. Use verbose, self-documenting names instead. The only acceptable comments are `// TODO:` for critical unresolved issues.
 - **All Editor files go in `Assets/Scripts/Editor/`** — namespace `RogueliteAutoBattler.Editor`
 - **Always use `Undo`** — RegisterCreatedObjectUndo, DestroyObjectImmediate, CollapseUndoOperations
 - **Always `MarkSceneDirty`** after modifications

--- a/.claude/agents/refacto-unity.md
+++ b/.claude/agents/refacto-unity.md
@@ -51,6 +51,8 @@ You are a senior Unity 2D refactoring specialist working on a **Roguelite Auto-B
 - **Sensitive data in client code** — API keys, secret formulas, drop tables that should be server-only
 
 ### LOW — Dead Code & Cleanup
+- **All comments** (`//`, `/* */`, `/// <summary>`, XML doc) → remove. Use verbose self-documenting names instead. The only acceptable comments are `// TODO:` for critical unresolved issues.
+- `[Tooltip("...")]` attributes that duplicate the field name → remove (keep `[Header]` for field groups)
 - Unused variables/methods, commented code, stale TODOs, unused usings → remove
 - **Unused files** — Grep the entire project for references. If a `.cs` file is never referenced (no `using`, no `GetComponent`, no serialized field, no menu attribute), flag it for deletion
 - **Unused functions** — If a public/internal method has zero callers across the project, remove it (unless it's a Unity callback like `Awake`, `Update`, `OnEnable`, etc.)

--- a/.claude/agents/review-commit-unity.md
+++ b/.claude/agents/review-commit-unity.md
@@ -65,10 +65,12 @@ You audit ONLY the code that changed in the latest feature/commit for a **Roguel
 
 ### LOW
 
+- **Comments in code** — Any `//`, `/* */`, `/// <summary>`, XML doc comments → flag for removal. Use verbose names instead. Only `// TODO:` for critical issues is acceptable.
+- **`[Tooltip]` attributes** that duplicate the field name → flag for removal
 - **Unused usings** — `using` directives with no references in the file
 - **Naming conventions** — PascalCase for public, _camelCase for private fields, IName for interfaces
 - **Dead code** — Unused variables, commented code, unreachable branches
-- **Missing `[Header]`/`[Tooltip]`** on serialized fields
+- **Missing `[Header]`** on serialized field groups
 
 ## Cross-Reference Check
 

--- a/.claude/agents/review-unity.md
+++ b/.claude/agents/review-unity.md
@@ -84,6 +84,8 @@ This is the key question. Examples:
 
 ### LOW — Naming, conventions, cleanup
 
+- **Comments in code** — Any `//`, `/* */`, `/// <summary>`, XML doc comments should be removed. Use verbose names instead. Only `// TODO:` for critical issues is acceptable.
+- **`[Tooltip]` attributes** that duplicate the field name
 - **File name doesn't match class name** — Required for MonoBehaviours
 - **Inconsistent naming conventions**
 - **Empty folders** with only `.meta` files

--- a/.claude/agents/test-play-unity.md
+++ b/.claude/agents/test-play-unity.md
@@ -443,6 +443,9 @@ public IEnumerator WeaponSprite_SurvivesAnimatorFrames()
 
 ## Rules
 
+### Code Style — No Comments
+- **NEVER write comments** — no `//`, no `/* */`, no `/// <summary>`. Use verbose, self-documenting test method names and variable names instead. The only acceptable comments are `// TODO:` for critical unresolved issues.
+
 ### CRITICAL — Tests Are Safety Nets, Not Obstacles
 
 Tests verify that the app behaves correctly. The goal is that **the final test suite produces the same results** — same behaviors validated, same coverage. Never weaken tests just to make them green.

--- a/Assets/Scripts/Combat/AnimHashes.cs
+++ b/Assets/Scripts/Combat/AnimHashes.cs
@@ -2,18 +2,12 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Pre-hashed Animator state names shared across combat scripts.
-    /// Using int hashes avoids per-call string hashing and prevents silent typo failures.
-    /// </summary>
     public static class AnimHashes
     {
         public static readonly int Idle = Animator.StringToHash("Idle");
         public static readonly int Walk = Animator.StringToHash("Walk");
         public static readonly int Run = Animator.StringToHash("Run");
         public static readonly int ChopAttack = Animator.StringToHash("ChopAttack");
-
-        // Bool parameter used by Idle↔Walk transitions in the animator controller.
         public static readonly int IsMoving = Animator.StringToHash("IsMoving");
     }
 }

--- a/Assets/Scripts/Combat/AnimationEventRelay.cs
+++ b/Assets/Scripts/Combat/AnimationEventRelay.cs
@@ -2,21 +2,15 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Relays animation events from the Visual child (where the Animator lives)
-    /// to the CombatController on the parent root GameObject.
-    /// </summary>
     public class AnimationEventRelay : MonoBehaviour
     {
         private CombatController _controller;
 
-        /// <summary>Binds this relay to the given controller.</summary>
         public void Initialize(CombatController controller)
         {
             _controller = controller;
         }
 
-        // Called by ChopAttack animation event at the hit frame.
         public void OnAttackHit()
         {
             if (_controller != null)

--- a/Assets/Scripts/Combat/AttackSlotRegistry.cs
+++ b/Assets/Scripts/Combat/AttackSlotRegistry.cs
@@ -3,10 +3,6 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Static registry that manages attack slots around each target.
-    /// Ensures multiple attackers spread out instead of stacking on the same point.
-    /// </summary>
     public static class AttackSlotRegistry
     {
         private const float FaceOffset = 0.25f;
@@ -22,14 +18,8 @@ namespace RogueliteAutoBattler.Combat
         private static readonly Dictionary<Transform, List<SlotEntry>> _slots =
             new Dictionary<Transform, List<SlotEntry>>();
 
-        /// <summary>
-        /// Registers <paramref name="attacker"/> on <paramref name="target"/> and returns the slot offset.
-        /// Idempotent: if attacker already registered on this target, returns existing slot.
-        /// If attacker was registered on a different target, releases from old target first.
-        /// </summary>
         public static Vector2 Acquire(Transform target, Transform attacker, bool attackerFacesRight)
         {
-            // If already registered on this target, return existing offset
             if (_slots.TryGetValue(target, out var entries))
             {
                 for (int i = 0; i < entries.Count; i++)
@@ -41,10 +31,8 @@ namespace RogueliteAutoBattler.Combat
                 }
             }
 
-            // Release from any other target the attacker may be registered on
             ReleaseFromAll(attacker);
 
-            // Find the smallest available slot index
             if (!_slots.TryGetValue(target, out entries))
             {
                 entries = new List<SlotEntry>();
@@ -62,10 +50,6 @@ namespace RogueliteAutoBattler.Combat
             return ComputeOffset(slotIndex, attackerFacesRight);
         }
 
-        /// <summary>
-        /// Frees the slot held by <paramref name="attacker"/> on <paramref name="target"/>.
-        /// No-op if not registered.
-        /// </summary>
         public static void Release(Transform target, Transform attacker)
         {
             if (!_slots.TryGetValue(target, out var entries))
@@ -86,19 +70,11 @@ namespace RogueliteAutoBattler.Combat
             }
         }
 
-        /// <summary>
-        /// Frees all slots for <paramref name="target"/>.
-        /// Safety net on target death.
-        /// </summary>
         public static void ReleaseAll(Transform target)
         {
             _slots.Remove(target);
         }
 
-        /// <summary>
-        /// Returns the count of attackers currently registered on <paramref name="target"/>.
-        /// Skips entries where the attacker has been destroyed.
-        /// </summary>
         public static int AttackerCount(Transform target)
         {
             if (!_slots.TryGetValue(target, out var entries))
@@ -116,42 +92,28 @@ namespace RogueliteAutoBattler.Combat
             return count;
         }
 
-        /// <summary>
-        /// Clears the entire registry. Used between levels.
-        /// </summary>
         public static void Clear()
         {
             _slots.Clear();
         }
 
-        /// <summary>
-        /// Computes the world-space offset for a given slot index.
-        /// Front slots (0..MaxFrontSlots-1) are on the facing side.
-        /// Overflow slots (MaxFrontSlots+) are behind the target.
-        /// </summary>
         private static Vector2 ComputeOffset(int slotIndex, bool attackerFacesRight)
         {
             float xSign = attackerFacesRight ? -1f : 1f;
 
             if (slotIndex < MaxFrontSlots)
             {
-                // Front side: slot 0 is center, then alternate top/bottom
                 float x = xSign * FaceOffset;
                 float y = SlotIndexToVertical(slotIndex);
                 return new Vector2(x, y);
             }
 
-            // Overflow: behind the target, same vertical pattern
             int overflowIndex = slotIndex - MaxFrontSlots;
             float xBehind = -xSign * FaceOffset;
             float yBehind = SlotIndexToVertical(overflowIndex);
             return new Vector2(xBehind, yBehind);
         }
 
-        /// <summary>
-        /// Maps a local index (0,1,2,3,4,...) to a vertical offset.
-        /// 0 -> 0, 1 -> +Spacing, 2 -> -Spacing, 3 -> +2*Spacing, 4 -> -2*Spacing, ...
-        /// </summary>
         private static float SlotIndexToVertical(int localIndex)
         {
             if (localIndex == 0) return 0f;
@@ -161,13 +123,8 @@ namespace RogueliteAutoBattler.Combat
             return isTop ? tier * VerticalSpacing : -tier * VerticalSpacing;
         }
 
-        /// <summary>
-        /// Finds the smallest slot index not currently occupied in the entry list.
-        /// Accounts for gaps left by released slots.
-        /// </summary>
         private static int FindSmallestAvailableIndex(List<SlotEntry> entries)
         {
-            // Purge destroyed attackers while we scan
             for (int i = entries.Count - 1; i >= 0; i--)
             {
                 if (entries[i].Attacker == null)
@@ -176,7 +133,6 @@ namespace RogueliteAutoBattler.Combat
                 }
             }
 
-            // Find smallest unused index
             for (int candidate = 0; ; candidate++)
             {
                 bool taken = false;
@@ -193,13 +149,8 @@ namespace RogueliteAutoBattler.Combat
             }
         }
 
-        /// <summary>
-        /// Releases <paramref name="attacker"/> from any target it may be registered on.
-        /// </summary>
         private static void ReleaseFromAll(Transform attacker)
         {
-            // An attacker can only be registered on one target at a time
-            // (Acquire releases from any previous target before registering on the new one).
             Transform targetToClean = null;
 
             foreach (var kvp in _slots)

--- a/Assets/Scripts/Combat/CharacterAppearance.cs
+++ b/Assets/Scripts/Combat/CharacterAppearance.cs
@@ -3,20 +3,6 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Resolves equipment sprite slots on an animated character prefab and allows
-    /// swapping sprites at runtime. Added via <c>AddComponent</c> at spawn time
-    /// on the character root (same level as Rigidbody2D).
-    /// </summary>
-    /// <remarks>
-    /// Equipment slots: head, hat, weapon, shield. Some animation clips (e.g.
-    /// ChopAttack) contain PPtrCurves that override weapon/shield sprites.
-    /// <see cref="LateUpdate"/> re-applies any explicitly set sprites every frame
-    /// so they always win over Animator overrides.
-    /// Body and hand sprites are controlled by Animator curves — do NOT swap them.
-    /// Child names must match the prefab hierarchy exactly because animation clips
-    /// reference children by path name.
-    /// </remarks>
     public class CharacterAppearance : MonoBehaviour
     {
         private const string HeadPath = "human_head_skin_1_0";
@@ -34,16 +20,9 @@ namespace RogueliteAutoBattler.Combat
         private Sprite _appliedWeapon;
         private Sprite _appliedShield;
 
-        /// <summary>SpriteRenderer for the head slot (may be null if not found).</summary>
         public SpriteRenderer HeadRenderer => _headRenderer;
-
-        /// <summary>SpriteRenderer for the hat/armor slot (may be null if not found).</summary>
         public SpriteRenderer HatRenderer => _hatRenderer;
-
-        /// <summary>SpriteRenderer for the weapon slot (may be null if not found).</summary>
         public SpriteRenderer WeaponRenderer => _weaponRenderer;
-
-        /// <summary>SpriteRenderer for the shield slot (may be null if not found).</summary>
         public SpriteRenderer ShieldRenderer => _shieldRenderer;
 
         private void Awake()
@@ -63,14 +42,6 @@ namespace RogueliteAutoBattler.Combat
             _shieldRenderer = FindSlotRenderer(visual, ShieldPath, "Shield");
         }
 
-        /// <summary>
-        /// Applies sprites to the equipment slots. Pass null for any slot to keep
-        /// the prefab default sprite unchanged.
-        /// </summary>
-        /// <param name="head">Sprite for the head slot, or null to keep default.</param>
-        /// <param name="hat">Sprite for the hat/armor slot, or null to keep default.</param>
-        /// <param name="weapon">Sprite for the weapon slot, or null to keep default.</param>
-        /// <param name="shield">Sprite for the shield slot, or null to keep default.</param>
         public void ApplyAppearance(Sprite head, Sprite hat, Sprite weapon, Sprite shield)
         {
             if (head != null && _headRenderer != null)
@@ -98,9 +69,6 @@ namespace RogueliteAutoBattler.Combat
             }
         }
 
-        /// <summary>
-        /// Convenience overload that unpacks an <see cref="AppearanceData"/> and applies its sprites.
-        /// </summary>
         public void ApplyAppearance(AppearanceData appearance)
         {
             if (appearance == null) return;
@@ -108,11 +76,6 @@ namespace RogueliteAutoBattler.Combat
                 appearance.WeaponSprite, appearance.ShieldSprite);
         }
 
-        /// <summary>
-        /// Re-applies tracked sprites after the Animator has written its PPtrCurve
-        /// changes. This ensures custom equipment sprites always win over animation
-        /// defaults.
-        /// </summary>
         private void LateUpdate()
         {
             if (_appliedHead != null && _headRenderer != null)

--- a/Assets/Scripts/Combat/CharacterMover.cs
+++ b/Assets/Scripts/Combat/CharacterMover.cs
@@ -2,27 +2,17 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Moves this character along the X axis toward a target Transform.
-    /// Uses Rigidbody2D.linearVelocity for physics-based movement.
-    /// </summary>
     [RequireComponent(typeof(Rigidbody2D))]
     [RequireComponent(typeof(CircleCollider2D))]
     public class CharacterMover : MonoBehaviour
     {
         [Header("Movement")]
-        [Tooltip("Movement speed in world units per second.")]
         [SerializeField] private float _moveSpeed = 2f;
 
         private const float HomeArrivalThreshold = 0.15f;
         private const float HomeDampingFactor = 8f;
-
-        // During scroll, walk at 90 % of scroll max speed so the conveyor
-        // "distances" the characters slightly at peak speed, then they catch up
-        // as it decelerates.
         private const float ScrollWalkRatio = 0.9f;
 
-        // Shared low-friction material so characters slide past each other.
         private static PhysicsMaterial2D _frictionlessMaterial;
 
         private Transform _target;
@@ -37,30 +27,21 @@ namespace RogueliteAutoBattler.Combat
         private Vector2 _homeOffset;
         private float _homeFacingX;
 
-        /// <summary>Cached Animator from GetComponentInChildren (may be null).</summary>
         public Animator Animator => _animator;
-
-        /// <summary>Whether an Animator was found on this character.</summary>
         public bool HasAnimator => _hasAnimator;
 
-        /// <summary>The Transform this character moves toward. Set to null to stop.</summary>
         public Transform Target
         {
             get => _target;
             set => _target = value;
         }
 
-        /// <summary>
-        /// Screen-absolute anchor to return to when Target is null.
-        /// Should be a Transform outside CombatWorld (e.g. with ScreenAnchor component).
-        /// </summary>
         public Transform HomeAnchor
         {
             get => _homeAnchor;
             set => _homeAnchor = value;
         }
 
-        /// <summary>The formation offset from the home anchor assigned to this character.</summary>
         public Vector2 HomeOffset => _homeOffset;
 
         private void Awake()
@@ -75,7 +56,6 @@ namespace RogueliteAutoBattler.Combat
             else
                 _rb.freezeRotation = true;
 
-            // Low-friction material so characters push each other smoothly without gripping.
             if (_frictionlessMaterial == null)
             {
                 _frictionlessMaterial = new PhysicsMaterial2D("LowFriction")
@@ -92,7 +72,6 @@ namespace RogueliteAutoBattler.Combat
             if (_hasAnimator)
                 _animator.applyRootMotion = false;
 
-            // Store initial facing direction to restore on home arrival.
             _homeFacingX = transform.localScale.x < 0f ? 1f : -1f;
         }
 
@@ -103,18 +82,12 @@ namespace RogueliteAutoBattler.Combat
 
             if (_target == null)
             {
-                // Disable collider when homing so teammates don't block each other.
                 if (_col != null) _col.enabled = false;
 
                 bool scrolling = _conveyor != null && _conveyor.IsScrolling;
 
                 if (scrolling)
                 {
-                    // Dynamic Rigidbody2D children are NOT carried by the
-                    // kinematic parent — apply scroll velocity explicitly.
-                    // Walk toward the screen-anchored home at a constant speed
-                    // slightly below scroll max so characters visibly drift
-                    // during peak speed, then catch up during deceleration.
                     Vector2 scroll = _conveyor.ScrollVelocity;
                     float walkSpeed = _conveyor.MaxSpeed * ScrollWalkRatio;
 
@@ -131,11 +104,10 @@ namespace RogueliteAutoBattler.Combat
                     }
 
                     _rb.linearVelocity = scroll + walkVel;
-                    SetMoving(true, false); // Walk animation always on during scroll
+                    SetMoving(true, false);
                     return;
                 }
 
-                // --- Not scrolling: normal damped homing ---
                 if (_homeAnchor != null)
                 {
                     Vector2 homePos = (Vector2)_homeAnchor.position + _homeOffset;
@@ -164,7 +136,6 @@ namespace RogueliteAutoBattler.Combat
                 return;
             }
 
-            // Re-enable collider in combat mode.
             if (_col != null) _col.enabled = true;
 
             Vector2 destination = (Vector2)_target.position;
@@ -176,29 +147,22 @@ namespace RogueliteAutoBattler.Combat
             SetMoving(true, true);
         }
 
-        /// <summary>Overrides the serialized move speed at runtime (set from stats on spawn).</summary>
         public void SetMoveSpeed(float speed)
         {
             _moveSpeed = speed;
         }
 
-        /// <summary>Sets the formation offset from the home anchor for this character's home position.</summary>
         public void SetHomeOffset(Vector2 offset)
         {
             _homeOffset = offset;
         }
 
-        /// <summary>Immediately zeroes velocity.</summary>
         public void Stop()
         {
             if (_rb != null)
                 _rb.linearVelocity = Vector2.zero;
         }
 
-        /// <summary>
-        /// Flips the character sprite to face the given X direction.
-        /// Sprites face LEFT natively: directionX > 0 flips to face right, directionX &lt; 0 keeps native.
-        /// </summary>
         public void FlipToward(float directionX)
         {
             if (Mathf.Approximately(directionX, 0f))
@@ -220,8 +184,6 @@ namespace RogueliteAutoBattler.Combat
             if (!_hasAnimator)
                 return;
 
-            // Sync the bool parameter so Idle↔Walk transitions
-            // don't fight against Play() calls.
             _animator.SetBool(AnimHashes.IsMoving, _isMoving);
 
             if (!_isMoving)

--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -11,22 +11,13 @@ namespace RogueliteAutoBattler.Combat
         Dead
     }
 
-    /// <summary>
-    /// Manages auto-battle state for a single character. Reads distance to the target
-    /// each FixedUpdate and transitions between Moving and Attacking states.
-    /// Delegates movement to <see cref="CharacterMover"/> and animation to the Animator.
-    /// Damage is dealt via animation event callback (<see cref="OnAnimationHit"/>),
-    /// ensuring visual and logical synchronization.
-    /// </summary>
     [RequireComponent(typeof(CharacterMover))]
     [RequireComponent(typeof(CombatStats))]
     public class CombatController : MonoBehaviour
     {
         [Header("Combat")]
-        [Tooltip("Attack reach in world units (distance check).")]
         [SerializeField] private float _attackRange = 0.5f;
 
-        // Must match the Chop animation clip length.
         private const float ChopAttackDuration = 0.5f;
         private const float FadeOutDuration = 0.25f;
 
@@ -41,29 +32,20 @@ namespace RogueliteAutoBattler.Combat
         private bool _waitingForHit;
         private bool _attackerFacesRight;
 
-        /// <summary>Current combat state of this character.</summary>
         public CombatState State => _state;
 
-        /// <summary>
-        /// Callback to find a new target when the current one dies.
-        /// Set by the spawning system (LevelManager or CombatSpawnManager).
-        /// Returns null if no target is available.
-        /// </summary>
         public System.Func<Transform> FindNewTarget { get; set; }
 
-        /// <summary>Sets whether this attacker approaches from the left (true) or right (false).</summary>
         public void SetAttackerFacing(bool facesRight)
         {
             _attackerFacesRight = facesRight;
         }
 
-        /// <summary>The Transform this character moves toward and attacks.</summary>
         public Transform Target
         {
             get => _mover.Target;
             set
             {
-                // Release slot on old target before unsubscribing
                 if (_mover != null && _mover.Target != null)
                     AttackSlotRegistry.Release(_mover.Target, transform);
 
@@ -73,7 +55,6 @@ namespace RogueliteAutoBattler.Combat
 
                 if (value != null)
                 {
-                    // Register for attacker counting (used by LeastContested targeting).
                     AttackSlotRegistry.Acquire(value, transform, _attackerFacesRight);
 
                     _targetStats = value.GetComponent<CombatStats>();
@@ -100,7 +81,6 @@ namespace RogueliteAutoBattler.Combat
             if (_mover != null && _mover.Target != null)
                 AttackSlotRegistry.Release(_mover.Target, transform);
 
-            // Use Unity's null check (not cached _hasStats) — the object may be destroyed at teardown.
             if (_stats != null)
                 _stats.OnDied -= HandleSelfDied;
 
@@ -140,7 +120,6 @@ namespace RogueliteAutoBattler.Combat
             if (_state == newState)
                 return;
 
-            // Cannot transition out of Dead
             if (_state == CombatState.Dead)
                 return;
 
@@ -178,7 +157,6 @@ namespace RogueliteAutoBattler.Combat
             }
         }
 
-        /// <summary>Shared setup for Dead and None states: stop movement, reset animation.</summary>
         private void EnterInactiveState()
         {
             _mover.Stop();
@@ -246,10 +224,6 @@ namespace RogueliteAutoBattler.Combat
             Destroy(gameObject);
         }
 
-        /// <summary>
-        /// Clears the current target and returns the character to idle/moving state.
-        /// Used by LevelManager when clearing targets between levels.
-        /// </summary>
         public void Disengage()
         {
             Target = null;
@@ -258,9 +232,6 @@ namespace RogueliteAutoBattler.Combat
             if (_state == CombatState.Dead)
                 return;
 
-            // Set state directly — SetState(Moving) would work but SetState(None)
-            // disables the mover. We need the mover enabled so CharacterMover
-            // walks the character back to HomeAnchor during scroll transition.
             _state = CombatState.Moving;
             _mover.enabled = true;
             _waitingForHit = false;
@@ -270,7 +241,6 @@ namespace RogueliteAutoBattler.Combat
             }
         }
 
-        /// <summary>Overrides the serialized attack range at runtime (set from EnemySpawnData on spawn).</summary>
         public void SetAttackRange(float range)
         {
             _attackRange = range;
@@ -285,7 +255,6 @@ namespace RogueliteAutoBattler.Combat
 
             _waitingForHit = true;
 
-            // Set cooldown NOW, not in OnAnimationHit — survives retarget/state changes.
             float attackInterval = 1f / _stats.AttackSpeed;
             _nextAttackTime = Time.time + attackInterval;
             float animSpeed = attackInterval < ChopAttackDuration
@@ -299,10 +268,6 @@ namespace RogueliteAutoBattler.Combat
             }
         }
 
-        /// <summary>
-        /// Called by <see cref="AnimationEventRelay"/> when the attack animation
-        /// reaches the hit frame. Deals damage and returns to idle.
-        /// </summary>
         public void OnAnimationHit()
         {
             if (!_waitingForHit)
@@ -317,8 +282,6 @@ namespace RogueliteAutoBattler.Combat
             {
                 int damage = _stats.Atk;
 #if UNITY_EDITOR
-                // Capture name before TakeDamage — it may kill the target, firing
-                // HandleTargetDied synchronously which nulls _targetStats.
                 string targetName = _targetStats.gameObject.name;
 #endif
                 _targetStats.TakeDamage(damage);
@@ -332,8 +295,6 @@ namespace RogueliteAutoBattler.Combat
                 _animator.speed = 1f;
                 _animator.Play(AnimHashes.Idle);
             }
-
-            // Cooldown already set in StartAttackSwing.
         }
     }
 }

--- a/Assets/Scripts/Combat/CombatSetupHelper.cs
+++ b/Assets/Scripts/Combat/CombatSetupHelper.cs
@@ -4,10 +4,6 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Components returned by <see cref="CombatSetupHelper.AssembleCharacter"/> so callers
-    /// can perform team-specific wiring (death tracking, target assignment, etc.).
-    /// </summary>
     public struct CharacterComponents
     {
         public CombatStats Stats;
@@ -15,10 +11,6 @@ namespace RogueliteAutoBattler.Combat
         public CombatController Controller;
     }
 
-    /// <summary>
-    /// Shared setup utilities used by both <see cref="CombatSpawnManager"/> (allies)
-    /// and <see cref="LevelManager"/> (enemies) to avoid code duplication.
-    /// </summary>
     public static class CombatSetupHelper
     {
         public const string TeamContainerName = "Team";
@@ -27,12 +19,6 @@ namespace RogueliteAutoBattler.Combat
         public const string EnemiesHomeAnchorName = "EnemiesHomeAnchor";
         public const string CombatTriggerZoneName = "CombatTriggerZone";
 
-        /// <summary>
-        /// Adds all combat components to a freshly instantiated character:
-        /// CombatStats, HealthBar, CharacterMover, CircleCollider2D radius,
-        /// CombatController, AnimationEventRelay, and CharacterAppearance.
-        /// Returns the key components so the caller can do team-specific wiring.
-        /// </summary>
         public static CharacterComponents AssembleCharacter(
             GameObject character,
             int maxHp,
@@ -46,30 +32,24 @@ namespace RogueliteAutoBattler.Combat
             AppearanceData appearance,
             string callerName)
         {
-            // CombatStats — direct initialization from spawn data values.
             var combatStats = character.AddComponent<CombatStats>();
             combatStats.InitializeDirect(maxHp, atk, attackSpeed, regenHpPerSecond);
 
-            // HealthBar — must be added after CombatStats (reads it in Awake).
             character.AddComponent<HealthBar>();
 
-            // CharacterMover — set speed, home anchor, and home offset.
             var mover = character.AddComponent<CharacterMover>();
             mover.SetMoveSpeed(moveSpeed);
             if (homeAnchor != null)
                 mover.HomeAnchor = homeAnchor;
             mover.SetHomeOffset(homeOffset);
 
-            // Collider radius — set after AddComponent<CharacterMover> which auto-adds CircleCollider2D.
             var col = character.GetComponent<CircleCollider2D>();
             if (col != null)
                 col.radius = colliderRadius;
 
-            // CombatController + AnimationEventRelay wiring.
             var controller = character.AddComponent<CombatController>();
             WireAnimationRelay(character, controller, callerName);
 
-            // Visual appearance.
             var appearanceComp = character.AddComponent<CharacterAppearance>();
             appearanceComp.ApplyAppearance(appearance);
 
@@ -81,10 +61,6 @@ namespace RogueliteAutoBattler.Combat
             };
         }
 
-        /// <summary>
-        /// Finds an <see cref="AnimationEventRelay"/> on the character's Animator child
-        /// and wires it to the given <see cref="CombatController"/>.
-        /// </summary>
         public static void WireAnimationRelay(GameObject character, CombatController controller, string callerName)
         {
             var animator = character.GetComponentInChildren<Animator>();
@@ -98,11 +74,6 @@ namespace RogueliteAutoBattler.Combat
             relay.Initialize(controller);
         }
 
-        /// <summary>
-        /// Recalculates formation offsets for all alive characters in a container.
-        /// Does NOT move characters — only updates their <see cref="CharacterMover.SetHomeOffset"/>.
-        /// The homing logic in <see cref="CharacterMover.FixedUpdate"/> handles actual movement.
-        /// </summary>
         public static void RecalculateFormation(Transform container, Transform homeAnchor, bool facingRight)
         {
             if (container == null || homeAnchor == null)
@@ -134,10 +105,6 @@ namespace RogueliteAutoBattler.Combat
             }
         }
 
-        /// <summary>
-        /// Resolves Team and Enemies child containers under the given parent transform,
-        /// filling in any null references.
-        /// </summary>
         public static void FindContainersIfNeeded(Transform parent, ref Transform teamContainer, ref Transform enemiesContainer, string callerName)
         {
             if (teamContainer == null)

--- a/Assets/Scripts/Combat/CombatSpawnManager.cs
+++ b/Assets/Scripts/Combat/CombatSpawnManager.cs
@@ -3,11 +3,6 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Spawns ally characters at the start of combat. Enemy spawning is handled
-    /// by <see cref="LevelManager"/> via wave data.
-    /// Each ally prefab must have the Root/Visual hierarchy (Rigidbody2D on root, Animator on Visual child).
-    /// </summary>
     public class CombatSpawnManager : MonoBehaviour
     {
         [Header("Team")]
@@ -26,7 +21,6 @@ namespace RogueliteAutoBattler.Combat
         public const string EnemiesHomeAnchorName = CombatSetupHelper.EnemiesHomeAnchorName;
         public const string CombatTriggerZoneName = CombatSetupHelper.CombatTriggerZoneName;
 
-        // The default sprite faces left. Flip X to face right.
         private static readonly Vector3 FacingRightScale = new Vector3(-1f, 1f, 1f);
 
         private void Start()

--- a/Assets/Scripts/Combat/CombatStats.cs
+++ b/Assets/Scripts/Combat/CombatStats.cs
@@ -2,10 +2,6 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Runtime component holding current HP for a character in combat.
-    /// Attached to each character at spawn via <see cref="CombatSpawnManager"/>.
-    /// </summary>
     public class CombatStats : MonoBehaviour
     {
         private int _currentHp;
@@ -15,22 +11,12 @@ namespace RogueliteAutoBattler.Combat
         private float _regenHpPerSecond;
         private float _regenAccumulator;
 
-        /// <summary>Current health points.</summary>
         public int CurrentHp => _currentHp;
-
-        /// <summary>Maximum health points.</summary>
         public int MaxHp => _maxHp;
-
-        /// <summary>Damage dealt per attack.</summary>
         public int Atk => _atk;
-
-        /// <summary>Attacks per second.</summary>
         public float AttackSpeed => _attackSpeed;
-
-        /// <summary>True when CurrentHp has reached zero.</summary>
         public bool IsDead => _currentHp <= 0;
 
-        /// <summary>Initializes stats directly from values (used by wave-spawned enemies without a SO).</summary>
         public void InitializeDirect(int maxHp, int atk, float attackSpeed, float regenHpPerSecond = 0f)
         {
             _maxHp = maxHp;
@@ -41,11 +27,9 @@ namespace RogueliteAutoBattler.Combat
             _regenAccumulator = 0f;
         }
 
-        /// <summary>Fired once when CurrentHp reaches zero.</summary>
+        // TODO: Server-authoritative — validate damage server-side
         public event System.Action OnDied;
 
-        // TODO: Server-authoritative — validate damage server-side
-        /// <summary>Reduces CurrentHp by <paramref name="damage"/>, clamped to zero.</summary>
         public void TakeDamage(int damage)
         {
             if (IsDead) return;
@@ -53,9 +37,6 @@ namespace RogueliteAutoBattler.Combat
             _currentHp = Mathf.Max(0, _currentHp - damage);
             if (IsDead)
             {
-                // Safety net: free all slots pointing to this target before OnDied fires.
-                // Attackers will also individually release via HandleTargetDied -> Target setter,
-                // but this ensures no stale slots if an attacker is destroyed simultaneously.
                 AttackSlotRegistry.ReleaseAll(transform);
 #if UNITY_EDITOR
                 Debug.Log($"[CombatStats] {gameObject.name} died!");

--- a/Assets/Scripts/Combat/FormationLayout.cs
+++ b/Assets/Scripts/Combat/FormationLayout.cs
@@ -2,20 +2,12 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Calculates formation positions for a group of units.
-    /// Returns offsets relative to an anchor point.
-    /// </summary>
     public static class FormationLayout
     {
         private const float DefaultYSpacing = 0.5f;
         private const float DefaultColumnSpacing = 0.5f;
         private const int MaxPerColumn = 5;
 
-        /// <summary>
-        /// Returns world-space positions for <paramref name="count"/> units.
-        /// <paramref name="facingRight"/>: true for allies (back column at -X), false for enemies (back column at +X).
-        /// </summary>
         public static Vector2[] GetPositions(
             Vector2 anchor,
             int count,
@@ -29,20 +21,16 @@ namespace RogueliteAutoBattler.Combat
 
             if (count <= MaxPerColumn)
             {
-                // Single column
                 FillColumn(positions, 0, count, anchor.x, anchor.y, ySpacing);
             }
             else
             {
-                // Two columns
                 int frontCount = Mathf.CeilToInt(count / 2f);
                 int backCount = count - frontCount;
 
                 float backOffsetX = facingRight ? -columnSpacing : columnSpacing;
 
-                // Front column at anchor.x
                 FillColumn(positions, 0, frontCount, anchor.x, anchor.y, ySpacing);
-                // Back column offset on X
                 FillColumn(positions, frontCount, backCount, anchor.x + backOffsetX, anchor.y, ySpacing);
             }
 

--- a/Assets/Scripts/Combat/GroundFitter.cs
+++ b/Assets/Scripts/Combat/GroundFitter.cs
@@ -2,10 +2,6 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Sizes and positions the ground SpriteRenderer to match the GameArea
-    /// (top portion of the screen). Recalculates when screen size or camera changes.
-    /// </summary>
     [RequireComponent(typeof(SpriteRenderer))]
     public class GroundFitter : MonoBehaviour
     {
@@ -56,9 +52,7 @@ namespace RogueliteAutoBattler.Combat
 
             float width = Mathf.Max(_groundWidth, visibleWidth + 2f);
             _renderer.size = new Vector2(width, groundHeight);
-            // Anchor left edge to the left edge of the screen.
-            // Sprite is centered on its transform, so offset by half width minus half visible width.
-            // Offset so left edge is 1 unit past the screen's left edge (safety buffer).
+
             float visibleHalfWidth = visibleWidth * 0.5f;
             float anchorX = -(visibleHalfWidth + 1f) + width * 0.5f;
             transform.localPosition = new Vector3(anchorX, groundCenterY, 0f);

--- a/Assets/Scripts/Combat/HealthBar.cs
+++ b/Assets/Scripts/Combat/HealthBar.cs
@@ -2,50 +2,29 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Renders a world-space HP bar above the character using SpriteRenderers.
-    /// Must be placed on the same root GameObject as <see cref="CombatStats"/>.
-    ///
-    /// Structure:
-    ///   HealthBar_Pivot  (empty GO, child of character root — absorbs parent flip)
-    ///   ├── BG           (SpriteRenderer, dark, centered pivot)
-    ///   └── Fill         (SpriteRenderer, colored, left-aligned pivot)
-    ///
-    /// URP 2D uses Lit sprites by default: without a Light2D the bar would appear
-    /// black. Both renderers are explicitly set to Sprite-Unlit-Default.
-    /// </summary>
     [RequireComponent(typeof(CombatStats))]
     public class HealthBar : MonoBehaviour
     {
         private const string EffectsSortingLayer = "Effects";
-        private const string DefaultSpriteMaterial = "Universal Render Pipeline/2D/Sprite-Unlit-Default";
+        private const string UnlitShaderName = "Universal Render Pipeline/2D/Sprite-Unlit-Default";
 
         [Header("Bar Dimensions")]
-        [Tooltip("Total width of the health bar in world units.")]
         [SerializeField] private float _barWidth = 0.3f;
-
-        [Tooltip("Height of the health bar in world units.")]
         [SerializeField] private float _barHeight = 0.04f;
-
-        [Tooltip("Vertical offset above the character root position.")]
         [SerializeField] private float _yOffset = 0.3f;
 
-        // Full opacity — Unlit material, no alpha blending needed for visibility.
-        private static readonly Color ColorBg      = new Color(0.15f, 0.15f, 0.15f, 1f);
+        private static readonly Color ColorBg = new Color(0.15f, 0.15f, 0.15f, 1f);
         private static readonly Color ColorHealthy = new Color(0.20f, 0.80f, 0.20f, 1f);
         private static readonly Color ColorWarning = new Color(0.80f, 0.80f, 0.20f, 1f);
         private static readonly Color ColorCritical = new Color(0.80f, 0.20f, 0.20f, 1f);
 
-        // Shared Unlit material — created once, reused by all HealthBar instances.
         private static Material _unlitMaterial;
-
-        // Shared sprites — created once, reused by all HealthBar instances.
         private static Sprite _centeredSprite;
         private static Sprite _leftAlignedSprite;
 
         private CombatStats _stats;
-        private Transform   _pivotTransform;
-        private Transform   _fillTransform;
+        private Transform _pivotTransform;
+        private Transform _fillTransform;
         private SpriteRenderer _fillRenderer;
 
         private void Awake()
@@ -55,75 +34,50 @@ namespace RogueliteAutoBattler.Combat
             CreateBar();
         }
 
-        // ------------------------------------------------------------------
-        // Bar construction
-        // ------------------------------------------------------------------
-
         private void CreateBar()
         {
-            // Sprites —————————————————————————————————————————————————————
-            // Centered sprite (pivot 0.5, 0.5) — used for BG.
             var bgSprite = GetOrCreateSprite(ref _centeredSprite, new Vector2(0.5f, 0.5f));
-            // Left-aligned sprite (pivot 0, 0.5) — used for Fill so scaling X
-            // from 0 grows toward the right from the left edge.
             var fillSprite = GetOrCreateSprite(ref _leftAlignedSprite, new Vector2(0f, 0.5f));
 
-            // Pivot ———————————————————————————————————————————————————————
-            // An empty intermediary absorbs the parent's X flip.
-            // If the parent has localScale.x < 0 (flipped character), this pivot
-            // counteracts it with localScale.x = -1 so all children stay in
-            // normal (unflipped) space from the viewer's perspective.
             var pivotGo = new GameObject("HealthBar_Pivot");
             pivotGo.transform.SetParent(transform, false);
             pivotGo.transform.localPosition = new Vector3(0f, _yOffset, 0f);
             ApplyFlipCompensation(pivotGo.transform);
             _pivotTransform = pivotGo.transform;
 
-            // BG ——————————————————————————————————————————————————————————
-            // Centered in pivot space — full bar width, always visible.
             var bgGo = new GameObject("BG");
             bgGo.transform.SetParent(_pivotTransform, false);
             bgGo.transform.localPosition = Vector3.zero;
-            bgGo.transform.localScale    = new Vector3(_barWidth, _barHeight, 1f);
+            bgGo.transform.localScale = new Vector3(_barWidth, _barHeight, 1f);
             var bgRenderer = bgGo.AddComponent<SpriteRenderer>();
-            bgRenderer.sprite           = bgSprite;
-            bgRenderer.color            = ColorBg;
+            bgRenderer.sprite = bgSprite;
+            bgRenderer.color = ColorBg;
             bgRenderer.sortingLayerName = EffectsSortingLayer;
-            bgRenderer.sortingOrder     = 10;
-            bgRenderer.material         = _unlitMaterial;
+            bgRenderer.sortingOrder = 10;
+            bgRenderer.material = _unlitMaterial;
 
-            // Fill ————————————————————————————————————————————————————————
-            // Left-aligned: position at the left edge of the BG (-width/2 in pivot
-            // space). Scale X = barWidth * ratio so it grows rightward from that edge.
             var fillGo = new GameObject("Fill");
             fillGo.transform.SetParent(_pivotTransform, false);
             fillGo.transform.localPosition = new Vector3(-_barWidth * 0.5f, 0f, 0f);
-            fillGo.transform.localScale    = new Vector3(_barWidth, _barHeight, 1f);
+            fillGo.transform.localScale = new Vector3(_barWidth, _barHeight, 1f);
             _fillRenderer = fillGo.AddComponent<SpriteRenderer>();
-            _fillRenderer.sprite           = fillSprite;
-            _fillRenderer.color            = ColorHealthy;
+            _fillRenderer.sprite = fillSprite;
+            _fillRenderer.color = ColorHealthy;
             _fillRenderer.sortingLayerName = EffectsSortingLayer;
-            _fillRenderer.sortingOrder     = 11;
-            _fillRenderer.material         = _unlitMaterial;
+            _fillRenderer.sortingOrder = 11;
+            _fillRenderer.material = _unlitMaterial;
             _fillTransform = fillGo.transform;
         }
-
-        // ------------------------------------------------------------------
-        // Runtime update
-        // ------------------------------------------------------------------
 
         private void LateUpdate()
         {
             if (_stats == null || _stats.MaxHp <= 0)
                 return;
 
-            // Reapply flip compensation every frame — the parent scale can change
-            // (e.g. character reverses direction mid-combat).
             ApplyFlipCompensation(_pivotTransform);
 
             float ratio = (float)_stats.CurrentHp / _stats.MaxHp;
 
-            // Fill width represents HP ratio; height and Z stay unchanged.
             var scale = _fillTransform.localScale;
             scale.x = _barWidth * ratio;
             _fillTransform.localScale = scale;
@@ -135,24 +89,12 @@ namespace RogueliteAutoBattler.Combat
                     : ColorCritical;
         }
 
-        // ------------------------------------------------------------------
-        // Helpers
-        // ------------------------------------------------------------------
-
-        /// <summary>
-        /// Sets pivot.localScale.x = -1 when the parent's world X scale is negative,
-        /// so all children of the pivot render unflipped from the viewer's perspective.
-        /// </summary>
         private void ApplyFlipCompensation(Transform pivot)
         {
             float sign = transform.localScale.x < 0f ? -1f : 1f;
             pivot.localScale = new Vector3(sign, 1f, 1f);
         }
 
-        /// <summary>
-        /// Returns a cached 1x1 white sprite with the given pivot, creating it on first call.
-        /// Shared across all HealthBar instances to avoid per-instance sprite allocations.
-        /// </summary>
         private static Sprite GetOrCreateSprite(ref Sprite cached, Vector2 pivot)
         {
             if (cached != null)
@@ -163,16 +105,12 @@ namespace RogueliteAutoBattler.Combat
             return cached;
         }
 
-        /// <summary>
-        /// Lazily creates the shared Unlit material.
-        /// URP 2D Lit sprites appear black without a Light2D — Unlit bypasses lighting entirely.
-        /// </summary>
         private static void EnsureUnlitMaterial()
         {
             if (_unlitMaterial != null)
                 return;
 
-            var shader = Shader.Find(DefaultSpriteMaterial);
+            var shader = Shader.Find(UnlitShaderName);
             if (shader != null)
             {
                 _unlitMaterial = new Material(shader);

--- a/Assets/Scripts/Combat/LevelManager.cs
+++ b/Assets/Scripts/Combat/LevelManager.cs
@@ -4,10 +4,6 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Reads the LevelDatabase at runtime, applies the current stage's terrain sprite,
-    /// and spawns enemy waves for the current level. Attach to the CombatWorld root.
-    /// </summary>
     [RequireComponent(typeof(WorldConveyor))]
     public class LevelManager : MonoBehaviour
     {
@@ -22,18 +18,13 @@ namespace RogueliteAutoBattler.Combat
         [SerializeField] private int _currentLevelIndex;
 
         [Header("Containers")]
-        [Tooltip("Parent transform for spawned enemies.")]
         [SerializeField] private Transform _enemiesContainer;
-
-        [Tooltip("Parent transform for the ally team (used to find targets for enemies).")]
         [SerializeField] private Transform _teamContainer;
 
         [Header("Scroll Transition")]
-        [Tooltip("Distance in world units the world scrolls left between levels.")]
         [SerializeField] private float _scrollDistance = 2f;
 
         [Header("Enemy Spawn")]
-        [Tooltip("Extra X offset to spawn enemies off-screen to the right of EnemiesHomeAnchor.")]
         [SerializeField] private float _enemySpawnOffscreenX = 1f;
 
         [Header("Anchors")]
@@ -66,15 +57,11 @@ namespace RogueliteAutoBattler.Combat
                 _enemiesHomeAnchor = GameObject.Find(CombatSetupHelper.EnemiesHomeAnchorName)?.transform;
             _conveyor = GetComponent<WorldConveyor>();
             ApplyStage(_currentStageIndex);
-            // Wait until an ally actually exists in the team container.
             yield return new WaitUntil(() => TargetFinder.Closest(_teamContainer, Vector3.zero) != null);
             WireAllyDeathTracking();
             StartLevel(_currentLevelIndex);
         }
 
-        /// <summary>
-        /// Applies the terrain sprite for the given stage index.
-        /// </summary>
         public void ApplyStage(int stageIndex)
         {
             if (_levelDatabase == null)
@@ -105,9 +92,6 @@ namespace RogueliteAutoBattler.Combat
             }
         }
 
-        /// <summary>
-        /// Starts spawning enemy waves for the given level index within the current stage.
-        /// </summary>
         public void StartLevel(int levelIndex)
         {
             if (_levelDatabase == null)
@@ -166,7 +150,6 @@ namespace RogueliteAutoBattler.Combat
             Debug.Log($"[{nameof(LevelManager)}] Spawning wave {waveIndex} '{wave.WaveName}' ({wave.Enemies.Count} enemies).");
 #endif
 
-            // Calculate formation positions for this wave's enemies.
             Vector2 anchorPos = _enemiesHomeAnchor != null
                 ? (Vector2)_enemiesHomeAnchor.position
                 : new Vector2(FallbackEnemySpawnX, 0f);
@@ -212,21 +195,17 @@ namespace RogueliteAutoBattler.Combat
                 data.Appearance,
                 nameof(LevelManager));
 
-            // Prevent allies and enemies from pushing each other physically.
             IgnoreCollisionWithOppositeTeam(enemy, _teamContainer);
 
-            // Track enemy death for level progression.
             _aliveEnemyCount++;
             components.Stats.OnDied += OnEnemyDied;
 
             var enemyTransform = enemy.transform;
 
-            // CombatController — set attack range, wire retarget delegate with closure on position.
             components.Controller.SetAttackRange(data.AttackRange);
             components.Controller.SetAttackerFacing(false);
             components.Controller.FindNewTarget = () => TargetFinder.LeastContested(_teamContainer, enemyTransform.position);
 
-            // Set target through CombatController.Target so OnDied subscription is wired.
             Transform allyTarget = TargetFinder.LeastContested(_teamContainer, enemyTransform.position);
             if (allyTarget != null)
                 components.Controller.Target = allyTarget;
@@ -235,7 +214,6 @@ namespace RogueliteAutoBattler.Combat
                 Debug.LogWarning($"[{nameof(LevelManager)}] No alive ally found for enemy '{data.EnemyName}' to target.");
 #endif
 
-            // Wire ally to target this enemy if it has no target yet.
             SetAllyTarget(enemy.transform);
 
 #if UNITY_EDITOR
@@ -243,10 +221,6 @@ namespace RogueliteAutoBattler.Combat
 #endif
         }
 
-        /// <summary>
-        /// Sets the ally's target to the given enemy if the ally currently has no target
-        /// or its current target is dead. Also wires the retarget delegate once.
-        /// </summary>
         private void SetAllyTarget(Transform firstEnemy)
         {
             if (_teamContainer == null)
@@ -261,15 +235,12 @@ namespace RogueliteAutoBattler.Combat
                 if (!allyTransform.TryGetComponent<CharacterMover>(out var allyMover))
                     continue;
 
-                // Assign target if ally has none or current target is dead
                 bool needsTarget = allyMover.Target == null;
                 if (!needsTarget && allyMover.Target.TryGetComponent<CombatStats>(out var targetStats))
                     needsTarget = targetStats.IsDead;
 
                 if (needsTarget)
                 {
-                    // Only target this enemy if it's inside the combat zone.
-                    // Use CombatController.Target so OnDied subscription is wired.
                     bool inZone = firstEnemy.position.x <= CombatZoneX;
                     if (inZone && allyTransform.TryGetComponent<CombatController>(out var allyController))
                         allyController.Target = firstEnemy;
@@ -330,10 +301,6 @@ namespace RogueliteAutoBattler.Combat
 
         private IEnumerator LevelTransitionCoroutine()
         {
-            // Scroll starts immediately — allies walk back to HomeAnchor
-            // while the world scrolls; the slow conveyor lets them catch up naturally.
-
-            // Start scroll and spawn enemies when deceleration begins
             if (_conveyor != null)
             {
                 bool enemiesSpawned = false;
@@ -350,11 +317,9 @@ namespace RogueliteAutoBattler.Combat
                 _conveyor.OnDecelerationStarted += OnDecel;
                 _conveyor.ScrollBy(_scrollDistance);
 
-                // Wait for scroll to finish
                 yield return new WaitUntil(() => !_conveyor.IsScrolling);
                 _conveyor.OnDecelerationStarted -= OnDecel;
 
-                // If scroll was too short for deceleration phase, spawn now
                 if (!enemiesSpawned)
                 {
 #if UNITY_EDITOR
@@ -453,13 +418,11 @@ namespace RogueliteAutoBattler.Combat
                 if (!ally.TryGetComponent<CombatStats>(out var stats) || stats.IsDead)
                     continue;
 
-                stats.OnDied -= OnAllyDied; // Prevent double-subscription
+                stats.OnDied -= OnAllyDied;
                 stats.OnDied += OnAllyDied;
                 _aliveAllyCount++;
             }
         }
-
-        // ---- Test helpers (internal, visible to Tests.PlayMode via InternalsVisibleTo) ----
 
         internal int AliveAllyCount => _aliveAllyCount;
         internal bool LevelInProgress => _levelInProgress;
@@ -483,10 +446,6 @@ namespace RogueliteAutoBattler.Combat
         internal void RecalculateEnemyFormationForTest() =>
             CombatSetupHelper.RecalculateFormation(_enemiesContainer, _enemiesHomeAnchor, facingRight: false);
 
-        /// <summary>
-        /// Disables physics collision between a newly spawned character and all
-        /// characters in the opposite team container. Bidirectional (A ignores B = B ignores A).
-        /// </summary>
         private static void IgnoreCollisionWithOppositeTeam(GameObject character, Transform oppositeContainer)
         {
             if (oppositeContainer == null) return;
@@ -501,6 +460,5 @@ namespace RogueliteAutoBattler.Combat
                     Physics2D.IgnoreCollision(col, otherCol, true);
             }
         }
-
     }
 }

--- a/Assets/Scripts/Combat/ScreenAnchor.cs
+++ b/Assets/Scripts/Combat/ScreenAnchor.cs
@@ -2,13 +2,8 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Positions this GameObject at a screen-relative (viewport) position in world space.
-    /// Place at scene root (outside CombatWorld) so it stays fixed regardless of world scroll.
-    /// </summary>
     public class ScreenAnchor : MonoBehaviour
     {
-        [Tooltip("Viewport position (0,0 = bottom-left, 1,1 = top-right).")]
         [SerializeField] private Vector2 _viewportPosition = new Vector2(0.5f, 0.5f);
 
         private Camera _camera;

--- a/Assets/Scripts/Combat/TargetFinder.cs
+++ b/Assets/Scripts/Combat/TargetFinder.cs
@@ -2,18 +2,10 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Static utility for finding targets in a container by various criteria.
-    /// Designed to be extensible for AI targeting (focus healer, lowest HP, etc.).
-    /// </summary>
     public static class TargetFinder
     {
         private const float ContestPenalty = 1.0f;
 
-        /// <summary>
-        /// Finds the closest alive target on the X axis (side-scroller distance).
-        /// <paramref name="maxWorldX"/> filters out targets whose world X position exceeds the limit.
-        /// </summary>
         public static Transform Closest(Transform container, Vector3 from, float maxRange = float.MaxValue, float maxWorldX = float.MaxValue)
         {
             if (container == null)
@@ -41,10 +33,6 @@ namespace RogueliteAutoBattler.Combat
             return best;
         }
 
-        /// <summary>
-        /// Finds the least contested alive target, weighting by distance and attacker count.
-        /// Prefers targets with fewer attackers. Falls back to closest when attacker counts are equal.
-        /// </summary>
         public static Transform LeastContested(
             Transform container,
             Vector3 from,
@@ -80,10 +68,6 @@ namespace RogueliteAutoBattler.Combat
             return best;
         }
 
-        /// <summary>
-        /// Finds the alive target with the lowest current HP in the given container.
-        /// Useful for focus-fire strategies.
-        /// </summary>
         public static Transform LowestHp(Transform container)
         {
             if (container == null)
@@ -107,10 +91,6 @@ namespace RogueliteAutoBattler.Combat
             return best;
         }
 
-        /// <summary>
-        /// Finds the alive target with the highest current HP in the given container.
-        /// Useful for tank-targeting strategies.
-        /// </summary>
         public static Transform HighestHp(Transform container)
         {
             if (container == null)
@@ -134,9 +114,6 @@ namespace RogueliteAutoBattler.Combat
             return best;
         }
 
-        /// <summary>
-        /// Returns true if the Transform has a CombatStats component that is not dead.
-        /// </summary>
         public static bool IsAlive(Transform t)
         {
             return t != null

--- a/Assets/Scripts/Combat/VisualEquipmentTestLoop.cs
+++ b/Assets/Scripts/Combat/VisualEquipmentTestLoop.cs
@@ -3,49 +3,25 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Debug component that randomly cycles head, weapon, hat, and shield sprites on all
-    /// <see cref="CharacterAppearance"/> instances every <see cref="_cycleInterval"/> seconds.
-    /// Sprite arrays must be populated at editor time (e.g. by CombatWorldBuilder)
-    /// because AssetDatabase is unavailable at runtime.
-    /// </summary>
     public class VisualEquipmentTestLoop : MonoBehaviour
     {
 #if UNITY_EDITOR
         [Header("Sprite Pools")]
-        [Tooltip("Available head sprites to cycle through.")]
         [SerializeField] private Sprite[] _headSprites;
-
-        [Tooltip("Available weapon sprites to cycle through.")]
         [SerializeField] private Sprite[] _weaponSprites;
-
-        [Tooltip("Available hat/armor sprites to cycle through.")]
         [SerializeField] private Sprite[] _hatSprites;
-
-        [Tooltip("Available shield sprites to cycle through.")]
         [SerializeField] private Sprite[] _shieldSprites;
 
         [Header("Timing")]
-        [Tooltip("Seconds between each random equipment swap.")]
         [SerializeField] private float _cycleInterval = 5f;
 
         [Header("Debug")]
-        [Tooltip("Log each cycle with the number of characters affected.")]
         [SerializeField] private bool _logCycles;
 
-        /// <summary>Head sprite pool (for editor wiring).</summary>
         public Sprite[] HeadSprites { get => _headSprites; set => _headSprites = value; }
-
-        /// <summary>Weapon sprite pool (for editor wiring).</summary>
         public Sprite[] WeaponSprites { get => _weaponSprites; set => _weaponSprites = value; }
-
-        /// <summary>Hat sprite pool (for editor wiring).</summary>
         public Sprite[] HatSprites { get => _hatSprites; set => _hatSprites = value; }
-
-        /// <summary>Shield sprite pool (for editor wiring).</summary>
         public Sprite[] ShieldSprites { get => _shieldSprites; set => _shieldSprites = value; }
-
-        /// <summary>Seconds between each equipment swap cycle (for testing).</summary>
         public float CycleInterval { get => _cycleInterval; set => _cycleInterval = value; }
 
         private void Start()

--- a/Assets/Scripts/Combat/WorldConveyor.cs
+++ b/Assets/Scripts/Combat/WorldConveyor.cs
@@ -2,11 +2,6 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Combat
 {
-    /// <summary>
-    /// Moves its own transform along the X axis with symmetric acceleration/deceleration.
-    /// Attach to the CombatWorld root. Driven externally via <see cref="ScrollBy"/>.
-    /// Uses a kinematic Rigidbody2D so child dynamic bodies keep their correct velocity.
-    /// </summary>
     [RequireComponent(typeof(Rigidbody2D))]
     public class WorldConveyor : MonoBehaviour
     {
@@ -19,30 +14,19 @@ namespace RogueliteAutoBattler.Combat
         private Rigidbody2D _rb;
 
         [Header("Defaults")]
-        [Tooltip("Default maximum scroll speed in units per second.")]
         [SerializeField] private float _defaultMaxSpeed = 1f;
-
-        [Tooltip("Default acceleration/deceleration in units per second squared.")]
         [SerializeField] private float _defaultAcceleration = 0.5f;
 
-        /// <summary>Current scroll speed in world units per second.</summary>
         public float CurrentSpeed => _currentSpeed;
-
-        /// <summary>Max speed of the current (or last) scroll segment.</summary>
         public float MaxSpeed => _maxSpeed;
 
-        /// <summary>Current scroll velocity vector (negative X when scrolling left).</summary>
         public Vector2 ScrollVelocity => _isScrolling
             ? new Vector2(Mathf.Sign(_targetX - _rb.position.x) * _currentSpeed, 0f)
             : Vector2.zero;
 
-        /// <summary>True while a scroll is in progress.</summary>
         public bool IsScrolling => _isScrolling;
 
-        /// <summary>Fired when a scroll reaches its target position.</summary>
         public event System.Action OnScrollComplete;
-
-        /// <summary>Fired once when the scroll enters the deceleration phase.</summary>
         public event System.Action OnDecelerationStarted;
 
         private void Awake()
@@ -51,18 +35,11 @@ namespace RogueliteAutoBattler.Combat
             _rb.bodyType = RigidbodyType2D.Kinematic;
         }
 
-        /// <summary>
-        /// Starts a scroll using the default max speed and acceleration configured in the Inspector.
-        /// </summary>
         public void ScrollBy(float distance)
         {
             ScrollBy(distance, _defaultMaxSpeed, _defaultAcceleration);
         }
 
-        /// <summary>
-        /// Starts a scroll. The world moves <paramref name="distance"/> units to the left (negative X).
-        /// Accelerates from 0 to <paramref name="maxSpeed"/>, then decelerates symmetrically to stop at the target.
-        /// </summary>
         public void ScrollBy(float distance, float maxSpeed, float acceleration)
         {
             if (acceleration <= 0f)
@@ -99,7 +76,6 @@ namespace RogueliteAutoBattler.Combat
             float posX = _rb.position.x;
             float remaining = Mathf.Abs(_targetX - posX);
 
-            // Close enough — snap and finish.
             if (remaining < 0.01f)
             {
                 Arrive();
@@ -107,13 +83,10 @@ namespace RogueliteAutoBattler.Combat
             }
 
             float dt = Time.fixedDeltaTime;
-
-            // Braking distance: v^2 / (2a)
             float brakingDist = (_currentSpeed * _currentSpeed) / (2f * _acceleration);
 
             if (remaining <= brakingDist + 0.1f)
             {
-                // Decelerate
                 if (!_decelerating)
                 {
                     _decelerating = true;
@@ -126,7 +99,6 @@ namespace RogueliteAutoBattler.Combat
             }
             else if (_currentSpeed < _maxSpeed)
             {
-                // Accelerate
                 _currentSpeed += _acceleration * dt;
                 if (_currentSpeed > _maxSpeed)
                     _currentSpeed = _maxSpeed;

--- a/Assets/Scripts/Editor/CombatHudBuilder.cs
+++ b/Assets/Scripts/Editor/CombatHudBuilder.cs
@@ -7,9 +7,6 @@ using UnityEngine.UI;
 
 namespace RogueliteAutoBattler.Editor
 {
-    /// <summary>
-    /// Builds the combat HUD panel (transparent overlay revealing the 2D world behind the Canvas).
-    /// </summary>
     internal static class CombatHudBuilder
     {
         private const int HudFontSize = 28;
@@ -22,29 +19,23 @@ namespace RogueliteAutoBattler.Editor
             GameObjectUtility.SetParentAndAlign(go, parent.gameObject);
             EditorUIFactory.Stretch(go.AddComponent<RectTransform>());
 
-            // No Image — transparent, reveals the 2D world behind
             EditorUIFactory.SetupCanvasGroup(go, true);
 
             UIScreen screen = go.AddComponent<CombatScreen>();
 
-            // --- Top left: Reset timer (pill badge) ---
             CreateHudBadge(go.transform, "ResetTimer", "Reset: 3j 14h",
                 new Vector2(0, 0.92f), new Vector2(0.35f, 1f),
                 new Vector2(12, -8), new Vector2(-8, -8),
                 TextAlignmentOptions.Center);
 
-            // --- Top right: Gold + Diamond side by side (start at 55%) ---
-            // Gold badge with icon
             CreateCurrencyBadge(go.transform, "Gold", "1.93m",
                 new Vector2(0.55f, 0.92f), new Vector2(0.77f, 1f),
                 (Color)new Color32(255, 215, 0, 255));
 
-            // Diamond badge with icon
             CreateCurrencyBadge(go.transform, "Diamond", "211",
                 new Vector2(0.77f, 0.92f), new Vector2(1f, 1f),
                 (Color)new Color32(185, 242, 255, 255));
 
-            // --- Center: Battle indicator (below top row) ---
             var battleGo = new GameObject("BattleIndicator");
             GameObjectUtility.SetParentAndAlign(battleGo, go);
             RectTransform battleRect = battleGo.AddComponent<RectTransform>();
@@ -62,7 +53,6 @@ namespace RogueliteAutoBattler.Editor
             return screen;
         }
 
-        /// <summary>Creates a currency badge: dark bg + small icon (placeholder) + colored text, using HorizontalLayoutGroup.</summary>
         internal static void CreateCurrencyBadge(Transform parent, string name, string text,
             Vector2 anchorMin, Vector2 anchorMax, Color textColor)
         {
@@ -77,7 +67,6 @@ namespace RogueliteAutoBattler.Editor
             Image bg = go.AddComponent<Image>();
             bg.color = HudBarBg;
 
-            // Layout: icon + text side by side — childControl forces sizes from LayoutElement
             HorizontalLayoutGroup layout = go.AddComponent<HorizontalLayoutGroup>();
             layout.spacing = 6;
             layout.padding = new RectOffset(16, 24, 0, 0);
@@ -87,7 +76,6 @@ namespace RogueliteAutoBattler.Editor
             layout.childForceExpandWidth = false;
             layout.childForceExpandHeight = false;
 
-            // Icon — fixed 50x50 square
             var iconGo = new GameObject("Icon");
             GameObjectUtility.SetParentAndAlign(iconGo, go);
             iconGo.AddComponent<RectTransform>();
@@ -102,7 +90,6 @@ namespace RogueliteAutoBattler.Editor
             iconLe.flexibleWidth = 0;
             iconLe.flexibleHeight = 0;
 
-            // Text — fills remaining space
             var labelGo = new GameObject("Label");
             GameObjectUtility.SetParentAndAlign(labelGo, go);
             labelGo.AddComponent<RectTransform>();
@@ -117,7 +104,6 @@ namespace RogueliteAutoBattler.Editor
             labelLe.flexibleHeight = 1;
         }
 
-        /// <summary>Creates a small HUD badge: dark semi-transparent bg + text.</summary>
         internal static void CreateHudBadge(Transform parent, string name, string text,
             Vector2 anchorMin, Vector2 anchorMax, Vector2 offsetMin, Vector2 offsetMax,
             TextAlignmentOptions alignment, Color? textColor = null)
@@ -130,11 +116,9 @@ namespace RogueliteAutoBattler.Editor
             r.offsetMin = offsetMin;
             r.offsetMax = offsetMax;
 
-            // Dark semi-transparent rounded-ish background
             Image bg = go.AddComponent<Image>();
             bg.color = HudBarBg;
 
-            // Text
             var labelGo = new GameObject("Label");
             GameObjectUtility.SetParentAndAlign(labelGo, go);
             EditorUIFactory.Stretch(labelGo.AddComponent<RectTransform>());

--- a/Assets/Scripts/Editor/CombatWorldBuilder.cs
+++ b/Assets/Scripts/Editor/CombatWorldBuilder.cs
@@ -7,19 +7,11 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Editor
 {
-    /// <summary>
-    /// Builds the CombatWorld 2D scene hierarchy and configures the main camera.
-    /// </summary>
     internal static class CombatWorldBuilder
     {
         private const float CameraOrthoSize = 5.4f;
         private const float CameraZPosition = -10f;
-
-        // Ground tile — 200 units wide so the camera never sees an edge during a scroll session.
-        // Height and centerY are calculated at runtime by GroundFitter.
         private const float GroundWidth = 200f;
-
-        // Must match GroundFitter._gameAreaBottomRatio default (0.40f).
         private const float GameAreaBottomRatio = 0.40f;
 
         private const string WeaponSpritesFolder = "Assets/Sprites/Items/melee weapons";
@@ -35,27 +27,17 @@ namespace RogueliteAutoBattler.Editor
         };
 
         private const string GridSpritePath = "Assets/Sprites/Environment/grid_ground.png";
-        private const int GridTextureSize = 64;   // pixels per tile
-        private const int GridCellSize = 8;        // pixels per checkerboard cell
-        private const int GridPixelsPerUnit = 64;  // 1 tile = 1 world unit
+        private const int GridTextureSize = 64;
+        private const int GridCellSize = 8;
+        private const int GridPixelsPerUnit = 64;
 
-        // Checkerboard colours — dark green / light green so movement is obvious.
-        private static readonly Color32 GridColorA = new Color32(45, 90, 39, 255);   // #2d5a27
-        private static readonly Color32 GridColorB = new Color32(61, 122, 55, 255);  // #3d7a37
+        private static readonly Color32 GridColorA = new Color32(45, 90, 39, 255);
+        private static readonly Color32 GridColorB = new Color32(61, 122, 55, 255);
 
-        // Blue variant for alternate terrain.
         private const string GridBlueSpritePath = "Assets/Sprites/Environment/grid_ground_blue.png";
-        private static readonly Color32 GridBlueColorA = new Color32(30, 60, 120, 255);  // #1e3c78
-        private static readonly Color32 GridBlueColorB = new Color32(45, 85, 160, 255);  // #2d55a0
+        private static readonly Color32 GridBlueColorA = new Color32(30, 60, 120, 255);
+        private static readonly Color32 GridBlueColorB = new Color32(45, 85, 160, 255);
 
-        // ------------------------------------------------------------------
-        // Camera
-        // ------------------------------------------------------------------
-
-        /// <summary>
-        /// Configures the main camera as orthographic with the correct settings for 2D mobile.
-        /// Creates one if none exists.
-        /// </summary>
         internal static Camera ConfigureMainCamera()
         {
             Camera cam = Camera.main;
@@ -84,38 +66,24 @@ namespace RogueliteAutoBattler.Editor
             return cam;
         }
 
-        // ------------------------------------------------------------------
-        // CombatWorld hierarchy
-        // ------------------------------------------------------------------
-
-        /// <summary>
-        /// Creates a CombatWorld container with a tiled ground and containers for characters/effects.
-        /// Attaches WorldConveyor (side-scroll motion) and CombatSpawnManager (spawn orchestrator) to the root.
-        /// GroundFitter is attached to the Ground child.
-        /// </summary>
         internal static GameObject CreateCombatWorld()
         {
             var root = new GameObject("CombatWorld");
             root.transform.position = Vector3.zero;
             Undo.RegisterCreatedObjectUndo(root, "Create CombatWorld");
 
-            // Ground — tiled checkerboard, sized to match GameArea (top 60% of screen).
-            // Positioned behind everything on Background sorting layer.
-            // GroundFitter recalculates size and position at runtime from the camera.
             var groundGo = new GameObject("Ground");
             groundGo.transform.SetParent(root.transform, false);
             Undo.RegisterCreatedObjectUndo(groundGo, "Create CombatWorld");
             SpriteRenderer groundRenderer = groundGo.AddComponent<SpriteRenderer>();
             groundRenderer.sprite = CreateOrLoadGridSprite();
             groundRenderer.drawMode = SpriteDrawMode.Tiled;
-            // Position and size for edit-mode preview (GroundFitter overrides at runtime).
-            // GameArea = top 60%: bottom at y = -orthoSize + 0.4*visibleHeight, top at y = orthoSize
+
             float visibleHeight = CameraOrthoSize * 2f;
             float gameAreaBottom = -CameraOrthoSize + GameAreaBottomRatio * visibleHeight;
             float groundHeight = CameraOrthoSize - gameAreaBottom;
             float groundCenterY = (gameAreaBottom + CameraOrthoSize) * 0.5f;
-            // Anchor left edge to the left of the screen (assume ~16:9 aspect for edit preview).
-            float previewAspect = 9f / 16f; // portrait mobile
+            float previewAspect = 9f / 16f;
             float previewHalfWidth = CameraOrthoSize * previewAspect;
             float anchorX = -previewHalfWidth + GroundWidth * 0.5f;
             groundGo.transform.localPosition = new Vector3(anchorX, groundCenterY, 0f);
@@ -123,9 +91,7 @@ namespace RogueliteAutoBattler.Editor
             groundRenderer.sortingLayerName = "Background";
             groundRenderer.sortingOrder = -10;
             groundRenderer.color = Color.white;
-            // URP 2D uses Lit sprites by default — without a Light2D in the scene,
-            // sprites appear black. The ground is a flat background that doesn't
-            // need lighting, so we use the Unlit material.
+
             var unlitShader = Shader.Find("Universal Render Pipeline/2D/Sprite-Unlit-Default");
             if (unlitShader != null)
                 groundRenderer.material = new Material(unlitShader);
@@ -133,41 +99,29 @@ namespace RogueliteAutoBattler.Editor
                 Debug.LogWarning($"[{nameof(CombatWorldBuilder)}] Shader 'Sprite-Unlit-Default' not found. Ground may render black.");
             groundGo.AddComponent<GroundFitter>();
 
-            // Team container — place adventurer prefabs here.
-            // Every SpriteRenderer in this subtree must use sorting layer "Characters".
             var teamGo = new GameObject(CombatSpawnManager.TeamContainerName);
             teamGo.transform.SetParent(root.transform, false);
             Undo.RegisterCreatedObjectUndo(teamGo, "Create CombatWorld");
 
-            // Enemies container — place enemy prefabs here.
-            // Every SpriteRenderer in this subtree must use sorting layer "Characters".
             var enemiesGo = new GameObject(CombatSpawnManager.EnemiesContainerName);
             enemiesGo.transform.SetParent(root.transform, false);
             Undo.RegisterCreatedObjectUndo(enemiesGo, "Create CombatWorld");
 
-            // Effects container — VFX, projectiles, hit-sparks, etc.
-            // SpriteRenderers here should use sorting layer "Effects" (order 4) so they
-            // render on top of characters.
             var fxGo = new GameObject("Effects");
             fxGo.transform.SetParent(root.transform, false);
             Undo.RegisterCreatedObjectUndo(fxGo, "Create CombatWorld");
 
-            // Kinematic Rigidbody2D on CombatWorld root so WorldConveyor can use
-            // MovePosition — this keeps child dynamic Rigidbody2Ds in sync with physics.
             var rootRb = root.AddComponent<Rigidbody2D>();
             rootRb.bodyType = RigidbodyType2D.Kinematic;
 
-            // WorldConveyor drives the physical side-scroll motion.
             root.AddComponent<WorldConveyor>();
 
-            // CombatSpawnManager handles spawning adventurers and enemies into their containers.
             var spawnManager = root.AddComponent<CombatSpawnManager>();
 
             var soSpawnManager = new SerializedObject(spawnManager);
             EditorUIFactory.SetObj(soSpawnManager, "_teamContainer", teamGo.transform);
             EditorUIFactory.SetObj(soSpawnManager, "_enemiesContainer", enemiesGo.transform);
 
-            // Assign TeamDatabase asset — create one with a default warrior if it doesn't exist.
             const string teamDbPath = "Assets/Data/TeamDatabase.asset";
             var teamDb = AssetDatabase.LoadAssetAtPath<TeamDatabase>(teamDbPath);
             if (teamDb == null)
@@ -201,7 +155,6 @@ namespace RogueliteAutoBattler.Editor
             }
             EditorUIFactory.SetObj(soSpawnManager, "_teamDatabase", teamDb);
 
-            // LevelManager reads the LevelDatabase at runtime and swaps the ground sprite.
             var levelManager = root.AddComponent<LevelManager>();
             var soLevelManager = new SerializedObject(levelManager);
             EditorUIFactory.SetObj(soLevelManager, "_groundRenderer", groundRenderer);
@@ -212,13 +165,10 @@ namespace RogueliteAutoBattler.Editor
             if (levelDb != null)
                 EditorUIFactory.SetObj(soLevelManager, "_levelDatabase", levelDb);
 
-            // Screen-absolute anchors at scene root (outside CombatWorld so they
-            // don't scroll). Home positions for characters + combat zone boundary.
             var teamAnchor = FindOrCreateHomeAnchor(CombatSpawnManager.TeamHomeAnchorName, new Vector2(0.12f, 0.70f));
             var enemiesAnchor = FindOrCreateHomeAnchor(CombatSpawnManager.EnemiesHomeAnchorName, new Vector2(0.88f, 0.70f));
             var combatTrigger = FindOrCreateHomeAnchor(CombatSpawnManager.CombatTriggerZoneName, new Vector2(1f, 0.5f));
 
-            // Wire anchor references to managers.
             EditorUIFactory.SetObj(soSpawnManager, "_teamHomeAnchor", teamAnchor);
             soSpawnManager.ApplyModifiedProperties();
 
@@ -227,38 +177,29 @@ namespace RogueliteAutoBattler.Editor
             EditorUIFactory.SetObj(soLevelManager, "_combatTriggerZone", combatTrigger);
             soLevelManager.ApplyModifiedProperties();
 
-            // VisualEquipmentTestLoop — cycles through weapon/hat/shield sprites at runtime.
             AddVisualEquipmentTestLoop(root);
 
             return root;
         }
-
-        // ------------------------------------------------------------------
-        // VisualEquipmentTestLoop setup
-        // ------------------------------------------------------------------
 
         private static void AddVisualEquipmentTestLoop(GameObject combatWorld)
         {
             var equipmentLoop = combatWorld.AddComponent<VisualEquipmentTestLoop>();
             var so = new SerializedObject(equipmentLoop);
 
-            // Heads: all head sprites from all races.
             var headSprites = new List<Sprite>();
             foreach (var folder in HeadSpriteFolders)
                 headSprites.AddRange(LoadSpritesFromFolder(folder));
             SetSpriteArray(so, "_headSprites", headSprites.ToArray());
 
-            // Weapons: all sprites in the melee weapons folder, excluding shield.
             var weaponSprites = LoadSpritesFromFolder(
                 WeaponSpritesFolder,
                 excludePathContaining: "shield");
             SetSpriteArray(so, "_weaponSprites", weaponSprites);
 
-            // Hats: all sprites in the cloth wardrobe folder.
             var hatSprites = LoadSpritesFromFolder(HatSpritesFolder);
             SetSpriteArray(so, "_hatSprites", hatSprites);
 
-            // Shields: all sub-sprites from the shield sprite sheet.
             var shieldSprites = LoadSpritesFromFile(ShieldSpritePath);
             SetSpriteArray(so, "_shieldSprites", shieldSprites);
 
@@ -268,10 +209,6 @@ namespace RogueliteAutoBattler.Editor
                       $"heads:{headSprites.Count}, weapons:{weaponSprites.Length}, hats:{hatSprites.Length}, shields:{shieldSprites.Length}");
         }
 
-        /// <summary>
-        /// Loads all Sprite objects found in a folder via AssetDatabase.FindAssets.
-        /// Each PNG may be a sprite sheet — LoadAllAssetsAtPath is used to capture all sub-sprites.
-        /// </summary>
         private static Sprite[] LoadSpritesFromFolder(string folder, string excludePathContaining = null)
         {
             var guids = AssetDatabase.FindAssets("t:Sprite", new[] { folder });
@@ -288,17 +225,11 @@ namespace RogueliteAutoBattler.Editor
             return result.ToArray();
         }
 
-        /// <summary>
-        /// Loads all Sprite objects from a single asset file (handles sprite sheets).
-        /// </summary>
         private static Sprite[] LoadSpritesFromFile(string assetPath)
         {
             return AssetDatabase.LoadAllAssetsAtPath(assetPath).OfType<Sprite>().ToArray();
         }
 
-        /// <summary>
-        /// Populates a SerializedProperty sprite array by name.
-        /// </summary>
         private static void SetSpriteArray(SerializedObject so, string propertyName, Sprite[] sprites)
         {
             var prop = so.FindProperty(propertyName);
@@ -315,7 +246,6 @@ namespace RogueliteAutoBattler.Editor
 
         private static Transform FindOrCreateHomeAnchor(string anchorName, Vector2 viewportPosition)
         {
-            // Reuse existing anchor if already in the scene to avoid duplicates on rebuild.
             var existing = GameObject.Find(anchorName);
             if (existing != null)
             {
@@ -342,23 +272,11 @@ namespace RogueliteAutoBattler.Editor
             return go.transform;
         }
 
-        // ------------------------------------------------------------------
-        // Grid sprite
-        // ------------------------------------------------------------------
-
-        /// <summary>
-        /// Creates or loads the blue checkerboard grid sprite (alternate terrain).
-        /// </summary>
         internal static Sprite CreateOrLoadBlueGridSprite()
         {
             return CreateOrLoadCheckerboardSprite(GridBlueSpritePath, GridBlueColorA, GridBlueColorB);
         }
 
-        /// <summary>
-        /// Creates or loads the green checkerboard grid sprite used as the default ground tile.
-        /// The sprite is a 64x64 PNG with Repeat wrap mode and FullRect mesh so
-        /// <see cref="SpriteDrawMode.Tiled"/> works correctly.
-        /// </summary>
         internal static Sprite CreateOrLoadGridSprite()
         {
             return CreateOrLoadCheckerboardSprite(GridSpritePath, GridColorA, GridColorB);

--- a/Assets/Scripts/Editor/EditorUIFactory.cs
+++ b/Assets/Scripts/Editor/EditorUIFactory.cs
@@ -5,9 +5,6 @@ using UnityEngine.UI;
 
 namespace RogueliteAutoBattler.Editor
 {
-    /// <summary>
-    /// Generic, reusable UI helpers for Editor setup scripts.
-    /// </summary>
     internal static class EditorUIFactory
     {
         internal static void Stretch(RectTransform r)
@@ -18,7 +15,6 @@ namespace RogueliteAutoBattler.Editor
             r.offsetMax = Vector2.zero;
         }
 
-        /// <summary>Creates a rectangular area between two vertical anchor ratios.</summary>
         internal static GameObject CreateArea(Transform parent, string name, float anchorBottom, float anchorTop, Color bg)
         {
             var go = new GameObject(name);
@@ -93,9 +89,6 @@ namespace RogueliteAutoBattler.Editor
             if (p != null) p.colorValue = v;
         }
 
-        /// <summary>
-        /// Ensures the directory for the given asset path exists, creating it if necessary.
-        /// </summary>
         internal static void EnsureDirectoryExists(string assetPath)
         {
             string dir = System.IO.Path.GetDirectoryName(assetPath);

--- a/Assets/Scripts/Editor/GameDesignerWindow.cs
+++ b/Assets/Scripts/Editor/GameDesignerWindow.cs
@@ -5,23 +5,13 @@ using System.Collections.Generic;
 
 namespace RogueliteAutoBattler.Editor
 {
-    /// <summary>
-    /// Unified Game Designer window with two tabs:
-    ///   Tab 0 — Team Builder  (formerly TeamEditorWindow)
-    ///   Tab 1 — Level Designer (formerly LevelEditorWindow)
-    /// All mutations go through SerializedObject / SerializedProperty for full Undo support.
-    /// </summary>
     public class GameDesignerWindow : EditorWindow
     {
-        // ─── Tab ─────────────────────────────────────────────────────────────
         private static readonly string[] TabNames = { "Party Builder", "Level Designer" };
         private int _selectedTab;
 
-        // ─── Shared: selected-row style ───────────────────────────────────
         private GUIStyle  _selectedRowStyle;
         private Texture2D _selectedRowTexture;
-
-        // ─── MenuItem ────────────────────────────────────────────────────────
 
         [MenuItem("Roguelite/Game Designer")]
         private static void OpenWindow()
@@ -31,8 +21,6 @@ namespace RogueliteAutoBattler.Editor
             window.Show();
         }
 
-        // ─── Lifecycle ───────────────────────────────────────────────────────
-
         private void OnEnable()
         {
             TeamTryAutoLoadDatabase();
@@ -41,13 +29,10 @@ namespace RogueliteAutoBattler.Editor
 
         private void OnDisable()
         {
-            // Team cleanup
             _teamSerializedDatabase = null;
 
-            // Level cleanup
             _levelSerializedDatabase = null;
 
-            // Shared style cleanup
             _selectedRowStyle = null;
             if (_selectedRowTexture != null)
             {
@@ -56,11 +41,8 @@ namespace RogueliteAutoBattler.Editor
             }
         }
 
-        // ─── OnGUI ───────────────────────────────────────────────────────────
-
         private void OnGUI()
         {
-            // Tab bar
             _selectedTab = GUILayout.Toolbar(_selectedTab, TabNames, EditorStyles.toolbarButton);
             GUILayout.Space(2f);
 
@@ -71,18 +53,14 @@ namespace RogueliteAutoBattler.Editor
             }
         }
 
-        // ══════════════════════════════════════════════════════════════════════
         #region Team Builder
-        // ══════════════════════════════════════════════════════════════════════
 
-        // ─── Layout constants ────────────────────────────────────────────────
         private const float TeamRowHeight        = 24f;
         private const float TeamSmallButtonWidth = 24f;
         private const float TeamAddButtonHeight  = 22f;
         private const string TeamDefaultAllyPrefabPath = "Assets/Prefabs/Characters/sampleCharacterHuman.prefab";
         private const string TeamDatabaseDefaultPath   = "Assets/Data/TeamDatabase.asset";
 
-        // ─── Default values for new allies ───────────────────────────────────
         private const string TeamDefaultAllyName      = "Warrior";
         private const int    TeamDefaultMaxHp          = 100;
         private const int    TeamDefaultAtk            = 10;
@@ -90,13 +68,10 @@ namespace RogueliteAutoBattler.Editor
         private const float  TeamDefaultMoveSpeed      = 2f;
         private const float  TeamDefaultRegenHpPerSec  = 0f;
 
-        // ─── State ───────────────────────────────────────────────────────────
         private TeamDatabase   _teamDatabase;
         private SerializedObject _teamSerializedDatabase;
         private Vector2 _teamScrollPos;
         private readonly Dictionary<string, bool> _teamFoldouts = new Dictionary<string, bool>();
-
-        // ─── Auto-load / create database ─────────────────────────────────────
 
         private void TeamTryAutoLoadDatabase()
         {
@@ -123,8 +98,6 @@ namespace RogueliteAutoBattler.Editor
             _teamFoldouts.Clear();
             Repaint();
         }
-
-        // ─── Draw ────────────────────────────────────────────────────────────
 
         private void DrawTeamTab()
         {
@@ -173,8 +146,6 @@ namespace RogueliteAutoBattler.Editor
                 AssetDatabase.SaveAssets();
         }
 
-        // ─── Toolbar ─────────────────────────────────────────────────────────
-
         private void DrawTeamToolbar()
         {
             GUILayout.BeginHorizontal(EditorStyles.toolbar);
@@ -200,8 +171,6 @@ namespace RogueliteAutoBattler.Editor
             GUILayout.EndHorizontal();
         }
 
-        // ─── Add button ──────────────────────────────────────────────────────
-
         private void TeamDrawAddButton(SerializedProperty alliesProp)
         {
             if (GUILayout.Button("+ Add Ally", GUILayout.Height(TeamAddButtonHeight)))
@@ -213,7 +182,6 @@ namespace RogueliteAutoBattler.Editor
                     var newAlly = alliesProp.GetArrayElementAtIndex(alliesProp.arraySize - 1);
                     TeamInitAllyDefaults(newAlly);
                 }
-                // If the list was non-empty, Unity's arraySize++ already copied the last element.
                 EditorUtility.SetDirty(_teamDatabase);
             }
         }
@@ -238,9 +206,6 @@ namespace RogueliteAutoBattler.Editor
             TeamSetFloatSafe(allyProp, "colliderRadius",    0.05f);
         }
 
-        // ─── Single ally foldout ─────────────────────────────────────────────
-
-        /// <summary>Returns true if the ally list was structurally modified (caller must break).</summary>
         private bool TeamDrawAlly(SerializedProperty alliesProp, int index)
         {
             var allyProp = alliesProp.GetArrayElementAtIndex(index);
@@ -254,7 +219,6 @@ namespace RogueliteAutoBattler.Editor
                 ? nameProp.stringValue
                 : $"Ally {index + 1}";
 
-            // Header row
             GUILayout.BeginHorizontal();
             {
                 _teamFoldouts[foldoutKey] = EditorGUILayout.Foldout(
@@ -280,7 +244,6 @@ namespace RogueliteAutoBattler.Editor
             if (!_teamFoldouts[foldoutKey])
                 return false;
 
-            // Fields
             EditorGUI.indentLevel++;
 
             if (nameProp != null)
@@ -339,8 +302,6 @@ namespace RogueliteAutoBattler.Editor
             return false;
         }
 
-        // ─── Helpers ─────────────────────────────────────────────────────────
-
         private static void TeamSetIntSafe(SerializedProperty parent, string name, int value)
         {
             var p = parent.FindPropertyRelative(name);
@@ -357,11 +318,8 @@ namespace RogueliteAutoBattler.Editor
 
         #endregion
 
-        // ══════════════════════════════════════════════════════════════════════
         #region Level Designer
-        // ══════════════════════════════════════════════════════════════════════
 
-        // ─── Layout constants ────────────────────────────────────────────────
         private const float LevelColumnStagesWidth  = 150f;
         private const float LevelColumnLevelsWidth  = 150f;
         private const float LevelRowHeight          = 24f;
@@ -371,7 +329,6 @@ namespace RogueliteAutoBattler.Editor
         private const string LevelDatabaseDefaultPath   = "Assets/Data/LevelDatabase.asset";
         private const string LevelDefaultEnemyPrefabPath = "Assets/Prefabs/Characters/sampleCharacterHuman.prefab";
 
-        // ─── Default values for new enemies ────────────────────────────────
         private const string LevelDefaultEnemyName       = "Enemy";
         private const int    LevelDefaultEnemyHp         = 50;
         private const int    LevelDefaultEnemyAtk        = 10;
@@ -380,15 +337,12 @@ namespace RogueliteAutoBattler.Editor
         private const float  LevelDefaultEnemyAttackRange = 0.5f;
         private const float  LevelDefaultEnemyColliderRadius = 0.15f;
 
-        // ─── State ───────────────────────────────────────────────────────────
         private LevelDatabase    _levelDatabase;
         private SerializedObject _levelSerializedDatabase;
         private int _levelSelectedStageIndex = -1;
         private int _levelSelectedLevelIndex = -1;
         private Vector2 _levelWavesScrollPos;
         private readonly Dictionary<string, bool> _levelFoldouts = new Dictionary<string, bool>();
-
-        // ─── Auto-load / create database ─────────────────────────────────────
 
         private void LevelTryAutoLoadDatabase()
         {
@@ -418,8 +372,6 @@ namespace RogueliteAutoBattler.Editor
             Repaint();
         }
 
-        // ─── Draw ────────────────────────────────────────────────────────────
-
         private void DrawLevelTab()
         {
             DrawLevelToolbar();
@@ -448,8 +400,6 @@ namespace RogueliteAutoBattler.Editor
                 AssetDatabase.SaveAssets();
         }
 
-        // ─── Toolbar ─────────────────────────────────────────────────────────
-
         private void DrawLevelToolbar()
         {
             GUILayout.BeginHorizontal(EditorStyles.toolbar);
@@ -474,8 +424,6 @@ namespace RogueliteAutoBattler.Editor
             }
             GUILayout.EndHorizontal();
         }
-
-        // ─── Stages panel ────────────────────────────────────────────────────
 
         private void DrawStagesPanel(SerializedProperty stagesProp)
         {
@@ -560,8 +508,6 @@ namespace RogueliteAutoBattler.Editor
             GUILayout.EndVertical();
         }
 
-        // ─── Levels panel ────────────────────────────────────────────────────
-
         private void DrawLevelsPanel(SerializedProperty stagesProp)
         {
             GUILayout.BeginVertical(GUILayout.Width(LevelColumnLevelsWidth));
@@ -643,8 +589,6 @@ namespace RogueliteAutoBattler.Editor
             GUILayout.EndVertical();
         }
 
-        // ─── Waves panel ─────────────────────────────────────────────────────
-
         private void DrawWavesPanel(SerializedProperty stagesProp)
         {
             GUILayout.BeginVertical();
@@ -715,13 +659,11 @@ namespace RogueliteAutoBattler.Editor
             GUILayout.EndVertical();
         }
 
-        /// <summary>Returns true if the wave list was structurally modified (caller must break).</summary>
         private bool DrawWave(SerializedProperty wavesProp, int wi)
         {
             var waveProp    = wavesProp.GetArrayElementAtIndex(wi);
             var enemiesProp = waveProp.FindPropertyRelative("enemies");
 
-            // Wave header
             EditorGUILayout.BeginHorizontal(EditorStyles.helpBox,
                 GUILayout.Height(LevelWaveHeaderHeight));
 
@@ -753,7 +695,6 @@ namespace RogueliteAutoBattler.Editor
 
             EditorGUILayout.EndHorizontal();
 
-            // Enemy list
             EditorGUI.indentLevel++;
 
             bool enemyListModified = false;
@@ -781,7 +722,6 @@ namespace RogueliteAutoBattler.Editor
                         else
                             InitEnemyDefaults(newEnemy);
                     }
-                    // If the wave was non-empty, Unity's arraySize++ already copied the last element.
                     EditorUtility.SetDirty(_levelDatabase);
                 }
             }
@@ -790,12 +730,6 @@ namespace RogueliteAutoBattler.Editor
             return false;
         }
 
-        /// <summary>
-        /// Searches backwards through the database for the last EnemySpawnData, starting just
-        /// before the current wave (index currentWaveIndex) in the selected level.
-        /// Search order: previous waves in current level → previous levels in current stage → previous stages.
-        /// Returns null if no enemy exists anywhere in the database.
-        /// </summary>
         private SerializedProperty FindLastEnemyInDatabase(int currentWaveIndex)
         {
             var stagesProp = _levelSerializedDatabase.FindProperty("stages");
@@ -814,7 +748,6 @@ namespace RogueliteAutoBattler.Editor
                     var waves = level.FindPropertyRelative("waves");
                     if (waves == null) continue;
 
-                    // For the current level start one wave before the current wave (which is empty).
                     int startWave = (si == _levelSelectedStageIndex && li == _levelSelectedLevelIndex)
                         ? currentWaveIndex - 1
                         : waves.arraySize - 1;
@@ -905,7 +838,6 @@ namespace RogueliteAutoBattler.Editor
                 prefab.objectReferenceValue = AssetDatabase.LoadAssetAtPath<GameObject>(LevelDefaultEnemyPrefabPath);
         }
 
-        /// <summary>Returns true if the enemy list was structurally modified (caller must break).</summary>
         private bool DrawEnemy(SerializedProperty enemiesProp, int wi, int ei)
         {
             var enemyProp     = enemiesProp.GetArrayElementAtIndex(ei);
@@ -1004,12 +936,6 @@ namespace RogueliteAutoBattler.Editor
             return false;
         }
 
-        // ─── Shared appearance drawer ─────────────────────────────────────────
-
-        /// <summary>
-        /// Draws the 4 appearance sprite fields for any parent property that contains
-        /// an <c>AppearanceData appearance</c> sub-property (e.g. EnemySpawnData, AllySpawnData).
-        /// </summary>
         private static void DrawAppearanceFields(SerializedProperty parentProp)
         {
             var appearanceProp = parentProp.FindPropertyRelative("appearance");
@@ -1032,8 +958,6 @@ namespace RogueliteAutoBattler.Editor
                 appearanceProp.FindPropertyRelative("shieldSprite"), new GUIContent("Shield"));
         }
 
-        // ─── Shared layout helpers ────────────────────────────────────────────
-
         private static void DrawPanelHeader(string title)
         {
             GUILayout.Label(title, EditorStyles.boldLabel);
@@ -1050,9 +974,7 @@ namespace RogueliteAutoBattler.Editor
 
         #endregion
 
-        // ══════════════════════════════════════════════════════════════════════
         #region Shared helpers
-        // ══════════════════════════════════════════════════════════════════════
 
         private GUIStyle GetSelectedRowStyle()
         {

--- a/Assets/Scripts/Editor/SetupNavigationSceneEditor.cs
+++ b/Assets/Scripts/Editor/SetupNavigationSceneEditor.cs
@@ -14,37 +14,23 @@ using UnityEngine.UI;
 
 namespace RogueliteAutoBattler.Editor
 {
-    /// <summary>
-    /// Creates the navigation UI hierarchy in one click.
-    /// Layout: 60% game (top) | 32% info (middle) | 8% nav bar (bottom, edge to edge).
-    /// Combat is the default screen (no tab selected).
-    /// CombatPanel is transparent — reveals the 2D world (CombatWorld) behind the Overlay Canvas.
-    /// Tab panels are opaque and cover the world when active.
-    /// </summary>
     public static class SetupNavigationSceneEditor
     {
-        // Canvas
         private const int CanvasWidth = 1080;
         private const int CanvasHeight = 1920;
         private const float CanvasMatch = 0.5f;
 
-        // Layout ratios (from bottom)
-        private const float NavRatio = 0.08f;   // bottom 8%
-        private const float InfoTop = 0.40f;     // info ends at 40% (30% tall)
-        // Game area = 40% to 100% (top 60%)
+        private const float NavRatio = 0.08f;
+        private const float InfoTop = 0.40f;
 
-        // Tab count
         private const int TabCount = 5;
 
-        // Font sizes
         private const int NavFontSize = 22;
         private const int PanelFontSize = 56;
         private const int InfoFontSize = 32;
 
-        // Input
         private const string InputAssetPath = "Assets/Settings/InputSystem_Actions.inputactions";
 
-        // Colors
         private static readonly Color NavBarBg = (Color)new Color32(25, 25, 25, 255);
         private static readonly Color NavBtnNormal = (Color)new Color32(40, 40, 40, 255);
         private static readonly Color NavBtnSelected = (Color)new Color32(80, 80, 80, 255);
@@ -67,7 +53,6 @@ namespace RogueliteAutoBattler.Editor
             int undoGroup = Undo.GetCurrentGroup();
             Undo.SetCurrentGroupName("Setup Navigation UI");
 
-            // Cleanup existing objects
             if (existingCanvas != null)
                 Undo.DestroyObjectImmediate(existingCanvas.gameObject);
 
@@ -83,36 +68,28 @@ namespace RogueliteAutoBattler.Editor
             if (oldWorld != null)
                 Undo.DestroyObjectImmediate(oldWorld);
 
-            // --- Setup camera ---
             Camera mainCam = CombatWorldBuilder.ConfigureMainCamera();
 
-            // --- Build 2D world ---
             GameObject combatWorldGo = CombatWorldBuilder.CreateCombatWorld();
             Undo.RegisterCreatedObjectUndo(combatWorldGo, "CombatWorld");
 
-            // --- Build Canvas HUD (Overlay — draws on top of world) ---
             GameObject esGo = CreateEventSystem();
             GameObject canvasGo = CreateCanvas(mainCam);
 
-            // 1. Game area (top 60%) — contains combat + tab panels
             GameObject gameArea = EditorUIFactory.CreateArea(canvasGo.transform, "GameArea", InfoTop, 1f, Color.clear);
             UIScreen combatScreen = CombatHudBuilder.CreateCombatPanel(gameArea.transform);
             UIScreen[] tabScreens = CreateTabPanels(gameArea.transform);
 
-            // 2. Info area — contains default info + per-tab info panels
             GameObject infoArea = EditorUIFactory.CreateArea(canvasGo.transform, "InfoArea", NavRatio, InfoTop, Color.clear);
             UIScreen defaultInfoScreen = CreateInfoPanel(infoArea.transform, "CombatInfo", "INVENTAIRE / STATS", InfoBg, true);
             UIScreen[] infoScreens = CreateTabInfoPanels(infoArea.transform);
 
-            // 3. Nav bar (edge to edge, no padding)
             GameObject navBar = CreateNavBar(canvasGo.transform);
             TabButton[] tabButtons = CreateTabButtons(navBar.transform);
 
-            // 4. NavigationManager (child of UICanvas for clean hierarchy)
             GameObject navGo = CreateNavigationManager(canvasGo.transform, combatScreen, defaultInfoScreen, tabButtons, tabScreens, infoScreens);
             WireCancelAction(navGo.GetComponent<NavigationManager>());
 
-            // Undo
             Undo.RegisterCreatedObjectUndo(esGo, "EventSystem");
             Undo.RegisterCreatedObjectUndo(canvasGo, "UICanvas");
             Undo.CollapseUndoOperations(undoGroup);
@@ -121,10 +98,6 @@ namespace RogueliteAutoBattler.Editor
             Selection.activeGameObject = canvasGo;
             Debug.Log("[SetupNavigationUI] Done. Press Play — click tabs to switch panels.");
         }
-
-        // =============================================================
-        // Core objects
-        // =============================================================
 
         private static GameObject CreateEventSystem()
         {
@@ -153,17 +126,13 @@ namespace RogueliteAutoBattler.Editor
             return go;
         }
 
-        // =============================================================
-        // Tab panels (overlay on top of combat)
-        // =============================================================
-
         private static UIScreen[] CreateTabPanels(Transform parent)
         {
             var configs = new[]
             {
                 new PanelCfg("VillagePanel", "VILLAGE", "2D6A4F", typeof(VillageScreen)),
                 new PanelCfg("SkillTreePanel", "ARBRE", "7B2D8E", typeof(SkillTreeScreen)),
-                new PanelCfg("AutrePanel", "AUTRE", "555555", typeof(GuildScreen)), // placeholder — replace with AutreScreen when created
+                new PanelCfg("AutrePanel", "AUTRE", "555555", typeof(GuildScreen)),
                 new PanelCfg("GuildePanel", "GUILDE", "1D3557", typeof(GuildScreen)),
                 new PanelCfg("ShopPanel", "SHOP", "E9C46A", typeof(ShopScreen)),
             };
@@ -178,7 +147,6 @@ namespace RogueliteAutoBattler.Editor
 
                 go.AddComponent<Image>().color = EditorUIFactory.HexToColor(c.Hex);
 
-                // Start hidden — combat is visible by default
                 EditorUIFactory.SetupCanvasGroup(go, false);
 
                 screens[i] = (UIScreen)go.AddComponent(c.ScreenType);
@@ -187,11 +155,6 @@ namespace RogueliteAutoBattler.Editor
             return screens;
         }
 
-        // =============================================================
-        // Info panels (inside InfoArea)
-        // =============================================================
-
-        /// <summary>Creates a single info panel with background and label.</summary>
         private static UIScreen CreateInfoPanel(Transform parent, string name, string label, Color bg, bool visible = false)
         {
             var go = new GameObject(name);
@@ -206,7 +169,6 @@ namespace RogueliteAutoBattler.Editor
             return screen;
         }
 
-        /// <summary>Creates one info panel per tab, all hidden by default.</summary>
         private static UIScreen[] CreateTabInfoPanels(Transform parent)
         {
             var configs = new[]
@@ -226,10 +188,6 @@ namespace RogueliteAutoBattler.Editor
             }
             return screens;
         }
-
-        // =============================================================
-        // Nav bar — bottom 8%, edge to edge, no padding
-        // =============================================================
 
         private static GameObject CreateNavBar(Transform parent)
         {
@@ -273,11 +231,9 @@ namespace RogueliteAutoBattler.Editor
                 GameObjectUtility.SetParentAndAlign(go, parent.gameObject);
                 go.AddComponent<RectTransform>();
 
-                // Button background — fills its cell, no border
                 Image img = go.AddComponent<Image>();
                 img.color = NavBtnNormal;
 
-                // Button component with flat color transition
                 Button btn = go.AddComponent<Button>();
                 ColorBlock cb = btn.colors;
                 cb.normalColor = Color.white;
@@ -286,7 +242,6 @@ namespace RogueliteAutoBattler.Editor
                 cb.selectedColor = Color.white;
                 btn.colors = cb;
 
-                // Force each button to take equal space (flex like CSS)
                 LayoutElement le = go.AddComponent<LayoutElement>();
                 le.flexibleWidth = 1f;
                 le.flexibleHeight = 1f;
@@ -294,12 +249,9 @@ namespace RogueliteAutoBattler.Editor
                 TabButton tb = go.AddComponent<TabButton>();
                 buttons[i] = tb;
 
-                // Label — centered text, stays white always
                 TextMeshProUGUI tmp = EditorUIFactory.CreateLabel(go.transform, "Label", c.Label, NavFontSize, Color.white);
                 tmp.fontStyle = FontStyles.Bold;
 
-                // Wire SerializedFields
-                // NOTE: _label is NOT wired — keeps text white. Only _icon (background) changes color.
                 var so = new SerializedObject(tb);
                 EditorUIFactory.SetInt(so, "_tabIndex", c.Index);
                 EditorUIFactory.SetObj(so, "_icon", img);
@@ -310,10 +262,6 @@ namespace RogueliteAutoBattler.Editor
             return buttons;
         }
 
-        // =============================================================
-        // NavigationManager wiring
-        // =============================================================
-
         private static GameObject CreateNavigationManager(Transform parent, UIScreen defaultScreen, UIScreen defaultInfoScreen,
             TabButton[] tabButtons, UIScreen[] tabScreens, UIScreen[] infoScreens)
         {
@@ -322,11 +270,9 @@ namespace RogueliteAutoBattler.Editor
             NavigationManager nav = go.AddComponent<NavigationManager>();
             var so = new SerializedObject(nav);
 
-            // Wire default screens
             EditorUIFactory.SetObj(so, "_defaultScreen", defaultScreen);
             EditorUIFactory.SetObj(so, "_defaultInfoScreen", defaultInfoScreen);
 
-            // Wire arrays
             EditorUIFactory.WireArray(so, "_tabButtons", tabButtons, TabCount);
             EditorUIFactory.WireArray(so, "_rootScreens", tabScreens, TabCount);
             EditorUIFactory.WireArray(so, "_infoScreens", infoScreens, TabCount);
@@ -364,10 +310,6 @@ namespace RogueliteAutoBattler.Editor
             }
             return null;
         }
-
-        // =============================================================
-        // Config structs
-        // =============================================================
 
         private readonly struct PanelCfg
         {

--- a/Assets/Scripts/ScriptableObjects/CharacterStats.cs
+++ b/Assets/Scripts/ScriptableObjects/CharacterStats.cs
@@ -2,28 +2,16 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Data
 {
-    /// <summary>
-    /// ScriptableObject holding base stats for a character type.
-    /// Create via Assets > Create > Roguelite > Character Stats.
-    /// </summary>
     [CreateAssetMenu(fileName = "NewCharacterStats", menuName = "Roguelite/Character Stats")]
     public class CharacterStats : ScriptableObject
     {
         [Header("Combat")]
-        [Tooltip("Damage dealt per attack.")]
         [SerializeField] private int atk = 10;
-
-        [Tooltip("Maximum health points.")]
         [SerializeField] private int maxHp = 100;
-
-        [Tooltip("HP regenerated per second.")]
         [SerializeField] private float regenHpPerSecond = 0f;
-
-        [Tooltip("Attacks per second. Also scales animation speed.")]
         [SerializeField] private float attackSpeed = 1f;
 
         [Header("Movement")]
-        [Tooltip("Movement speed in world units per second.")]
         [SerializeField] private float moveSpeed = 2f;
 
         public int Atk => atk;

--- a/Assets/Scripts/ScriptableObjects/LevelDataTypes.cs
+++ b/Assets/Scripts/ScriptableObjects/LevelDataTypes.cs
@@ -13,16 +13,9 @@ namespace RogueliteAutoBattler.Data
     [Serializable]
     public class AppearanceData
     {
-        [Tooltip("Sprite for the head slot. Null keeps prefab default.")]
         [SerializeField] private Sprite headSprite;
-
-        [Tooltip("Sprite for the hat/armor slot. Null keeps prefab default.")]
         [SerializeField] private Sprite hatSprite;
-
-        [Tooltip("Sprite for the weapon slot. Null keeps prefab default.")]
         [SerializeField] private Sprite weaponSprite;
-
-        [Tooltip("Sprite for the shield slot. Null keeps prefab default.")]
         [SerializeField] private Sprite shieldSprite;
 
         public Sprite HeadSprite => headSprite;
@@ -35,8 +28,7 @@ namespace RogueliteAutoBattler.Data
     public class StageData
     {
         [SerializeField] private string stageName = "New Stage";
-        [SerializeField] [Tooltip("Ground sprite for this stage's terrain.")]
-        private Sprite terrain;
+        [SerializeField] private Sprite terrain;
         [SerializeField] private List<LevelData> levels = new List<LevelData>();
 
         public string StageName => stageName;
@@ -58,8 +50,7 @@ namespace RogueliteAutoBattler.Data
     public class WaveData
     {
         [SerializeField] private string waveName = "Wave";
-        [SerializeField] [Tooltip("Delay in seconds before this wave spawns (Wave 1 is always 0).")]
-        private float spawnDelay;
+        [SerializeField] private float spawnDelay;
         [SerializeField] private List<EnemySpawnData> enemies = new List<EnemySpawnData>();
 
         public string WaveName => waveName;
@@ -71,7 +62,6 @@ namespace RogueliteAutoBattler.Data
     public class EnemySpawnData
     {
         [SerializeField] private string enemyName = "Enemy";
-        [Tooltip("Enemy prefab — must have Rigidbody2D root + Animator child")]
         [SerializeField] private GameObject prefab;
         [SerializeField] private int hp = 50;
         [SerializeField] private int atk = 10;
@@ -100,7 +90,6 @@ namespace RogueliteAutoBattler.Data
     public class AllySpawnData
     {
         [SerializeField] private string allyName = "Warrior";
-        [Tooltip("Ally prefab — must have Rigidbody2D root + Animator child")]
         [SerializeField] private GameObject prefab;
         [SerializeField] private int maxHp = 100;
         [SerializeField] private int atk = 10;

--- a/Assets/Scripts/UI/Core/NavigationManager.cs
+++ b/Assets/Scripts/UI/Core/NavigationManager.cs
@@ -4,57 +4,27 @@ using UnityEngine.InputSystem;
 
 namespace RogueliteAutoBattler.UI.Core
 {
-    /// <summary>
-    /// Singleton that manages tab navigation.
-    /// Combat screen is the default (no tab selected).
-    /// Clicking a tab shows that panel; clicking it again returns to combat.
-    /// </summary>
     public class NavigationManager : MonoBehaviour
     {
-        /// <summary>
-        /// Singleton instance.
-        /// Single-scene architecture — no DontDestroyOnLoad needed.
-        /// </summary>
         public static NavigationManager Instance { get; private set; }
 
         [Header("Default Screens")]
-        [SerializeField]
-        [Tooltip("Main screen shown when no tab is selected (Combat/Battle).")]
-        private UIScreen _defaultScreen;
-
-        [SerializeField]
-        [Tooltip("Info panel shown when no tab is selected.")]
-        private UIScreen _defaultInfoScreen;
+        [SerializeField] private UIScreen _defaultScreen;
+        [SerializeField] private UIScreen _defaultInfoScreen;
 
         [Header("Tab Setup")]
-        [SerializeField]
-        [Tooltip("Tab buttons in order.")]
-        private TabButton[] _tabButtons;
-
-        [SerializeField]
-        [Tooltip("Root screens in order (same order as tab buttons).")]
-        private UIScreen[] _rootScreens;
-
-        [SerializeField]
-        [Tooltip("Info screens in order (same order as tab buttons).")]
-        private UIScreen[] _infoScreens;
+        [SerializeField] private TabButton[] _tabButtons;
+        [SerializeField] private UIScreen[] _rootScreens;
+        [SerializeField] private UIScreen[] _infoScreens;
 
         [Header("Input")]
-        [SerializeField]
-        [Tooltip("Input action for back/cancel navigation (typically Escape key).")]
-        private InputActionReference _cancelAction;
+        [SerializeField] private InputActionReference _cancelAction;
 
         private ScreenStack[] _stacks;
         private int _currentTabIndex = -1;
 
-        /// <summary>
-        /// Index of the currently active tab. -1 means no tab (default/combat screen).
-        /// </summary>
         public int CurrentTab => _currentTabIndex;
 
-        /// <summary>
-        /// Fired when the active tab changes. -1 means returned to default screen.
-        /// </summary>
         public event Action<int> OnTabChanged;
 
         private void Awake()
@@ -96,7 +66,6 @@ namespace RogueliteAutoBattler.UI.Core
                 _stacks[i] = new ScreenStack(_rootScreens[i]);
             }
 
-            // Hide all info screens
             if (_infoScreens != null)
             {
                 for (int i = 0; i < _infoScreens.Length; i++)
@@ -111,7 +80,6 @@ namespace RogueliteAutoBattler.UI.Core
         {
             if (_stacks == null) return;
 
-            // Show default screens (combat + combat info), no tab selected
             if (_defaultScreen != null)
                 _defaultScreen.OnShow();
             if (_defaultInfoScreen != null)
@@ -145,37 +113,29 @@ namespace RogueliteAutoBattler.UI.Core
         {
             if (_stacks == null) return;
 
-            // If a tab is active and has sub-screens, pop
             if (_currentTabIndex >= 0 && _stacks[_currentTabIndex].Count > 1)
             {
                 PopScreen();
                 return;
             }
 
-            // If a tab is active, return to default (combat)
             if (_currentTabIndex >= 0)
             {
                 ReturnToDefault();
             }
         }
 
-        /// <summary>
-        /// Switches to the tab at the given index.
-        /// If the tab is already active, returns to the default screen (toggle behavior).
-        /// </summary>
         public void SwitchTab(int index)
         {
             if (_stacks == null || index < 0 || index >= _stacks.Length)
                 return;
 
-            // Toggle: clicking the active tab returns to default
             if (index == _currentTabIndex)
             {
                 ReturnToDefault();
                 return;
             }
 
-            // Hide current tab if any
             if (_currentTabIndex >= 0)
             {
                 _tabButtons[_currentTabIndex].Deselect();
@@ -184,7 +144,6 @@ namespace RogueliteAutoBattler.UI.Core
             }
             else
             {
-                // Hide default screens (combat)
                 if (_defaultScreen != null)
                     _defaultScreen.OnHide();
                 if (_defaultInfoScreen != null)
@@ -199,9 +158,6 @@ namespace RogueliteAutoBattler.UI.Core
             OnTabChanged?.Invoke(_currentTabIndex);
         }
 
-        /// <summary>
-        /// Returns to the default screen (combat). Deselects all tabs.
-        /// </summary>
         public void ReturnToDefault()
         {
             if (_currentTabIndex >= 0)
@@ -221,19 +177,12 @@ namespace RogueliteAutoBattler.UI.Core
             OnTabChanged?.Invoke(-1);
         }
 
-        /// <summary>
-        /// Pushes a sub-screen onto the current tab's stack.
-        /// </summary>
         public void PushScreen(UIScreen screen)
         {
             if (_stacks == null || _currentTabIndex < 0) return;
             _stacks[_currentTabIndex].Push(screen);
         }
 
-        /// <summary>
-        /// Pops the top screen from the current tab's stack.
-        /// Returns null if only the root remains.
-        /// </summary>
         public UIScreen PopScreen()
         {
             if (_stacks == null || _currentTabIndex < 0) return null;

--- a/Assets/Scripts/UI/Core/ScreenStack.cs
+++ b/Assets/Scripts/UI/Core/ScreenStack.cs
@@ -2,23 +2,12 @@ using System.Collections.Generic;
 
 namespace RogueliteAutoBattler.UI.Core
 {
-    /// <summary>
-    /// Manages a stack of UIScreens for a single tab. Plain C# class.
-    /// The root screen starts hidden; call ShowCurrent() to reveal it.
-    /// </summary>
     public class ScreenStack
     {
         private readonly Stack<UIScreen> _stack;
         private readonly UIScreen _root;
 
-        /// <summary>
-        /// The screen currently on top of the stack.
-        /// </summary>
         public UIScreen Current => _stack.Peek();
-
-        /// <summary>
-        /// Number of screens in the stack.
-        /// </summary>
         public int Count => _stack.Count;
 
         public ScreenStack(UIScreen rootScreen)
@@ -28,9 +17,6 @@ namespace RogueliteAutoBattler.UI.Core
             _stack.Push(_root);
         }
 
-        /// <summary>
-        /// Pushes a new screen on top of the current one.
-        /// </summary>
         public void Push(UIScreen screen)
         {
             Current.OnPush();
@@ -38,9 +24,6 @@ namespace RogueliteAutoBattler.UI.Core
             screen.OnShow();
         }
 
-        /// <summary>
-        /// Pops the top screen. Returns null if only the root remains.
-        /// </summary>
         public UIScreen Pop()
         {
             if (_stack.Count <= 1)
@@ -54,10 +37,6 @@ namespace RogueliteAutoBattler.UI.Core
             return popped;
         }
 
-        /// <summary>
-        /// Pops all screens above the root, hiding each one.
-        /// Does not show the root; call ShowCurrent() separately if needed.
-        /// </summary>
         public void Clear()
         {
             while (_stack.Count > 1)
@@ -67,17 +46,11 @@ namespace RogueliteAutoBattler.UI.Core
             }
         }
 
-        /// <summary>
-        /// Shows the current top screen.
-        /// </summary>
         public void ShowCurrent()
         {
             Current.OnShow();
         }
 
-        /// <summary>
-        /// Hides the current top screen.
-        /// </summary>
         public void HideCurrent()
         {
             Current.OnHide();

--- a/Assets/Scripts/UI/Core/TabButton.cs
+++ b/Assets/Scripts/UI/Core/TabButton.cs
@@ -4,45 +4,23 @@ using UnityEngine.UI;
 
 namespace RogueliteAutoBattler.UI.Core
 {
-    /// <summary>
-    /// A single tab button in the bottom navigation bar.
-    /// </summary>
     [RequireComponent(typeof(Button))]
     public class TabButton : MonoBehaviour
     {
         [Header("Configuration")]
-        [SerializeField]
-        [Tooltip("Index of the tab this button controls (0-4).")]
-        private int _tabIndex;
+        [SerializeField] private int _tabIndex;
 
         [Header("References")]
-        [SerializeField]
-        [Tooltip("Icon image for this tab.")]
-        private Image _icon;
-
-        [SerializeField]
-        [Tooltip("Text label for this tab.")]
-        private TextMeshProUGUI _label;
+        [SerializeField] private Image _icon;
+        [SerializeField] private TextMeshProUGUI _label;
 
         [Header("Colors")]
-        [SerializeField]
-        [Tooltip("Color when the tab is not selected.")]
-        private Color _normalColor = Color.gray;
-
-        [SerializeField]
-        [Tooltip("Color when the tab is selected.")]
-        private Color _selectedColor = Color.white;
+        [SerializeField] private Color _normalColor = Color.gray;
+        [SerializeField] private Color _selectedColor = Color.white;
 
         private Button _button;
 
-        /// <summary>
-        /// Index of the tab this button controls.
-        /// </summary>
         public int TabIndex => _tabIndex;
-
-        /// <summary>
-        /// Whether this tab is currently selected.
-        /// </summary>
         public bool IsSelected { get; private set; }
 
         private void Awake()
@@ -69,18 +47,12 @@ namespace RogueliteAutoBattler.UI.Core
             NavigationManager.Instance.SwitchTab(_tabIndex);
         }
 
-        /// <summary>
-        /// Marks this tab as selected and applies the selected color.
-        /// </summary>
         public void Select()
         {
             IsSelected = true;
             ApplyColor(_selectedColor);
         }
 
-        /// <summary>
-        /// Marks this tab as deselected and applies the normal color.
-        /// </summary>
         public void Deselect()
         {
             IsSelected = false;

--- a/Assets/Scripts/UI/Core/UIScreen.cs
+++ b/Assets/Scripts/UI/Core/UIScreen.cs
@@ -2,9 +2,6 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.UI.Core
 {
-    /// <summary>
-    /// Base class for all UI screens. Uses CanvasGroup for visibility control.
-    /// </summary>
     [RequireComponent(typeof(CanvasGroup))]
     public class UIScreen : MonoBehaviour
     {
@@ -15,9 +12,6 @@ namespace RogueliteAutoBattler.UI.Core
             EnsureCanvasGroup();
         }
 
-        /// <summary>
-        /// Called when this screen becomes visible.
-        /// </summary>
         public virtual void OnShow()
         {
             EnsureCanvasGroup();
@@ -26,9 +20,6 @@ namespace RogueliteAutoBattler.UI.Core
             _canvasGroup.interactable = true;
         }
 
-        /// <summary>
-        /// Called when this screen is hidden.
-        /// </summary>
         public virtual void OnHide()
         {
             EnsureCanvasGroup();
@@ -37,17 +28,11 @@ namespace RogueliteAutoBattler.UI.Core
             _canvasGroup.interactable = false;
         }
 
-        /// <summary>
-        /// Called when another screen is pushed on top of this one.
-        /// </summary>
         public virtual void OnPush()
         {
             OnHide();
         }
 
-        /// <summary>
-        /// Called when this screen returns to the front after the one above is popped.
-        /// </summary>
         public virtual void OnPop()
         {
             OnShow();

--- a/Assets/Scripts/UI/Screens/Combat/CombatScreen.cs
+++ b/Assets/Scripts/UI/Screens/Combat/CombatScreen.cs
@@ -2,9 +2,6 @@ using RogueliteAutoBattler.UI.Core;
 
 namespace RogueliteAutoBattler.UI.Screens.Combat
 {
-    /// <summary>
-    /// Placeholder screen for the Combat tab.
-    /// </summary>
     public class CombatScreen : UIScreen
     {
     }

--- a/Assets/Scripts/UI/Screens/Guild/GuildScreen.cs
+++ b/Assets/Scripts/UI/Screens/Guild/GuildScreen.cs
@@ -2,9 +2,6 @@ using RogueliteAutoBattler.UI.Core;
 
 namespace RogueliteAutoBattler.UI.Screens.Guild
 {
-    /// <summary>
-    /// Placeholder screen for the Guild tab.
-    /// </summary>
     public class GuildScreen : UIScreen
     {
     }

--- a/Assets/Scripts/UI/Screens/Shop/ShopScreen.cs
+++ b/Assets/Scripts/UI/Screens/Shop/ShopScreen.cs
@@ -2,9 +2,6 @@ using RogueliteAutoBattler.UI.Core;
 
 namespace RogueliteAutoBattler.UI.Screens.Shop
 {
-    /// <summary>
-    /// Placeholder screen for the Shop tab.
-    /// </summary>
     public class ShopScreen : UIScreen
     {
     }

--- a/Assets/Scripts/UI/Screens/SkillTree/SkillTreeScreen.cs
+++ b/Assets/Scripts/UI/Screens/SkillTree/SkillTreeScreen.cs
@@ -2,9 +2,6 @@ using RogueliteAutoBattler.UI.Core;
 
 namespace RogueliteAutoBattler.UI.Screens.SkillTree
 {
-    /// <summary>
-    /// Placeholder screen for the Skill Tree tab.
-    /// </summary>
     public class SkillTreeScreen : UIScreen
     {
     }

--- a/Assets/Scripts/UI/Screens/Village/VillageScreen.cs
+++ b/Assets/Scripts/UI/Screens/Village/VillageScreen.cs
@@ -2,9 +2,6 @@ using RogueliteAutoBattler.UI.Core;
 
 namespace RogueliteAutoBattler.UI.Screens.Village
 {
-    /// <summary>
-    /// Placeholder screen for the Village tab.
-    /// </summary>
     public class VillageScreen : UIScreen
     {
     }

--- a/Assets/Tests/EditMode/CombatStatsTests.cs
+++ b/Assets/Tests/EditMode/CombatStatsTests.cs
@@ -64,8 +64,8 @@ namespace RogueliteAutoBattler.Tests.EditMode
             int diedCount = 0;
             _stats.OnDied += () => diedCount++;
 
-            _stats.TakeDamage(100); // First kill
-            _stats.TakeDamage(50);  // Damage while dead
+            _stats.TakeDamage(100);
+            _stats.TakeDamage(50);
 
             Assert.AreEqual(1, diedCount);
         }

--- a/Assets/Tests/EditMode/EditModeTestBase.cs
+++ b/Assets/Tests/EditMode/EditModeTestBase.cs
@@ -4,18 +4,10 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Tests.EditMode
 {
-    /// <summary>
-    /// Base class for Edit Mode tests that create GameObjects.
-    /// Tracks all created objects and destroys them immediately in TearDown.
-    /// </summary>
     public abstract class EditModeTestBase
     {
         private readonly List<GameObject> _created = new List<GameObject>();
 
-        /// <summary>
-        /// Registers a GameObject for automatic cleanup in TearDown.
-        /// Returns the same object for inline use.
-        /// </summary>
         protected GameObject Track(GameObject go)
         {
             _created.Add(go);

--- a/Assets/Tests/EditMode/FormationLayoutTests.cs
+++ b/Assets/Tests/EditMode/FormationLayoutTests.cs
@@ -35,14 +35,10 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             Assert.AreEqual(3, positions.Length);
 
-            // totalHeight = (3-1) * 0.5 = 1.0
-            // startY = 0 + 1.0 * 0.5 = 0.5
-            // positions: 0.5, 0.0, -0.5
             Assert.That(positions[0].y, Is.EqualTo(0.5f).Within(0.01f));
             Assert.That(positions[1].y, Is.EqualTo(0.0f).Within(0.01f));
             Assert.That(positions[2].y, Is.EqualTo(-0.5f).Within(0.01f));
 
-            // All same X at anchor
             Assert.That(positions[0].x, Is.EqualTo(0f).Within(0.01f));
             Assert.That(positions[1].x, Is.EqualTo(0f).Within(0.01f));
             Assert.That(positions[2].x, Is.EqualTo(0f).Within(0.01f));
@@ -57,16 +53,12 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             Assert.AreEqual(5, positions.Length);
 
-            // totalHeight = (5-1) * 0.5 = 2.0
-            // startY = 1.0 + 2.0 * 0.5 = 2.0
-            // positions Y: 2.0, 1.5, 1.0, 0.5, 0.0
             Assert.That(positions[0].y, Is.EqualTo(2.0f).Within(0.01f));
             Assert.That(positions[1].y, Is.EqualTo(1.5f).Within(0.01f));
             Assert.That(positions[2].y, Is.EqualTo(1.0f).Within(0.01f));
             Assert.That(positions[3].y, Is.EqualTo(0.5f).Within(0.01f));
             Assert.That(positions[4].y, Is.EqualTo(0.0f).Within(0.01f));
 
-            // All same X at anchor
             for (int i = 0; i < 5; i++)
             {
                 Assert.That(positions[i].x, Is.EqualTo(2f).Within(0.01f));
@@ -82,9 +74,6 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             Assert.AreEqual(6, positions.Length);
 
-            // frontCount = Ceil(6/2) = 3, backCount = 3
-            // Front column (indices 0-2): X = anchor.x = 1.0
-            // Back column  (indices 3-5): X = anchor.x + (-0.5) = 0.5  (facingRight => -columnSpacing)
             for (int i = 0; i < 3; i++)
             {
                 Assert.That(positions[i].x, Is.EqualTo(1.0f).Within(0.01f));
@@ -105,9 +94,6 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             Assert.AreEqual(6, positions.Length);
 
-            // frontCount = Ceil(6/2) = 3, backCount = 3
-            // Front column (indices 0-2): X = anchor.x = 1.0
-            // Back column  (indices 3-5): X = anchor.x + (+0.5) = 1.5  (facingLeft => +columnSpacing)
             for (int i = 0; i < 3; i++)
             {
                 Assert.That(positions[i].x, Is.EqualTo(1.0f).Within(0.01f));

--- a/Assets/Tests/EditMode/RecalculateFormationTests.cs
+++ b/Assets/Tests/EditMode/RecalculateFormationTests.cs
@@ -25,7 +25,6 @@ namespace RogueliteAutoBattler.Tests.EditMode
             for (int i = 0; i < 3; i++)
             {
                 chars[i] = CreateFormationChild($"Char{i}");
-                // Give arbitrary initial offsets that differ from expected
                 chars[i].GetComponent<CharacterMover>().SetHomeOffset(new Vector2(99f, 99f));
             }
 
@@ -52,16 +51,13 @@ namespace RogueliteAutoBattler.Tests.EditMode
             var char1 = CreateFormationChild("Dead1");
             var char2 = CreateFormationChild("Alive2");
 
-            // Kill the second character
             char1.GetComponent<CombatStats>().TakeDamage(9999);
             Assert.IsTrue(char1.GetComponent<CombatStats>().IsDead, "Precondition: char1 should be dead");
 
-            // Record dead character's offset before recalculation
             var deadOffsetBefore = char1.GetComponent<CharacterMover>().HomeOffset;
 
             CombatSetupHelper.RecalculateFormation(_container.transform, _anchor.transform, facingRight: true);
 
-            // The two alive characters should get offsets for a 2-unit formation
             Vector2[] expected = FormationLayout.GetPositions(anchorPos, 2, true);
 
             var alive0Offset = char0.GetComponent<CharacterMover>().HomeOffset;
@@ -75,7 +71,6 @@ namespace RogueliteAutoBattler.Tests.EditMode
             Assert.That(alive2Offset.x, Is.EqualTo(expectedOffset1.x).Within(0.01f), "Alive2 X");
             Assert.That(alive2Offset.y, Is.EqualTo(expectedOffset1.y).Within(0.01f), "Alive2 Y");
 
-            // Dead character's offset should be unchanged
             var deadOffsetAfter = char1.GetComponent<CharacterMover>().HomeOffset;
             Assert.That(deadOffsetAfter.x, Is.EqualTo(deadOffsetBefore.x).Within(0.001f),
                 "Dead character X offset should not change");
@@ -89,17 +84,14 @@ namespace RogueliteAutoBattler.Tests.EditMode
             var char0 = CreateFormationChild("Dead0");
             var char1 = CreateFormationChild("Dead1");
 
-            // Kill both
             char0.GetComponent<CombatStats>().TakeDamage(9999);
             char1.GetComponent<CombatStats>().TakeDamage(9999);
 
-            // Record offsets before
             var offset0Before = char0.GetComponent<CharacterMover>().HomeOffset;
             var offset1Before = char1.GetComponent<CharacterMover>().HomeOffset;
 
             CombatSetupHelper.RecalculateFormation(_container.transform, _anchor.transform, facingRight: true);
 
-            // Both offsets should be unchanged
             var offset0After = char0.GetComponent<CharacterMover>().HomeOffset;
             var offset1After = char1.GetComponent<CharacterMover>().HomeOffset;
 
@@ -149,9 +141,6 @@ namespace RogueliteAutoBattler.Tests.EditMode
                 CombatSetupHelper.RecalculateFormation(_container.transform, null, true));
         }
 
-        /// <summary>
-        /// Creates a formation-ready character (CombatStats + CharacterMover) as a child of the container.
-        /// </summary>
         private GameObject CreateFormationChild(string name)
         {
             var go = TestCharacterFactory.CreateFormationCharacter(name: name, maxHp: 100, atk: 10, attackSpeed: 1f, moveSpeed: 2f);

--- a/Assets/Tests/EditMode/TargetFinderTests.cs
+++ b/Assets/Tests/EditMode/TargetFinderTests.cs
@@ -38,7 +38,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
             _container = Track(new GameObject("Container"));
 
             var nearest = CreateChild("Nearest_Dead", new Vector3(1f, 0f, 0f));
-            nearest.GetComponent<CombatStats>().TakeDamage(100); // Kill it
+            nearest.GetComponent<CombatStats>().TakeDamage(100);
 
             var secondNearest = CreateChild("Second", new Vector3(3f, 0f, 0f));
             CreateChild("Farthest", new Vector3(8f, 0f, 0f));
@@ -56,10 +56,10 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             CreateChild("HighHp", Vector3.zero);
             var low = CreateChild("LowHp", Vector3.zero);
-            low.GetComponent<CombatStats>().TakeDamage(70); // CurrentHp = 30
+            low.GetComponent<CombatStats>().TakeDamage(70);
 
             var mid = CreateChild("MidHp", Vector3.zero);
-            mid.GetComponent<CombatStats>().TakeDamage(40); // CurrentHp = 60
+            mid.GetComponent<CombatStats>().TakeDamage(40);
 
             Transform result = TargetFinder.LowestHp(_container.transform);
 
@@ -74,10 +74,10 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             var full = CreateChild("FullHp", Vector3.zero);
             var damaged = CreateChild("DamagedHp", Vector3.zero);
-            damaged.GetComponent<CombatStats>().TakeDamage(50); // CurrentHp = 50
+            damaged.GetComponent<CombatStats>().TakeDamage(50);
 
             var lowHp = CreateChild("LowHp", Vector3.zero);
-            lowHp.GetComponent<CombatStats>().TakeDamage(80); // CurrentHp = 20
+            lowHp.GetComponent<CombatStats>().TakeDamage(80);
 
             Transform result = TargetFinder.HighestHp(_container.transform);
 

--- a/Assets/Tests/PlayMode/CharacterAppearanceTests.cs
+++ b/Assets/Tests/PlayMode/CharacterAppearanceTests.cs
@@ -71,13 +71,11 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             var appearance = go.GetComponent<CharacterAppearance>();
 
-            // Record originals
             var origHead = appearance.HeadRenderer.sprite;
             var origHat = appearance.HatRenderer.sprite;
             var origWeapon = appearance.WeaponRenderer.sprite;
             var origShield = appearance.ShieldRenderer.sprite;
 
-            // Create test sprites
             var testHead = CreateTestSprite();
             var testHat = CreateTestSprite();
             var testWeapon = CreateTestSprite();
@@ -94,7 +92,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.AreEqual(testShield, appearance.ShieldRenderer.sprite,
                 "Shield sprite should be the test sprite after ApplyAppearance.");
 
-            // Verify they are not the originals
             Assert.AreNotEqual(origHead, appearance.HeadRenderer.sprite,
                 "Head sprite should differ from the original.");
             Assert.AreNotEqual(origHat, appearance.HatRenderer.sprite,
@@ -115,13 +112,11 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             var appearance = go.GetComponent<CharacterAppearance>();
 
-            // Record originals
             var origHead = appearance.HeadRenderer.sprite;
             var origHat = appearance.HatRenderer.sprite;
             var origWeapon = appearance.WeaponRenderer.sprite;
             var origShield = appearance.ShieldRenderer.sprite;
 
-            // Apply all nulls
             appearance.ApplyAppearance(null, null, null, null);
 
             Assert.AreEqual(origHead, appearance.HeadRenderer.sprite,
@@ -144,12 +139,10 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             var appearance = go.GetComponent<CharacterAppearance>();
 
-            // Record originals
             var origHat = appearance.HatRenderer.sprite;
             var origWeapon = appearance.WeaponRenderer.sprite;
             var origShield = appearance.ShieldRenderer.sprite;
 
-            // Create one test sprite for head only
             var testHead = CreateTestSprite();
 
             appearance.ApplyAppearance(testHead, null, null, null);
@@ -167,25 +160,20 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator CharacterAppearance_ApplyAppearance_WeaponSurvivesAnimatorFrames()
         {
-            // Instantiate prefab WITH Animator enabled (real-world scenario)
             var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(PrefabPath);
             var go = Object.Instantiate(prefab);
             Track(go);
 
             var appearance = go.AddComponent<CharacterAppearance>();
-            yield return null; // Awake runs
-
-            // DO NOT disable the Animator — this is the real-world test
+            yield return null;
 
             var testSprite = CreateTestSprite();
-            appearance.ApplyAppearance(null, null, testSprite, null); // weapon only
+            appearance.ApplyAppearance(null, null, testSprite, null);
 
-            // Wait several frames for the Animator to potentially override
             yield return null;
             yield return null;
             yield return null;
 
-            // The weapon should STILL show our test sprite, not the animation's default
             Assert.AreEqual(testSprite, appearance.WeaponRenderer.sprite,
                 "Weapon sprite was overridden by Animator — ApplyAppearance must survive animation frames");
         }

--- a/Assets/Tests/PlayMode/CharacterMoverTests.cs
+++ b/Assets/Tests/PlayMode/CharacterMoverTests.cs
@@ -23,7 +23,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             var mover = charGo.GetComponent<CharacterMover>();
 
-            // Wait a frame so Awake runs.
             yield return null;
 
             mover.HomeAnchor = anchor.transform;
@@ -52,7 +51,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             var mover = charGo.GetComponent<CharacterMover>();
 
-            // Wait a frame so Awake runs.
             yield return null;
 
             mover.Target = targetGo.transform;
@@ -82,24 +80,19 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             var mover = charGo.GetComponent<CharacterMover>();
             var conveyor = conveyorGo.GetComponent<WorldConveyor>();
 
-            // Wait a frame so Awake runs.
             yield return null;
 
-            // No target, no home anchor — character receives scroll velocity
-            // (dynamic Rigidbody2D children are NOT carried by kinematic parent).
             mover.Target = null;
             mover.HomeAnchor = null;
 
             float startX = charGo.transform.position.x;
 
-            // Start scrolling the conveyor.
             conveyor.ScrollBy(4f, 8f, 16f);
 
             yield return new WaitForSeconds(ScrollTestTimeout);
 
             float endX = charGo.transform.position.x;
 
-            // The character moves with the scroll velocity (leftward = negative X).
             Assert.That(endX, Is.LessThan(startX - 1f),
                 "Character should move with scroll when no home anchor is set.");
         }
@@ -109,7 +102,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         {
             var anchor = Track(TestCharacterFactory.CreateAnchor("HomeAnchor", new Vector2(0f, 0f)));
 
-            // Place character very close to anchor — damping should result in very low velocity.
             var charGo = Track(TestCharacterFactory.CreateMoverCharacter(
                 name: "DampedChar",
                 moveSpeed: 5f,
@@ -122,7 +114,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             mover.HomeAnchor = anchor.transform;
             mover.Target = null;
 
-            // Let physics run a few steps.
             yield return new WaitForFixedUpdate();
             yield return new WaitForFixedUpdate();
             yield return new WaitForFixedUpdate();
@@ -130,7 +121,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             var rb = charGo.GetComponent<Rigidbody2D>();
             float velocity = Mathf.Abs(rb.linearVelocity.x);
 
-            // At distance 0.05, correctionSpeed = min(0.05 * 8, 5) = 0.4 — well below moveSpeed of 5.
             Assert.That(velocity, Is.LessThan(2f),
                 "Velocity near home should be proportionally damped (much less than moveSpeed).");
         }
@@ -149,22 +139,17 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             var mover = charGo.GetComponent<CharacterMover>();
             var conveyor = conveyorGo.GetComponent<WorldConveyor>();
 
-            // Wait a frame so Awake runs.
             yield return null;
 
             mover.HomeAnchor = anchor.transform;
             mover.Target = null;
 
-            // Start scroll: conveyor moves 4 units left.
             conveyor.ScrollBy(4f, 8f, 16f);
 
-            // Wait mid-scroll — homing is active, character walks toward anchor
-            // while scroll velocity is applied underneath.
             yield return new WaitForSeconds(0.5f);
 
             float midDrift = Mathf.Abs(charGo.transform.position.x - anchor.transform.position.x);
 
-            // Character should stay near anchor because walkVel compensates scroll.
             Assert.That(midDrift, Is.LessThan(2f),
                 $"Character should stay near anchor during scroll thanks to homing (drift was {midDrift:F2}).");
         }
@@ -183,21 +168,17 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             var mover = charGo.GetComponent<CharacterMover>();
             var conveyor = conveyorGo.GetComponent<WorldConveyor>();
 
-            // Wait a frame so Awake runs.
             yield return null;
 
             mover.HomeAnchor = anchor.transform;
             mover.Target = null;
 
-            // Short fast scroll.
             conveyor.ScrollBy(2f, 8f, 16f);
 
-            // Wait for scroll to complete plus walk-back time.
             yield return new WaitForSeconds(3f);
 
             float endDrift = Mathf.Abs(charGo.transform.position.x - anchor.transform.position.x);
 
-            // After scroll ends, character should have walked back near anchor.
             Assert.That(endDrift, Is.LessThan(0.5f),
                 $"Character should return near anchor after scroll (drift was {endDrift:F2}).");
         }
@@ -212,12 +193,8 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             var mover = charGo.GetComponent<CharacterMover>();
 
-            // Wait a frame so Awake runs.
             yield return null;
 
-            // FlipToward sets transform.localScale.x on the root.
-            // directionX > 0 => localScale.x = -1 (face right, since sprites face LEFT natively)
-            // directionX < 0 => localScale.x = 1 (face left, native)
             mover.FlipToward(1f);
             yield return null;
 

--- a/Assets/Tests/PlayMode/CombatControllerTests.cs
+++ b/Assets/Tests/PlayMode/CombatControllerTests.cs
@@ -12,7 +12,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator EnteringAttackState_StopsMovementAndGoesIdle()
         {
-            // Arrange — enemy close enough to enter Attacking immediately.
             var enemyGo = Track(TestCharacterFactory.CreateFullCombatCharacter(
                 "Enemy", maxHp: 100, position: new Vector2(0.3f, 0f)));
             var heroGo = Track(TestCharacterFactory.CreateFullCombatCharacter(
@@ -27,7 +26,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             heroController.SetAttackRange(0.5f);
             heroController.Target = enemyGo.transform;
 
-            // Wait for hero to enter Attacking state.
             float timeout = 2f;
             float elapsed = 0f;
             while (heroController.State != CombatState.Attacking && elapsed < timeout)
@@ -39,7 +37,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.AreEqual(CombatState.Attacking, heroController.State,
                 "Hero should be in Attacking state (enemy within attack range).");
 
-            // Assert — mover is disabled and velocity is zero (character stopped).
             Assert.IsFalse(heroMover.enabled,
                 "CharacterMover should be disabled in Attacking state.");
             Assert.That(heroRb.linearVelocity.magnitude, Is.LessThan(0.1f),
@@ -49,7 +46,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator MovingState_SharedTargetDies_Retargets()
         {
-            // Arrange — hero far from enemy A, so state will be Moving.
             var enemyA = Track(TestCharacterFactory.CreateFullCombatCharacter(
                 "EnemyA", maxHp: 1, position: new Vector2(5f, 0f)));
             var enemyB = Track(TestCharacterFactory.CreateFullCombatCharacter(
@@ -57,28 +53,23 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             var heroGo = Track(TestCharacterFactory.CreateFullCombatCharacter(
                 "Hero", maxHp: 100, atk: 10, moveSpeed: 2f, position: new Vector2(0f, 0f)));
 
-            // Wait a frame so Awake runs on all components.
             yield return null;
 
             var heroController = heroGo.GetComponent<CombatController>();
             heroController.Target = enemyA.transform;
             heroController.FindNewTarget = () => enemyB.transform;
 
-            // Let FixedUpdate run so CombatController transitions from None to Moving.
             yield return new WaitForFixedUpdate();
             yield return null;
 
             Assert.AreEqual(CombatState.Moving, heroController.State,
                 "Sanity: hero should be in Moving state (far from enemy A).");
 
-            // Act — another source kills enemy A, firing OnDied synchronously.
             LogAssert.Expect(LogType.Log, $"[CombatStats] EnemyA died!");
             enemyA.GetComponent<CombatStats>().TakeDamage(100);
 
-            // One frame for state to settle.
             yield return null;
 
-            // Assert — hero retargeted to enemy B and is still moving.
             Assert.AreEqual(enemyB.transform, heroController.Target,
                 "Hero should have retargeted to enemy B.");
             Assert.AreEqual(CombatState.Moving, heroController.State,
@@ -88,10 +79,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator AttackingState_SharedTargetDies_Retargets()
         {
-            // Arrange — enemy A close to hero so state will be Attacking.
-            // Attack range must exceed collider separation (~1.0 for two default
-            // CircleCollider2D radius 0.5), otherwise physics pushback prevents
-            // the hero from ever reaching Attacking state.
             var enemyA = Track(TestCharacterFactory.CreateFullCombatCharacter(
                 "EnemyA", maxHp: 1, position: new Vector2(0.3f, 0f)));
             var enemyB = Track(TestCharacterFactory.CreateFullCombatCharacter(
@@ -99,7 +86,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             var heroGo = Track(TestCharacterFactory.CreateFullCombatCharacter(
                 "Hero", maxHp: 100, atk: 10, moveSpeed: 2f, position: new Vector2(0f, 0f)));
 
-            // Wait a frame so Awake runs on all components.
             yield return null;
 
             var heroController = heroGo.GetComponent<CombatController>();
@@ -107,8 +93,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             heroController.Target = enemyA.transform;
             heroController.FindNewTarget = () => enemyB.transform;
 
-            // Wait for hero to enter Attacking state. May take several physics frames
-            // because CircleCollider2D pushback can temporarily separate the characters.
             float timeout = 2f;
             float elapsed = 0f;
             while (heroController.State != CombatState.Attacking && elapsed < timeout)
@@ -120,14 +104,11 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.AreEqual(CombatState.Attacking, heroController.State,
                 "Sanity: hero should be in Attacking state (enemy A within attack range).");
 
-            // Act — another source kills enemy A, firing OnDied synchronously.
             LogAssert.Expect(LogType.Log, $"[CombatStats] EnemyA died!");
             enemyA.GetComponent<CombatStats>().TakeDamage(100);
 
-            // One frame for state to settle.
             yield return null;
 
-            // Assert — hero retargeted to enemy B and switched to Moving.
             Assert.AreEqual(enemyB.transform, heroController.Target,
                 "Hero should have retargeted to enemy B.");
             Assert.AreEqual(CombatState.Moving, heroController.State,

--- a/Assets/Tests/PlayMode/CombatStatsRegenTests.cs
+++ b/Assets/Tests/PlayMode/CombatStatsRegenTests.cs
@@ -21,14 +21,11 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             var stats = charGo.GetComponent<CombatStats>();
 
-            // Wait a frame so Awake runs.
             yield return null;
 
-            // Deal 50 damage, bringing HP to 50.
             stats.TakeDamage(50);
             Assert.AreEqual(50, stats.CurrentHp, "HP should be 50 after taking 50 damage.");
 
-            // Wait for regen to heal. At 20 HP/s, after 1.5s, ~30 HP should be healed.
             yield return new WaitForSeconds(1.5f);
 
             Assert.That(stats.CurrentHp, Is.GreaterThan(50),
@@ -49,10 +46,8 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             var stats = charGo.GetComponent<CombatStats>();
 
-            // Wait a frame so Awake runs.
             yield return null;
 
-            // Deal only 10 damage. At 50 HP/s regen, the 10 HP gap should be filled in ~0.2s.
             stats.TakeDamage(10);
             Assert.AreEqual(90, stats.CurrentHp, "HP should be 90 after taking 10 damage.");
 

--- a/Assets/Tests/PlayMode/FormationRecalculationTests.cs
+++ b/Assets/Tests/PlayMode/FormationRecalculationTests.cs
@@ -16,11 +16,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         private GameObject _teamHomeAnchor;
         private GameObject _enemiesHomeAnchor;
 
-        /// <summary>
-        /// Creates a LevelManager on a fresh GameObject with WorldConveyor.
-        /// Also creates Team and Enemies containers, and home anchors.
-        /// Disable LevelManager immediately so Start() does not run.
-        /// </summary>
         private void CreateLevelManagerSetup(
             Vector2? teamAnchorPos = null,
             Vector2? enemiesAnchorPos = null)
@@ -40,14 +35,9 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 "EnemiesHomeAnchor", enemiesAnchorPos ?? new Vector2(5f, 0f)));
         }
 
-        // ---------------------------------------------------------------
-        // Test 1: Allies win, one ally dead, formation recalculated
-        // ---------------------------------------------------------------
-
         [UnityTest]
         public IEnumerator AlliesWin_OneAllyDead_FormationRecalculated()
         {
-            // Arrange
             CreateLevelManagerSetup(
                 teamAnchorPos: Vector2.zero,
                 enemiesAnchorPos: new Vector2(5f, 0f));
@@ -63,10 +53,8 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             ally2.transform.SetParent(_teamContainer.transform);
             ally3.transform.SetParent(_teamContainer.transform);
 
-            // Wait a frame so Awake runs on all components.
             yield return null;
 
-            // Set initial home offsets for a 3-unit formation.
             Vector2 teamAnchorPos = (Vector2)_teamHomeAnchor.transform.position;
             Vector2[] initial3Positions = FormationLayout.GetPositions(teamAnchorPos, 3, facingRight: true);
 
@@ -91,48 +79,37 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 _teamHomeAnchor.transform, _enemiesHomeAnchor.transform);
             _levelManager.WireAllyDeathTrackingForTest();
 
-            // Act -- kill ally #2 (the middle one).
             LogAssert.Expect(LogType.Log, "[CombatStats] Ally2 died!");
             ally2.GetComponent<CombatStats>().TakeDamage(9999);
 
-            // Simulate end-of-combat: clear targets and recalculate.
             _levelManager.ClearAllyTargetsForTest();
             _levelManager.RecalculateAllyFormationForTest();
 
             yield return null;
 
-            // Assert -- compute expected 2-unit formation.
             Vector2[] expected2Positions = FormationLayout.GetPositions(teamAnchorPos, 2, facingRight: true);
             Vector2 expectedOffset0 = expected2Positions[0] - teamAnchorPos;
             Vector2 expectedOffset1 = expected2Positions[1] - teamAnchorPos;
 
-            // Ally1 (alive) should have the first position of the 2-unit formation.
             Assert.AreEqual(expectedOffset0.x, mover1.HomeOffset.x, 0.001f,
                 "Ally1 HomeOffset.x should match 2-unit formation position 0.");
             Assert.AreEqual(expectedOffset0.y, mover1.HomeOffset.y, 0.001f,
                 "Ally1 HomeOffset.y should match 2-unit formation position 0.");
 
-            // Ally3 (alive) should have the second position of the 2-unit formation.
             Assert.AreEqual(expectedOffset1.x, mover3.HomeOffset.x, 0.001f,
                 "Ally3 HomeOffset.x should match 2-unit formation position 1.");
             Assert.AreEqual(expectedOffset1.y, mover3.HomeOffset.y, 0.001f,
                 "Ally3 HomeOffset.y should match 2-unit formation position 1.");
 
-            // Ally2 (dead) should still have its original offset (not recalculated).
             Assert.AreEqual(initialOffset2.x, mover2.HomeOffset.x, 0.001f,
                 "Dead Ally2 HomeOffset.x should be unchanged.");
             Assert.AreEqual(initialOffset2.y, mover2.HomeOffset.y, 0.001f,
                 "Dead Ally2 HomeOffset.y should be unchanged.");
         }
 
-        // ---------------------------------------------------------------
-        // Test 2: Enemies win, one enemy dead, formation recalculated
-        // ---------------------------------------------------------------
-
         [UnityTest]
         public IEnumerator EnemiesWin_OneEnemyDead_FormationRecalculated()
         {
-            // Arrange
             CreateLevelManagerSetup(
                 teamAnchorPos: Vector2.zero,
                 enemiesAnchorPos: new Vector2(5f, 0f));
@@ -148,10 +125,8 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             enemy2.transform.SetParent(_enemiesContainer.transform);
             enemy3.transform.SetParent(_enemiesContainer.transform);
 
-            // Wait a frame so Awake runs.
             yield return null;
 
-            // Set initial home offsets for a 3-unit enemy formation (facingRight: false).
             Vector2 enemyAnchorPos = (Vector2)_enemiesHomeAnchor.transform.position;
             Vector2[] initial3Positions = FormationLayout.GetPositions(enemyAnchorPos, 3, facingRight: false);
 
@@ -175,53 +150,41 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 _teamContainer.transform, _enemiesContainer.transform,
                 _teamHomeAnchor.transform, _enemiesHomeAnchor.transform);
 
-            // Act -- kill enemy #2 (the middle one).
             LogAssert.Expect(LogType.Log, "[CombatStats] Enemy2 died!");
             enemy2.GetComponent<CombatStats>().TakeDamage(9999);
 
-            // Simulate end-of-combat: clear targets and recalculate.
             _levelManager.ClearEnemyTargetsForTest();
             _levelManager.RecalculateEnemyFormationForTest();
 
             yield return null;
 
-            // Assert -- compute expected 2-unit formation (facingRight: false).
             Vector2[] expected2Positions = FormationLayout.GetPositions(enemyAnchorPos, 2, facingRight: false);
             Vector2 expectedOffset0 = expected2Positions[0] - enemyAnchorPos;
             Vector2 expectedOffset1 = expected2Positions[1] - enemyAnchorPos;
 
-            // Enemy1 (alive) should have the first position of the 2-unit formation.
             Assert.AreEqual(expectedOffset0.x, mover1.HomeOffset.x, 0.001f,
                 "Enemy1 HomeOffset.x should match 2-unit formation position 0.");
             Assert.AreEqual(expectedOffset0.y, mover1.HomeOffset.y, 0.001f,
                 "Enemy1 HomeOffset.y should match 2-unit formation position 0.");
 
-            // Enemy3 (alive) should have the second position of the 2-unit formation.
             Assert.AreEqual(expectedOffset1.x, mover3.HomeOffset.x, 0.001f,
                 "Enemy3 HomeOffset.x should match 2-unit formation position 1.");
             Assert.AreEqual(expectedOffset1.y, mover3.HomeOffset.y, 0.001f,
                 "Enemy3 HomeOffset.y should match 2-unit formation position 1.");
 
-            // Enemy2 (dead) should still have its original offset.
             Assert.AreEqual(initialOffset2.x, mover2.HomeOffset.x, 0.001f,
                 "Dead Enemy2 HomeOffset.x should be unchanged.");
             Assert.AreEqual(initialOffset2.y, mover2.HomeOffset.y, 0.001f,
                 "Dead Enemy2 HomeOffset.y should be unchanged.");
         }
 
-        // ---------------------------------------------------------------
-        // Test 3: Survivors walk toward new home positions after recalc
-        // ---------------------------------------------------------------
-
         [UnityTest]
         public IEnumerator RecalculateFormation_SurvivorsWalkToNewPositions()
         {
-            // Arrange -- 3 allies with CharacterMover, no target (homing mode).
             CreateLevelManagerSetup(
                 teamAnchorPos: Vector2.zero,
                 enemiesAnchorPos: new Vector2(5f, 0f));
 
-            // Place allies at their initial 3-unit formation positions so they start "at home".
             Vector2 teamAnchorPos = (Vector2)_teamHomeAnchor.transform.position;
             Vector2[] initial3Positions = FormationLayout.GetPositions(teamAnchorPos, 3, facingRight: true);
 
@@ -236,7 +199,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             ally2.transform.SetParent(_teamContainer.transform);
             ally3.transform.SetParent(_teamContainer.transform);
 
-            // Wait a frame so Awake runs.
             yield return null;
 
             var mover1 = ally1.GetComponent<CharacterMover>();
@@ -259,21 +221,16 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 _teamHomeAnchor.transform, _enemiesHomeAnchor.transform);
             _levelManager.WireAllyDeathTrackingForTest();
 
-            // Kill ally #2.
             LogAssert.Expect(LogType.Log, "[CombatStats] Ally2 died!");
             ally2.GetComponent<CombatStats>().TakeDamage(9999);
 
-            // Simulate disengage so CombatController re-enables CharacterMover.
             _levelManager.ClearAllyTargetsForTest();
 
-            // Record positions BEFORE recalculation.
             Vector2 ally1PosBefore = (Vector2)ally1.transform.position;
             Vector2 ally3PosBefore = (Vector2)ally3.transform.position;
 
-            // Act -- recalculate formation (this updates HomeOffset, homing logic moves them).
             _levelManager.RecalculateAllyFormationForTest();
 
-            // Compute the new home positions that survivors should walk toward.
             Vector2[] expected2Positions = FormationLayout.GetPositions(teamAnchorPos, 2, facingRight: true);
             Vector2 newHome1 = expected2Positions[0];
             Vector2 newHome3 = expected2Positions[1];
@@ -281,11 +238,9 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             float ally1DistBefore = Vector2.Distance(ally1PosBefore, newHome1);
             float ally3DistBefore = Vector2.Distance(ally3PosBefore, newHome3);
 
-            // Wait for physics to move characters toward their new home positions.
             for (int i = 0; i < 30; i++)
                 yield return new WaitForFixedUpdate();
 
-            // Assert -- survivors have moved closer to their new home positions.
             Vector2 ally1PosAfter = (Vector2)ally1.transform.position;
             Vector2 ally3PosAfter = (Vector2)ally3.transform.position;
 

--- a/Assets/Tests/PlayMode/LevelManagerDefeatTests.cs
+++ b/Assets/Tests/PlayMode/LevelManagerDefeatTests.cs
@@ -14,40 +14,21 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         private GameObject _teamContainer;
         private GameObject _enemiesContainer;
 
-        /// <summary>
-        /// Creates a LevelManager on a fresh GameObject with WorldConveyor (which auto-adds Rigidbody2D).
-        /// Also creates Team and Enemies container GameObjects.
-        /// Must yield a frame after calling this so Awake runs on all components.
-        /// </summary>
         private void CreateLevelManagerSetup()
         {
             _levelManagerGo = new GameObject("TestLevelManager");
-
-            // WorldConveyor has [RequireComponent(typeof(Rigidbody2D))], auto-adds it.
             _levelManagerGo.AddComponent<WorldConveyor>();
-
-            // LevelManager has [RequireComponent(typeof(WorldConveyor))], already satisfied.
             _levelManager = _levelManagerGo.AddComponent<LevelManager>();
-
-            // Disable LevelManager immediately so its Start() coroutine does not run.
-            // Start() tries to find containers by child name and reads a LevelDatabase,
-            // which are not set up in tests. We use InitializeForTest() instead.
             _levelManager.enabled = false;
-
             Track(_levelManagerGo);
 
             _teamContainer = Track(new GameObject("Team"));
             _enemiesContainer = Track(new GameObject("Enemies"));
         }
 
-        // ---------------------------------------------------------------
-        // Test 1: WireAllyDeathTracking correctly counts alive allies
-        // ---------------------------------------------------------------
-
         [UnityTest]
         public IEnumerator WireAllyDeathTracking_CountsAliveAllies()
         {
-            // Arrange
             CreateLevelManagerSetup();
 
             var ally1 = Track(TestCharacterFactory.CreateCombatCharacter("Ally1", maxHp: 100));
@@ -57,25 +38,18 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             ally2.transform.SetParent(_teamContainer.transform);
             ally3.transform.SetParent(_teamContainer.transform);
 
-            // Wait a frame so Awake runs on all components.
             yield return null;
 
             _levelManager.InitializeForTest(_teamContainer.transform, _enemiesContainer.transform);
             _levelManager.WireAllyDeathTrackingForTest();
 
-            // Assert
             Assert.AreEqual(3, _levelManager.AliveAllyCount,
                 "AliveAllyCount should be 3 after wiring 3 alive allies.");
         }
 
-        // ---------------------------------------------------------------
-        // Test 2: All allies dying sets LevelInProgress to false
-        // ---------------------------------------------------------------
-
         [UnityTest]
         public IEnumerator AllAlliesDie_LevelInProgressBecomesFalse()
         {
-            // Arrange
             CreateLevelManagerSetup();
 
             var ally1 = Track(TestCharacterFactory.CreateCombatCharacter("Ally1", maxHp: 50));
@@ -90,7 +64,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             Assert.IsTrue(_levelManager.LevelInProgress, "Sanity: LevelInProgress should be true initially.");
 
-            // Act -- kill both allies.
             LogAssert.Expect(LogType.Log, "[CombatStats] Ally1 died!");
             ally1.GetComponent<CombatStats>().TakeDamage(9999);
 
@@ -100,19 +73,13 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             yield return null;
 
-            // Assert
             Assert.IsFalse(_levelManager.LevelInProgress,
                 "LevelInProgress should be false after all allies die.");
         }
 
-        // ---------------------------------------------------------------
-        // Test 3: All allies dying clears enemy targets
-        // ---------------------------------------------------------------
-
         [UnityTest]
         public IEnumerator AllAlliesDie_ClearsEnemyTargets()
         {
-            // Arrange -- 2 allies and 2 enemies with targets pointing at allies.
             CreateLevelManagerSetup();
 
             var ally1 = Track(TestCharacterFactory.CreateFullCombatCharacter(
@@ -129,10 +96,8 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             enemy1.transform.SetParent(_enemiesContainer.transform);
             enemy2.transform.SetParent(_enemiesContainer.transform);
 
-            // Wait a frame so Awake runs (CombatController caches CharacterMover etc.).
             yield return null;
 
-            // Give enemies targets pointing at allies.
             var enemyCtrl1 = enemy1.GetComponent<CombatController>();
             var enemyCtrl2 = enemy2.GetComponent<CombatController>();
             enemyCtrl1.Target = ally1.transform;
@@ -141,7 +106,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             _levelManager.InitializeForTest(_teamContainer.transform, _enemiesContainer.transform);
             _levelManager.WireAllyDeathTrackingForTest();
 
-            // Act -- kill all allies.
             LogAssert.Expect(LogType.Log, "[CombatStats] Ally1 died!");
             ally1.GetComponent<CombatStats>().TakeDamage(9999);
 
@@ -151,21 +115,15 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             yield return null;
 
-            // Assert -- enemies should have had their targets cleared.
             Assert.IsNull(enemyCtrl1.Target,
                 "Enemy1 target should be null after all allies died.");
             Assert.IsNull(enemyCtrl2.Target,
                 "Enemy2 target should be null after all allies died.");
         }
 
-        // ---------------------------------------------------------------
-        // Test 4: Partial ally death keeps LevelInProgress true
-        // ---------------------------------------------------------------
-
         [UnityTest]
         public IEnumerator PartialAllyDeath_LevelStillInProgress()
         {
-            // Arrange
             CreateLevelManagerSetup();
 
             var ally1 = Track(TestCharacterFactory.CreateCombatCharacter("Ally1", maxHp: 50));
@@ -183,7 +141,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             _levelManager.InitializeForTest(_teamContainer.transform, _enemiesContainer.transform);
             _levelManager.WireAllyDeathTrackingForTest();
 
-            // Act -- kill 2 out of 3 allies.
             LogAssert.Expect(LogType.Log, "[CombatStats] Ally1 died!");
             ally1.GetComponent<CombatStats>().TakeDamage(9999);
 
@@ -192,28 +149,21 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             yield return null;
 
-            // Assert -- level still in progress, 1 ally alive.
             Assert.IsTrue(_levelManager.LevelInProgress,
                 "LevelInProgress should remain true when 1 ally is still alive.");
             Assert.AreEqual(1, _levelManager.AliveAllyCount,
                 "AliveAllyCount should be 1 after 2 of 3 allies die.");
         }
 
-        // ---------------------------------------------------------------
-        // Test 5: After all allies die, enemies return toward home anchor
-        // ---------------------------------------------------------------
-
         [UnityTest]
         public IEnumerator AllAlliesDie_EnemiesReturnTowardAnchor()
         {
-            // Arrange -- 1 ally and 2 enemies positioned away from their home anchor.
             CreateLevelManagerSetup();
 
             var ally1 = Track(TestCharacterFactory.CreateFullCombatCharacter(
                 "Ally1", maxHp: 50, position: new Vector2(-3f, 0f)));
             ally1.transform.SetParent(_teamContainer.transform);
 
-            // Home anchor at X=5. Enemies start at X=0 (far from home).
             var homeAnchor = Track(TestCharacterFactory.CreateAnchor("EnemyHome", new Vector2(5f, 0f)));
 
             var enemy1 = Track(TestCharacterFactory.CreateFullCombatCharacter(
@@ -223,14 +173,11 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             enemy1.transform.SetParent(_enemiesContainer.transform);
             enemy2.transform.SetParent(_enemiesContainer.transform);
 
-            // Wait a frame so Awake runs on all components.
             yield return null;
 
-            // Set home anchor on enemies' CharacterMover so they know where to return.
             enemy1.GetComponent<CharacterMover>().HomeAnchor = homeAnchor.transform;
             enemy2.GetComponent<CharacterMover>().HomeAnchor = homeAnchor.transform;
 
-            // Give enemies a target so they are in combat.
             var enemyCtrl1 = enemy1.GetComponent<CombatController>();
             var enemyCtrl2 = enemy2.GetComponent<CombatController>();
             enemyCtrl1.Target = ally1.transform;
@@ -239,20 +186,16 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             _levelManager.InitializeForTest(_teamContainer.transform, _enemiesContainer.transform);
             _levelManager.WireAllyDeathTrackingForTest();
 
-            // Record initial positions before the ally dies.
             float enemy1StartX = enemy1.transform.position.x;
             float enemy2StartX = enemy2.transform.position.x;
 
-            // Act -- kill the ally. This triggers ClearEnemyTargets -> Disengage -> walk to home.
             LogAssert.Expect(LogType.Log, "[CombatStats] Ally1 died!");
             LogAssert.Expect(LogType.Log, "[LevelManager] Level lost! All allies defeated.");
             ally1.GetComponent<CombatStats>().TakeDamage(9999);
 
-            // Wait several FixedUpdate frames for physics-based movement toward home anchor.
             for (int i = 0; i < 20; i++)
                 yield return new WaitForFixedUpdate();
 
-            // Assert -- enemies should have moved closer to home anchor (X=5) from X=0.
             float enemy1EndX = enemy1.transform.position.x;
             float enemy2EndX = enemy2.transform.position.x;
             float homeX = homeAnchor.transform.position.x;
@@ -268,14 +211,9 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 $"Enemy2 should be closer to home anchor. Start dist={enemy2StartDist:F2}, End dist={enemy2EndDist:F2}");
         }
 
-        // ---------------------------------------------------------------
-        // Test 6: ClearEnemyTargets disengages all enemies
-        // ---------------------------------------------------------------
-
         [UnityTest]
         public IEnumerator ClearEnemyTargets_DisengagesAllEnemies()
         {
-            // Arrange -- 2 enemies with targets set.
             CreateLevelManagerSetup();
 
             var dummyTarget = Track(TestCharacterFactory.CreateCombatCharacter(
@@ -288,7 +226,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             enemy1.transform.SetParent(_enemiesContainer.transform);
             enemy2.transform.SetParent(_enemiesContainer.transform);
 
-            // Wait a frame so Awake runs.
             yield return null;
 
             var enemyCtrl1 = enemy1.GetComponent<CombatController>();
@@ -298,16 +235,13 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             _levelManager.InitializeForTest(_teamContainer.transform, _enemiesContainer.transform);
 
-            // Sanity -- targets are set.
             Assert.IsNotNull(enemyCtrl1.Target, "Sanity: Enemy1 should have a target before clear.");
             Assert.IsNotNull(enemyCtrl2.Target, "Sanity: Enemy2 should have a target before clear.");
 
-            // Act
             _levelManager.ClearEnemyTargetsForTest();
 
             yield return null;
 
-            // Assert -- both enemies should have null target and Moving state.
             Assert.IsNull(enemyCtrl1.Target,
                 "Enemy1 target should be null after ClearEnemyTargets.");
             Assert.IsNull(enemyCtrl2.Target,

--- a/Assets/Tests/PlayMode/TestUtils/PlayModeTestBase.cs
+++ b/Assets/Tests/PlayMode/TestUtils/PlayModeTestBase.cs
@@ -4,18 +4,10 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Tests.PlayMode
 {
-    /// <summary>
-    /// Base class for Play Mode tests that create GameObjects.
-    /// Tracks all created objects and destroys them in TearDown.
-    /// </summary>
     public abstract class PlayModeTestBase
     {
         private readonly List<GameObject> _created = new List<GameObject>();
 
-        /// <summary>
-        /// Registers a GameObject for automatic cleanup in TearDown.
-        /// Returns the same object for inline use.
-        /// </summary>
         protected GameObject Track(GameObject go)
         {
             _created.Add(go);

--- a/Assets/Tests/PlayMode/TestUtils/TestCharacterFactory.cs
+++ b/Assets/Tests/PlayMode/TestUtils/TestCharacterFactory.cs
@@ -3,16 +3,8 @@ using UnityEngine;
 
 namespace RogueliteAutoBattler.Tests
 {
-    /// <summary>
-    /// Factory methods for creating lightweight combat GameObjects in tests.
-    /// No real sprites or animators — just the minimum components needed for logic tests.
-    /// </summary>
     public static class TestCharacterFactory
     {
-        /// <summary>
-        /// Creates a bare-bones combat character with Rigidbody2D + CombatStats initialized.
-        /// Adds a child "Visual" with SpriteRenderer for CharacterMover compatibility.
-        /// </summary>
         public static GameObject CreateCombatCharacter(
             string name = "TestChar",
             int maxHp = 100,
@@ -38,26 +30,13 @@ namespace RogueliteAutoBattler.Tests
             return go;
         }
 
-        /// <summary>
-        /// Creates a WorldConveyor host (Rigidbody2D Kinematic + WorldConveyor component).
-        /// WorldConveyor.Awake() sets bodyType to Kinematic automatically.
-        /// </summary>
         public static GameObject CreateConveyor(string name = "TestConveyor")
         {
             var go = new GameObject(name);
-
-            // WorldConveyor has [RequireComponent(typeof(Rigidbody2D))],
-            // so AddComponent<WorldConveyor> auto-adds Rigidbody2D.
-            // Awake() will set bodyType = Kinematic.
             go.AddComponent<WorldConveyor>();
-
             return go;
         }
 
-        /// <summary>
-        /// Creates a character with CharacterMover, optionally parented under a conveyor.
-        /// CharacterMover has [RequireComponent] for Rigidbody2D and CircleCollider2D.
-        /// </summary>
         public static GameObject CreateMoverCharacter(
             string name = "TestMover",
             float moveSpeed = 2f,
@@ -74,22 +53,15 @@ namespace RogueliteAutoBattler.Tests
 
             AddVisualChild(go);
 
-            // CharacterMover auto-adds Rigidbody2D and CircleCollider2D via RequireComponent.
             var mover = go.AddComponent<CharacterMover>();
             mover.SetMoveSpeed(moveSpeed);
 
-            // Configure Rigidbody2D for test use.
             var rb = go.GetComponent<Rigidbody2D>();
             rb.gravityScale = 0f;
 
             return go;
         }
 
-        /// <summary>
-        /// Creates a character with CharacterMover + CombatController + CombatStats,
-        /// suitable for testing combat state machine behavior (retarget, state transitions).
-        /// CombatController auto-adds CharacterMover and CombatStats via RequireComponent.
-        /// </summary>
         public static GameObject CreateFullCombatCharacter(
             string name = "TestFighter",
             int maxHp = 100,
@@ -105,15 +77,12 @@ namespace RogueliteAutoBattler.Tests
 
             AddVisualChild(go);
 
-            // Rigidbody2D first (required by CharacterMover).
             var rb = go.AddComponent<Rigidbody2D>();
             rb.gravityScale = 0f;
             rb.freezeRotation = true;
 
-            // CombatController auto-adds CharacterMover + CombatStats via RequireComponent.
             go.AddComponent<CombatController>();
 
-            // Initialize components after they exist.
             var stats = go.GetComponent<CombatStats>();
             stats.InitializeDirect(maxHp, atk, attackSpeed);
 
@@ -123,9 +92,6 @@ namespace RogueliteAutoBattler.Tests
             return go;
         }
 
-        /// <summary>
-        /// Adds a child "Visual" with SpriteRenderer (required by CharacterMover / CombatStats tests).
-        /// </summary>
         private static void AddVisualChild(GameObject parent)
         {
             var visual = new GameObject("Visual");
@@ -133,11 +99,6 @@ namespace RogueliteAutoBattler.Tests
             visual.AddComponent<SpriteRenderer>();
         }
 
-        /// <summary>
-        /// Creates a character with CombatStats + CharacterMover (no CombatController).
-        /// Suitable for testing formation recalculation and other logic that needs
-        /// both stats (alive/dead check) and mover (home offset).
-        /// </summary>
         public static GameObject CreateFormationCharacter(
             string name = "TestFormationChar",
             int maxHp = 100,
@@ -151,27 +112,21 @@ namespace RogueliteAutoBattler.Tests
             if (position.HasValue)
                 go.transform.position = position.Value;
 
-            // Rigidbody2D first (required by CharacterMover).
             var rb = go.AddComponent<Rigidbody2D>();
             rb.gravityScale = 0f;
             rb.freezeRotation = true;
 
             AddVisualChild(go);
 
-            // CombatStats for alive/dead checks.
             var stats = go.AddComponent<CombatStats>();
             stats.InitializeDirect(maxHp, atk, attackSpeed);
 
-            // CharacterMover for home offset management (auto-adds CircleCollider2D).
             var mover = go.AddComponent<CharacterMover>();
             mover.SetMoveSpeed(moveSpeed);
 
             return go;
         }
 
-        /// <summary>
-        /// Creates a simple anchor Transform at the given position.
-        /// </summary>
         public static GameObject CreateAnchor(string name = "Anchor", Vector2? position = null)
         {
             var go = new GameObject(name);

--- a/Assets/Tests/PlayMode/VisualEquipmentTestLoopTests.cs
+++ b/Assets/Tests/PlayMode/VisualEquipmentTestLoopTests.cs
@@ -21,10 +21,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.IsNotNull(prefab, $"Prefab not found at {PrefabPath}");
             var instance = Object.Instantiate(prefab);
 
-            // Disable the Animator so it does not override equipment sprites
-            // via PPtrCurves on subsequent frames. CharacterAppearance.Awake()
-            // only needs the Animator Transform to resolve slot paths; after
-            // that it can be safely disabled.
             var animator = instance.GetComponentInChildren<Animator>();
             if (animator != null)
                 animator.enabled = false;
@@ -41,11 +37,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             return sprite;
         }
 
-        /// <summary>
-        /// Creates a VisualEquipmentTestLoop with a very short cycle interval
-        /// and the given sprite arrays assigned. The component is disabled so that
-        /// Start does not run until the test explicitly enables it.
-        /// </summary>
         private VisualEquipmentTestLoop CreateLoop(
             float interval,
             Sprite[] weapons,
@@ -56,8 +47,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             var go = new GameObject("VisualEquipmentTestLoop");
             Track(go);
 
-            // Add component on active object (Awake runs immediately) but disable it
-            // so Start does not run until we enable it.
             var loop = go.AddComponent<VisualEquipmentTestLoop>();
             loop.enabled = false;
 
@@ -83,28 +72,22 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             base.TearDown();
         }
 
-        // ----------------------------------------------------------------
-        // Test 1: After one cycle interval the loop applies random sprites
-        // ----------------------------------------------------------------
         [UnityTest]
         public IEnumerator VisualEquipmentTestLoop_CyclesSpritesAfterInterval()
         {
-            // Arrange -- instantiate character, let Awake resolve slots
             var character = InstantiatePrefab();
             character.AddComponent<CharacterAppearance>();
-            yield return null; // Awake runs
+            yield return null;
 
             var appearance = character.GetComponent<CharacterAppearance>();
             Assert.IsNotNull(appearance.WeaponRenderer, "WeaponRenderer must be resolved.");
             Assert.IsNotNull(appearance.HatRenderer, "HatRenderer must be resolved.");
             Assert.IsNotNull(appearance.ShieldRenderer, "ShieldRenderer must be resolved.");
 
-            // Record original sprites
             var origWeapon = appearance.WeaponRenderer.sprite;
             var origHat = appearance.HatRenderer.sprite;
             var origShield = appearance.ShieldRenderer.sprite;
 
-            // Create test sprite arrays (single sprite each -- deterministic)
             var testWeapon = CreateTestSprite();
             var testHat = CreateTestSprite();
             var testShield = CreateTestSprite();
@@ -115,14 +98,11 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 hats: new[] { testHat },
                 shields: new[] { testShield });
 
-            // Enable component so Start runs, then yield a frame to ensure the coroutine is registered
             loop.enabled = true;
             yield return null;
 
-            // Act -- wait long enough for at least one cycle (interval = 0.1s)
             yield return new WaitForSeconds(0.2f);
 
-            // Assert -- sprites should now be the test sprites
             Assert.AreEqual(testWeapon, appearance.WeaponRenderer.sprite,
                 "Weapon sprite should have been changed by the loop.");
             Assert.AreEqual(testHat, appearance.HatRenderer.sprite,
@@ -130,7 +110,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.AreEqual(testShield, appearance.ShieldRenderer.sprite,
                 "Shield sprite should have been changed by the loop.");
 
-            // They should differ from the originals
             Assert.AreNotEqual(origWeapon, appearance.WeaponRenderer.sprite,
                 "Weapon sprite should differ from the original prefab sprite.");
             Assert.AreNotEqual(origHat, appearance.HatRenderer.sprite,
@@ -139,13 +118,9 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 "Shield sprite should differ from the original prefab sprite.");
         }
 
-        // ----------------------------------------------------------------
-        // Test 2: Empty arrays -- sprites stay at their defaults
-        // ----------------------------------------------------------------
         [UnityTest]
         public IEnumerator VisualEquipmentTestLoop_EmptyArrays_KeepsDefaults()
         {
-            // Arrange
             var character = InstantiatePrefab();
             character.AddComponent<CharacterAppearance>();
             yield return null;
@@ -163,13 +138,10 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 shields: new Sprite[0]);
 
             loop.enabled = true;
-            yield return null; // Ensure Start() runs and coroutine is registered
+            yield return null;
 
-            // Act -- wait for at least one cycle (interval = 0.1s)
             yield return new WaitForSeconds(0.2f);
 
-            // Assert -- sprites unchanged because PickRandom returns null for empty arrays,
-            // and ApplyAppearance skips null sprites
             Assert.AreEqual(origWeapon, appearance.WeaponRenderer.sprite,
                 "Weapon sprite should remain the default when weapon array is empty.");
             Assert.AreEqual(origHat, appearance.HatRenderer.sprite,
@@ -178,13 +150,9 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 "Shield sprite should remain the default when shield array is empty.");
         }
 
-        // ----------------------------------------------------------------
-        // Test 3: Multiple characters all get their sprites changed
-        // ----------------------------------------------------------------
         [UnityTest]
         public IEnumerator VisualEquipmentTestLoop_AffectsAllCharacters()
         {
-            // Arrange -- 3 characters
             var characters = new GameObject[3];
             var appearances = new CharacterAppearance[3];
 
@@ -196,7 +164,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 characters[i].AddComponent<CharacterAppearance>();
             }
 
-            yield return null; // Awake runs on all
+            yield return null;
 
             var origWeapons = new Sprite[3];
             var origHats = new Sprite[3];
@@ -213,7 +181,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 origShields[i] = appearances[i].ShieldRenderer.sprite;
             }
 
-            // Single test sprite per slot
             var testWeapon = CreateTestSprite();
             var testHat = CreateTestSprite();
             var testShield = CreateTestSprite();
@@ -225,12 +192,10 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 shields: new[] { testShield });
 
             loop.enabled = true;
-            yield return null; // Ensure Start() runs and coroutine is registered
+            yield return null;
 
-            // Act -- wait for at least one cycle (interval = 0.1s)
             yield return new WaitForSeconds(0.2f);
 
-            // Assert -- all 3 characters should have the test sprites
             for (int i = 0; i < 3; i++)
             {
                 Assert.AreEqual(testWeapon, appearances[i].WeaponRenderer.sprite,
@@ -242,24 +207,18 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             }
         }
 
-        // ----------------------------------------------------------------
-        // Test 4: Head sprites are cycled
-        // ----------------------------------------------------------------
         [UnityTest]
         public IEnumerator VisualEquipmentTestLoop_CyclesHeadSprites()
         {
-            // Arrange -- instantiate character, let Awake resolve slots
             var character = InstantiatePrefab();
             character.AddComponent<CharacterAppearance>();
-            yield return null; // Awake runs
+            yield return null;
 
             var appearance = character.GetComponent<CharacterAppearance>();
             Assert.IsNotNull(appearance.HeadRenderer, "HeadRenderer must be resolved.");
 
-            // Record original head sprite
             var origHead = appearance.HeadRenderer.sprite;
 
-            // Create test head sprite
             var testHead = CreateTestSprite();
 
             var loop = CreateLoop(
@@ -269,14 +228,11 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 shields: new Sprite[0],
                 heads: new[] { testHead });
 
-            // Enable component so Start runs
             loop.enabled = true;
             yield return null;
 
-            // Act -- wait for at least one cycle
             yield return new WaitForSeconds(0.2f);
 
-            // Assert -- head should have changed to the test sprite
             Assert.AreEqual(testHead, appearance.HeadRenderer.sprite,
                 "Head sprite should have been cycled by VisualEquipmentTestLoop.");
             Assert.AreNotEqual(origHead, appearance.HeadRenderer.sprite,

--- a/Assets/Tests/PlayMode/WorldConveyorTests.cs
+++ b/Assets/Tests/PlayMode/WorldConveyorTests.cs
@@ -21,7 +21,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             var conveyor = go.GetComponent<WorldConveyor>();
             float startX = go.transform.position.x;
 
-            // Wait one frame so Awake runs and Rigidbody2D is configured.
             yield return null;
 
             float distance = 5f;
@@ -30,7 +29,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             conveyor.ScrollBy(distance, maxSpeed, acceleration);
 
-            // Wait enough time for the scroll to complete.
             yield return new WaitForSeconds(ScrollTimeout);
 
             float endX = go.transform.position.x;
@@ -68,7 +66,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             conveyor.OnDecelerationStarted += () => fired = true;
 
-            // Use a longer distance with moderate acceleration to ensure deceleration phase occurs.
             conveyor.ScrollBy(5f, 4f, 2f);
 
             yield return new WaitForSeconds(LongScrollTimeout);
@@ -84,7 +81,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             yield return null;
 
-            // Use moderate values so the profile has clear acceleration and deceleration phases.
             conveyor.ScrollBy(8f, 4f, 2f);
 
             float peakSpeed = 0f;
@@ -92,7 +88,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             bool sawDeceleration = false;
             float previousSpeed = 0f;
 
-            // Sample speed over time.
             for (int i = 0; i < MaxSampleFrames; i++)
             {
                 yield return new WaitForFixedUpdate();
@@ -118,7 +113,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.IsTrue(sawDeceleration, "Speed should have decreased during deceleration phase.");
             Assert.That(peakSpeed, Is.GreaterThan(0.5f), "Peak speed should be meaningfully above zero.");
 
-            // After completion, speed should be zero.
             Assert.That(conveyor.CurrentSpeed, Is.EqualTo(0f).Within(0.01f),
                 "Speed should be zero after scroll completes.");
         }
@@ -133,7 +127,6 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             float startX = go.transform.position.x;
 
-            // ScrollBy with distance=0 logs a warning and does nothing.
             LogAssert.Expect(LogType.Warning, new Regex("distance must be > 0"));
 
             conveyor.ScrollBy(0f, 10f, 5f);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 Doc detaille : `Assets/doc/premier-jet-roguelite.html`
 
 # Project Structure
-Generated: 2026-03-27
+Generated: 2026-03-27 (updated)
 
 Assets/
 ├── Animations/  (23 files: .anim + .controller)


### PR DESCRIPTION
Closes #82

## Summary
- Removed all comments from 48 C# files (XML doc, inline comments, tooltips)
- Updated 6 agent prompts to enforce "no comments" rule
- Minor rename: DefaultSpriteMaterial → UnlitShaderName in HealthBar.cs

## Test Results
- 57/57 tests passing (22 EditMode + 35 PlayMode)

## Files Changed
- 48 C# files: comment removal
- 6 agent prompts: updated to enforce no-comment rule
- 1 config/setting file: minor refactor