### PR TITLE
feat(ui): sync StepProgressBar dot with scroll position (#121)

### DIFF
--- a/Assets/Data/LevelDatabase.asset
+++ b/Assets/Data/LevelDatabase.asset
@@ -123,9 +123,71 @@ MonoBehaviour:
               hatSprite: {fileID: 0}
               weaponSprite: {fileID: 0}
               shieldSprite: {fileID: 0}
+      - stepName: Step 4
+        waves:
+        - waveName: Wave 1
+          spawnDelay: 0
+          enemies:
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 10
+            atk: 2
+            attackSpeed: 1
+            moveSpeed: 1
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.05
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+      - stepName: Step 5
+        waves: []
     - levelName: Level 2
       steps:
       - stepName: Step 1
+        waves:
+        - waveName: Wave 1
+          spawnDelay: 0
+          enemies:
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 500
+            atk: 3
+            attackSpeed: 3
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.05
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+      - stepName: Step 2
+        waves:
+        - waveName: Wave 1
+          spawnDelay: 0
+          enemies:
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 500
+            atk: 3
+            attackSpeed: 3
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.05
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+      - stepName: Step 3
         waves:
         - waveName: Wave 1
           spawnDelay: 0

--- a/Assets/Scripts/Combat/Environment/WorldConveyor.cs
+++ b/Assets/Scripts/Combat/Environment/WorldConveyor.cs
@@ -16,6 +16,7 @@ namespace RogueliteAutoBattler.Combat.Environment
         private float _acceleration;
         private bool _isScrolling;
         private bool _decelerating;
+        private bool _hasScrolled;
         private Rigidbody2D _rb;
         private Vector2 _initialPosition;
 
@@ -37,7 +38,7 @@ namespace RogueliteAutoBattler.Combat.Environment
             get
             {
                 float totalDistance = Mathf.Abs(_targetX - _scrollStartX);
-                if (totalDistance < ArrivalThreshold) return _isScrolling ? 0f : 1f;
+                if (totalDistance < ArrivalThreshold) return _hasScrolled && !_isScrolling ? 1f : 0f;
                 float traveled = Mathf.Abs(_rb.position.x - _scrollStartX);
                 return Mathf.Clamp01(traveled / totalDistance);
             }
@@ -86,6 +87,7 @@ namespace RogueliteAutoBattler.Combat.Environment
             _currentSpeed = 0f;
             _isScrolling = true;
             _decelerating = false;
+            _hasScrolled = true;
             OnScrollStarted?.Invoke();
         }
 
@@ -143,6 +145,7 @@ namespace RogueliteAutoBattler.Combat.Environment
             _isScrolling = false;
             _decelerating = false;
             _currentSpeed = 0f;
+            _hasScrolled = false;
             _scrollStartX = _initialPosition.x;
             _rb.position = _initialPosition;
             transform.position = new Vector3(_initialPosition.x, _initialPosition.y, transform.position.z);

--- a/Assets/Scripts/Combat/Environment/WorldConveyor.cs
+++ b/Assets/Scripts/Combat/Environment/WorldConveyor.cs
@@ -10,6 +10,7 @@ namespace RogueliteAutoBattler.Combat.Environment
         private const float MinimumScrollSpeed = 0.1f;
 
         private float _targetX;
+        private float _scrollStartX;
         private float _currentSpeed;
         private float _maxSpeed;
         private float _acceleration;
@@ -31,6 +32,18 @@ namespace RogueliteAutoBattler.Combat.Environment
 
         public bool IsScrolling => _isScrolling;
 
+        public float ScrollProgress
+        {
+            get
+            {
+                float totalDistance = Mathf.Abs(_targetX - _scrollStartX);
+                if (totalDistance < ArrivalThreshold) return _isScrolling ? 0f : 1f;
+                float traveled = Mathf.Abs(_rb.position.x - _scrollStartX);
+                return Mathf.Clamp01(traveled / totalDistance);
+            }
+        }
+
+        public event System.Action OnScrollStarted;
         public event System.Action OnScrollComplete;
         public event System.Action OnDecelerationStarted;
 
@@ -66,12 +79,14 @@ namespace RogueliteAutoBattler.Combat.Environment
                 return;
             }
 
+            _scrollStartX = _rb.position.x;
             _targetX = _rb.position.x - distance;
             _maxSpeed = maxSpeed;
             _acceleration = acceleration;
             _currentSpeed = 0f;
             _isScrolling = true;
             _decelerating = false;
