### PR TITLE
chore(agents): add file placement rules to dev/leaddev agents

### DIFF
--- a/.claude/agents/dev-unity.md
+++ b/.claude/agents/dev-unity.md
@@ -122,6 +122,25 @@ private void SetMoving(bool isMoving)
 - Use `GetComponentInChildren<Animator>()` — the Animator is always on the Visual child
 - `transform.position` is acceptable only for non-animated objects (UI anchors, static environment pieces)
 
+## File Placement — Mandatory Before Creating Any File
+
+Before creating a new `.cs` file, you MUST:
+
+1. **Read CLAUDE.md's Project Structure** to see the current folder layout
+2. **Place the file in the correct sub-folder** based on its domain responsibility. Examples:
+   - Combat logic (controller, stats, targeting) → `Scripts/Combat/Core/`
+   - Level/wave orchestration → `Scripts/Combat/Levels/`
+   - Visual effects, health bars, appearances → `Scripts/Combat/Visuals/`
+   - World scrolling, ground, anchoring → `Scripts/Combat/Environment/`
+   - Gold, currency, economy → `Scripts/Economy/`
+   - Shared constants → `Scripts/Common/`
+   - Editor tools → `Scripts/Editor/`
+3. **Never place a file at the root of a folder that already has sub-folders** — find or create the right sub-folder
+4. **If no sub-folder fits** and the file represents a genuinely new domain concern, create a new sub-folder with a clear name
+5. **Namespace must match the folder path**: e.g., a file in `Scripts/Combat/Visuals/` uses namespace `RogueliteAutoBattler.Combat.Visuals`
+
+**Anti-pattern** (WRONG): dumping every new file into `Assets/Scripts/Combat/` regardless of domain.
+
 ## API Communication Patterns
 
 When implementing client-side code that talks to the server:

--- a/.claude/agents/dev-ux-unity.md
+++ b/.claude/agents/dev-ux-unity.md
@@ -141,6 +141,25 @@ SpriteRenderer:
 
 **Sorting layers on the Visual child**: all SpriteRenderers on the Visual child and its children must use `sortingLayerName = "Characters"`, same as before the split.
 
+## File Placement — Mandatory Before Creating Any File
+
+Before creating a new `.cs` file, you MUST:
+
+1. **Read CLAUDE.md's Project Structure** to see the current folder layout
+2. **Place the file in the correct sub-folder** based on its domain responsibility. Examples:
+   - Combat logic → `Scripts/Combat/Core/`
+   - Level/wave orchestration → `Scripts/Combat/Levels/`
+   - Visual effects, health bars, appearances → `Scripts/Combat/Visuals/`
+   - World scrolling, ground, anchoring → `Scripts/Combat/Environment/`
+   - Gold, currency, economy → `Scripts/Economy/`
+   - Shared constants → `Scripts/Common/`
+   - Editor tools → `Scripts/Editor/`
+3. **Never place a file at the root of a folder that already has sub-folders** — find or create the right sub-folder
+4. **If no sub-folder fits** and the file represents a genuinely new domain concern, create a new sub-folder with a clear name
+5. **Namespace must match the folder path**: e.g., `Scripts/Combat/Visuals/` uses namespace `RogueliteAutoBattler.Combat.Visuals`
+
+**Anti-pattern** (WRONG): dumping every new file into `Assets/Scripts/Combat/` regardless of domain.
+
 ## What You Build
 
 ### Pattern 1: MenuItem Setup Script (Reusable)

--- a/.claude/agents/leaddev-unity.md
+++ b/.claude/agents/leaddev-unity.md
@@ -100,7 +100,7 @@ Root (Rigidbody2D, CharacterMover, CombatController — NO Animator, NO SpriteRe
 ## Proposed Changes
 
 ### Client-Side (Unity)
-For each class: path, purpose, type (MonoBehaviour/SO/plain C#/interface), key members, dependencies
+For each class: full sub-folder path (e.g., `Scripts/Combat/Visuals/`), namespace, purpose, type (MonoBehaviour/SO/plain C#/interface), key members, dependencies
 
 ### Server-Side (API) — if applicable
 For each class: endpoint or service, purpose, what it validates/generates
@@ -111,6 +111,26 @@ Data structures exchanged between client and server
 ## Implementation Order
 [Numbered, dependency-respecting order — client and server can be parallelized]
 ```
+
+## File Placement — Specify in Every Plan
+
+For every new file in the plan, you MUST specify the **full sub-folder path** based on its domain responsibility. Never specify just a top-level folder like `Scripts/Combat/`.
+
+1. **Read CLAUDE.md's Project Structure** before planning to know existing sub-folders
+2. **Assign each file to a sub-folder** based on what it does:
+   - Combat logic (controller, stats, targeting) → `Scripts/Combat/Core/`
+   - Level/wave orchestration → `Scripts/Combat/Levels/`
+   - Visual effects, health bars, appearances → `Scripts/Combat/Visuals/`
+   - World scrolling, ground, anchoring → `Scripts/Combat/Environment/`
+   - Gold, currency, economy → `Scripts/Economy/`
+   - Shared constants → `Scripts/Common/`
+   - Editor tools → `Scripts/Editor/`
+3. **If a new sub-folder is needed**, explicitly say so: "Create `Scripts/Combat/AI/` for AI-related classes"
+4. **Specify the namespace** matching the folder path: e.g., `RogueliteAutoBattler.Combat.Visuals`
+5. **Never leave file location ambiguous** — the dev agent must not guess where to put files
+
+**Anti-pattern** (WRONG): "Create `DamageNumber.cs` in `Scripts/Combat/`" when sub-folders exist.
+**Correct**: "Create `DamageNumber.cs` in `Scripts/Combat/Visuals/` with namespace `RogueliteAutoBattler.Combat.Visuals`"
 
 ## Rules
 
@@ -154,6 +174,8 @@ These files CAN and SHOULD be edited programmatically when the plan requires cha
 For each step, include:
 ```
 Step N: [description]
+- File: [full path, e.g., Assets/Scripts/Combat/Visuals/DamageNumber.cs]
+- Namespace: [e.g., RogueliteAutoBattler.Combat.Visuals]
 - Type: [C# code / Unity asset YAML / Editor script / Scene setup]
 - Agent: [dev-unity / dev-ux-unity]
 - Automation: [how it will be done programmatically]


### PR DESCRIPTION
## Summary
- Add "File Placement" rules to `dev-unity`, `dev-ux-unity`, and `leaddev-unity` agent prompts
- Agents must now consult CLAUDE.md structure before creating files
- Never place files at root of folders with existing sub-folders
- leaddev-unity must specify full sub-folder paths and namespaces in plans
- Prevents flat-folder accumulation like the Combat/ issue (PR #115)

## Test plan
- [ ] Next feature Issue should place files in correct sub-folders automatically