+            OnScrollStarted?.Invoke();
         }
 
         private void FixedUpdate()
@@ -128,6 +143,7 @@ namespace RogueliteAutoBattler.Combat.Environment
             _isScrolling = false;
             _decelerating = false;
             _currentSpeed = 0f;
+            _scrollStartX = _initialPosition.x;
             _rb.position = _initialPosition;
             transform.position = new Vector3(_initialPosition.x, _initialPosition.y, transform.position.z);
         }

--- a/Assets/Scripts/UI/Widgets/StepProgressBar.cs
+++ b/Assets/Scripts/UI/Widgets/StepProgressBar.cs
@@ -267,7 +267,7 @@ namespace RogueliteAutoBattler.UI.Widgets
             Rebuild(_levelManager.TotalStepsInCurrentLevel, _levelManager.CurrentStepIndex);
         }
 
-        internal void SimulateStepChange(int stepIndex) => UpdateVisuals(stepIndex);
+        internal void SimulateStepChange(int stepIndex) => OnStepChanged(stepIndex);
 
         internal int SphereCount => _spheres.Count;
         internal int LineCount => _lines.Count;

--- a/Assets/Scripts/UI/Widgets/StepProgressBar.cs
+++ b/Assets/Scripts/UI/Widgets/StepProgressBar.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using RogueliteAutoBattler.Combat.Environment;
 using RogueliteAutoBattler.Combat.Levels;
 using UnityEngine;
 using UnityEngine.UI;
@@ -20,10 +21,18 @@ namespace RogueliteAutoBattler.UI.Widgets
         [SerializeField] private float _lineMinWidth = 4f;
 
         private LevelManager _levelManager;
+        private WorldConveyor _conveyor;
         private HorizontalLayoutGroup _layoutGroup;
         private readonly List<Image> _spheres = new List<Image>();
         private readonly List<Image> _lines = new List<Image>();
         private bool _initializedForTest;
+
+        private int _currentStep;
+        private Image _scrollDot;
+        private RectTransform _scrollDotRect;
+        private int _dotFromIndex;
+        private int _dotToIndex;
+        private bool _dotActive;
 
         private void Awake()
         {
@@ -40,6 +49,7 @@ namespace RogueliteAutoBattler.UI.Widgets
                 _levelManager = managers[0];
                 _levelManager.OnLevelStarted += OnLevelChanged;
                 _levelManager.OnStepStarted += OnStepChanged;
+                WireConveyor();
                 Rebuild(_levelManager.TotalStepsInCurrentLevel, _levelManager.CurrentStepIndex);
             }
         }
@@ -51,6 +61,8 @@ namespace RogueliteAutoBattler.UI.Widgets
                 _levelManager.OnLevelStarted -= OnLevelChanged;
                 _levelManager.OnStepStarted -= OnStepChanged;
             }
+
+            UnwireConveyor();
         }
 
         private void Rebuild(int totalSteps, int currentStep)
@@ -119,10 +131,32 @@ namespace RogueliteAutoBattler.UI.Widgets
             }
 
             UpdateVisuals(currentStep);
+            CreateScrollDot();
+        }
+
+        private void CreateScrollDot()
+        {
+            var dotGo = new GameObject("ScrollDot");
+            dotGo.transform.SetParent(transform, false);
+
+            _scrollDot = dotGo.AddComponent<Image>();
+            _scrollDot.sprite = _sphereSprite;
+            _scrollDot.color = _currentColor;
+            _scrollDot.raycastTarget = false;
+
+            _scrollDotRect = dotGo.GetComponent<RectTransform>();
+            _scrollDotRect.sizeDelta = new Vector2(_sphereSize, _sphereSize);
+
+            var layout = dotGo.AddComponent<LayoutElement>();
+            layout.ignoreLayout = true;
+
+            dotGo.SetActive(false);
         }
 
         private void UpdateVisuals(int currentStep)
         {
+            _currentStep = currentStep;
+
             for (int i = 0; i < _spheres.Count; i++)
             {
                 if (i < currentStep)
@@ -146,7 +180,80 @@ namespace RogueliteAutoBattler.UI.Widgets
 
         private void OnStepChanged(int stepIndex)
         {
+            StopDotScroll();
             UpdateVisuals(stepIndex);
+        }
+
+        private void WireConveyor()
+        {
+            _conveyor = _levelManager != null ? _levelManager.GetComponent<WorldConveyor>() : null;
+            if (_conveyor != null)
+            {
+                _conveyor.OnScrollStarted += OnConveyorScrollStarted;
+                _conveyor.OnScrollComplete += OnConveyorScrollComplete;
+            }
+        }
+
+        private void UnwireConveyor()
+        {
+            if (_conveyor != null)
+            {
+                _conveyor.OnScrollStarted -= OnConveyorScrollStarted;
+                _conveyor.OnScrollComplete -= OnConveyorScrollComplete;
+            }
+        }
+
+        private void OnConveyorScrollStarted()
+        {
+            int toIndex = _currentStep + 1;
+            if (toIndex <= _spheres.Count)
+                StartDotScroll(_currentStep, toIndex);
+        }
+
+        private void OnConveyorScrollComplete()
+        {
+            StopDotScroll();
+        }
+
+        private void StartDotScroll(int fromIndex, int toIndex)
+        {
+            if (_scrollDot == null) return;
+            _dotFromIndex = fromIndex;
+            _dotToIndex = toIndex;
+            _dotActive = true;
+            _scrollDot.gameObject.SetActive(true);
+        }
+
+        private void StopDotScroll()
+        {
+            if (!_dotActive) return;
+            _dotActive = false;
+            if (_scrollDot != null)
+                _scrollDot.gameObject.SetActive(false);
+        }
+
+        private void LateUpdate()
+        {
+            if (!_dotActive || _conveyor == null || _scrollDotRect == null) return;
+            if (_dotFromIndex < 0 || _dotFromIndex >= _spheres.Count) return;
+
+            Vector3 fromPos = _spheres[_dotFromIndex].transform.position;
+            Vector3 toPos;
+
+            if (_dotToIndex < _spheres.Count)
+            {
+                toPos = _spheres[_dotToIndex].transform.position;
+            }
+            else
+            {
+                var parentRect = (RectTransform)transform;
+                var corners = new Vector3[4];
+                parentRect.GetWorldCorners(corners);
+                toPos = new Vector3(corners[2].x, fromPos.y, fromPos.z);
+            }
+
+            float t = _conveyor.ScrollProgress;
+            _scrollDotRect.position = Vector3.Lerp(fromPos, toPos, t);
         }
 
         internal void InitializeForTest(LevelManager levelManager)
@@ -156,6 +263,7 @@ namespace RogueliteAutoBattler.UI.Widgets
 
             _levelManager.OnLevelStarted += OnLevelChanged;
             _levelManager.OnStepStarted += OnStepChanged;
+            WireConveyor();
             Rebuild(_levelManager.TotalStepsInCurrentLevel, _levelManager.CurrentStepIndex);
         }
 
@@ -168,5 +276,24 @@ namespace RogueliteAutoBattler.UI.Widgets
         internal Color CompletedColor => _completedColor;
         internal Color CurrentColor => _currentColor;
         internal Color UpcomingColor => _upcomingColor;
+        internal bool IsScrollDotActive => _scrollDot != null && _scrollDot.gameObject.activeSelf;
+
+        internal float ScrollDotNormalizedX
+        {
+            get
+            {
+                if (_scrollDotRect == null || _dotFromIndex < 0 || _dotFromIndex >= _spheres.Count)
+                    return 0f;
+
+                Vector3 fromPos = _spheres[_dotFromIndex].transform.position;
+                Vector3 toPos = _dotToIndex < _spheres.Count
+                    ? _spheres[_dotToIndex].transform.position
+                    : fromPos + Vector3.right;
+
+                float total = toPos.x - fromPos.x;
+                if (Mathf.Abs(total) < 0.001f) return 0f;
+                return Mathf.Clamp01((_scrollDotRect.position.x - fromPos.x) / total);
+            }
+        }
     }
 }

--- a/Assets/Scripts/UI/Widgets/StepProgressBar.cs
+++ b/Assets/Scripts/UI/Widgets/StepProgressBar.cs
@@ -33,6 +33,7 @@ namespace RogueliteAutoBattler.UI.Widgets
         private int _dotFromIndex;
         private int _dotToIndex;
         private bool _dotActive;
+        private readonly Vector3[] _worldCorners = new Vector3[4];
 
         private void Awake()
         {
@@ -247,9 +248,8 @@ namespace RogueliteAutoBattler.UI.Widgets
             else
             {
                 var parentRect = (RectTransform)transform;
-                var corners = new Vector3[4];
-                parentRect.GetWorldCorners(corners);
-                toPos = new Vector3(corners[2].x, fromPos.y, fromPos.z);
+                parentRect.GetWorldCorners(_worldCorners);
+                toPos = new Vector3(_worldCorners[2].x, fromPos.y, fromPos.z);
             }
 
             float t = _conveyor.ScrollProgress;
@@ -277,23 +277,5 @@ namespace RogueliteAutoBattler.UI.Widgets
         internal Color CurrentColor => _currentColor;
         internal Color UpcomingColor => _upcomingColor;
         internal bool IsScrollDotActive => _scrollDot != null && _scrollDot.gameObject.activeSelf;
-
-        internal float ScrollDotNormalizedX
-        {
-            get
-            {
-                if (_scrollDotRect == null || _dotFromIndex < 0 || _dotFromIndex >= _spheres.Count)
-                    return 0f;
-
-                Vector3 fromPos = _spheres[_dotFromIndex].transform.position;
-                Vector3 toPos = _dotToIndex < _spheres.Count
-                    ? _spheres[_dotToIndex].transform.position
-                    : fromPos + Vector3.right;
-
-                float total = toPos.x - fromPos.x;
-                if (Mathf.Abs(total) < 0.001f) return 0f;
-                return Mathf.Clamp01((_scrollDotRect.position.x - fromPos.x) / total);
-            }
-        }
     }
 }

--- a/Assets/Tests/PlayMode/StepProgressBarTests.cs
+++ b/Assets/Tests/PlayMode/StepProgressBarTests.cs
@@ -111,6 +111,66 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator Rebuild_CreatesScrollDot_Inactive()
+        {
+            yield return null;
+
+            Assert.IsFalse(_progressBar.IsScrollDotActive,
+                "ScrollDot should be inactive after Rebuild.");
+
+            var dotTransform = _progressBar.transform.Find("ScrollDot");
+            Assert.IsNotNull(dotTransform, "A child named ScrollDot should exist.");
+        }
+
+        [UnityTest]
+        public IEnumerator ScrollDot_BecomesActive_WhenConveyorScrollStarts()
+        {
+            yield return null;
+
+            var conveyor = _levelManager.GetComponent<WorldConveyor>();
+            conveyor.ScrollBy(2f, 10f, 20f);
+
+            yield return null;
+
+            Assert.IsTrue(_progressBar.IsScrollDotActive,
+                "ScrollDot should be active when conveyor starts scrolling.");
+        }
+
+        [UnityTest]
+        public IEnumerator ScrollDot_BecomesInactive_WhenStepChanges()
+        {
+            yield return null;
+
+            var conveyor = _levelManager.GetComponent<WorldConveyor>();
+            conveyor.ScrollBy(2f, 10f, 20f);
+
+            yield return null;
+            Assert.IsTrue(_progressBar.IsScrollDotActive);
+
+            _progressBar.SimulateStepChange(1);
+
+            Assert.IsFalse(_progressBar.IsScrollDotActive,
+                "ScrollDot should be inactive after step change.");
+        }
+
+        [UnityTest]
+        public IEnumerator ScrollDot_BecomesInactive_WhenConveyorScrollCompletes()
+        {
+            yield return null;
+
+            var conveyor = _levelManager.GetComponent<WorldConveyor>();
+            conveyor.ScrollBy(2f, 10f, 20f);
+
+            yield return null;
+            Assert.IsTrue(_progressBar.IsScrollDotActive);
+
+            yield return new WaitForSeconds(2f);
+
+            Assert.IsFalse(_progressBar.IsScrollDotActive,
+                "ScrollDot should be inactive after scroll completes.");
+        }
+
+        [UnityTest]
         public IEnumerator SingleStepLevel_ShowsOneSphereNoLines()
         {
             var singleLevelDatabase = ScriptableObject.CreateInstance<LevelDatabase>();

--- a/Assets/Tests/PlayMode/WorldConveyorTests.cs
+++ b/Assets/Tests/PlayMode/WorldConveyorTests.cs
@@ -145,6 +145,97 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator ScrollProgress_IsZero_BeforeScroll()
+        {
+            var go = Track(TestCharacterFactory.CreateConveyor("TestConveyor"));
+            var conveyor = go.GetComponent<WorldConveyor>();
+
+            yield return null;
+
+            Assert.That(conveyor.ScrollProgress, Is.EqualTo(0f).Within(0.01f),
+                "ScrollProgress should be 0 before any scroll.");
+        }
+
+        [UnityTest]
+        public IEnumerator ScrollProgress_IncreasesDuringScroll()
+        {
+            var go = Track(TestCharacterFactory.CreateConveyor("TestConveyor"));
+            var conveyor = go.GetComponent<WorldConveyor>();
+
+            yield return null;
+
+            conveyor.ScrollBy(8f, 4f, 2f);
+
+            float previousProgress = 0f;
+            bool sawIncrease = false;
+
+            for (int i = 0; i < MaxSampleFrames; i++)
+            {
+                yield return new WaitForFixedUpdate();
+
+                float progress = conveyor.ScrollProgress;
+                if (progress > previousProgress && previousProgress > 0f)
+                    sawIncrease = true;
+
+                previousProgress = progress;
+
+                if (!conveyor.IsScrolling)
+                    break;
+            }
+
+            Assert.IsTrue(sawIncrease, "ScrollProgress should increase during scroll.");
+        }
+
+        [UnityTest]
+        public IEnumerator ScrollProgress_ReachesOne_WhenScrollCompletes()
+        {
+            var go = Track(TestCharacterFactory.CreateConveyor("TestConveyor"));
+            var conveyor = go.GetComponent<WorldConveyor>();
+
+            yield return null;
+
+            float progressAtComplete = -1f;
+            conveyor.OnScrollComplete += () => progressAtComplete = conveyor.ScrollProgress;
+            conveyor.ScrollBy(3f, 10f, 20f);
+
+            yield return new WaitForSeconds(ScrollTimeout);
+
+            Assert.That(progressAtComplete, Is.GreaterThan(0.9f),
+                "ScrollProgress should be ~1.0 when OnScrollComplete fires.");
+        }
+
+        [UnityTest]
+        public IEnumerator OnScrollStarted_Fires_WhenScrollByIsCalled()
+        {
+            var go = Track(TestCharacterFactory.CreateConveyor("TestConveyor"));
+            var conveyor = go.GetComponent<WorldConveyor>();
+            bool fired = false;
+
+            yield return null;
+
+            conveyor.OnScrollStarted += () => fired = true;
+            conveyor.ScrollBy(3f, 10f, 20f);
+
+            Assert.IsTrue(fired, "OnScrollStarted should fire when ScrollBy is called.");
+        }
+
+        [UnityTest]
+        public IEnumerator OnScrollStarted_DoesNotFire_OnZeroDistance()
+        {
+            var go = Track(TestCharacterFactory.CreateConveyor("TestConveyor"));
+            var conveyor = go.GetComponent<WorldConveyor>();
+            bool fired = false;
+
+            yield return null;
+
+            conveyor.OnScrollStarted += () => fired = true;
+            LogAssert.Expect(LogType.Warning, new Regex("distance must be > 0"));
+            conveyor.ScrollBy(0f, 10f, 5f);
+
+            Assert.IsFalse(fired, "OnScrollStarted should not fire when distance is zero.");
+        }
+
+        [UnityTest]
         public IEnumerator ScrollBy_ZeroDistance_DoesNotScroll()
         {
             var go = Track(TestCharacterFactory.CreateConveyor("TestConveyor"));

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 Doc detaille : `Assets/doc/premier-jet-roguelite.html`
 
 # Project Structure
-Generated: 2026-03-31 (updated feature/119-editor-refactor)
+Generated: 2026-03-31 (updated feature/121-progress-bar-minimap)
 
 .github/
 └── workflows/


### PR DESCRIPTION
## Summary
- **WorldConveyor**: added `ScrollProgress` (0→1) property and `OnScrollStarted` event to expose real-time scroll state
- **StepProgressBar**: added overlay scroll dot that lerps between step spheres during conveyor scroll, acting as a minimap indicator
- Cached `Vector3[4]` allocation to avoid per-frame GC pressure on mobile

## Test plan
- [x] 130/130 PlayMode tests pass (5 new WorldConveyor + 4 new StepProgressBar tests)
- [ ] Manual: kill all enemies in a step, observe blue dot sliding smoothly during scroll
- [ ] Manual: verify dot acceleration/deceleration matches conveyor physics
- [ ] Manual: level transition — dot slides to right edge then bar rebuilds
- [ ] Manual: defeat reset — progress bar rebuilds cleanly, dot inactive

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)