### PR TITLE
fix(ui): keep StepProgressBar dot moving until conveyor scroll completes (#124)

### DIFF
--- a/Assets/Scripts/UI/Widgets/StepProgressBar.cs
+++ b/Assets/Scripts/UI/Widgets/StepProgressBar.cs
@@ -68,6 +68,7 @@ namespace RogueliteAutoBattler.UI.Widgets
 
         private void Rebuild(int totalSteps, int currentStep)
         {
+            StopDotScroll();
             _spheres.Clear();
             _lines.Clear();
 
@@ -181,7 +182,6 @@ namespace RogueliteAutoBattler.UI.Widgets
 
         private void OnStepChanged(int stepIndex)
         {
-            StopDotScroll();
             UpdateVisuals(stepIndex);
         }
 

--- a/Assets/Scripts/UI/Widgets/StepProgressBar.cs
+++ b/Assets/Scripts/UI/Widgets/StepProgressBar.cs
@@ -20,6 +20,8 @@ namespace RogueliteAutoBattler.UI.Widgets
         [SerializeField] private float _lineHeight = 3f;
         [SerializeField] private float _lineMinWidth = 4f;
 
+        private const float ScrollDotSizeMultiplier = 1.2f;
+
         private LevelManager _levelManager;
         private WorldConveyor _conveyor;
         private HorizontalLayoutGroup _layoutGroup;
@@ -147,7 +149,8 @@ namespace RogueliteAutoBattler.UI.Widgets
             _scrollDot.raycastTarget = false;
 
             _scrollDotRect = dotGo.GetComponent<RectTransform>();
-            _scrollDotRect.sizeDelta = new Vector2(_sphereSize, _sphereSize);
+            float dotSize = _sphereSize * ScrollDotSizeMultiplier;
+            _scrollDotRect.sizeDelta = new Vector2(dotSize, dotSize);
 
             var layout = dotGo.AddComponent<LayoutElement>();
             layout.ignoreLayout = true;
@@ -214,6 +217,7 @@ namespace RogueliteAutoBattler.UI.Widgets
         private void OnConveyorScrollComplete()
         {
             StopDotScroll();
+            UpdateVisuals(_currentStep);
         }
 
         private void StartDotScroll(int fromIndex, int toIndex)
@@ -223,6 +227,7 @@ namespace RogueliteAutoBattler.UI.Widgets
             _dotToIndex = toIndex;
             _dotActive = true;
             _scrollDot.gameObject.SetActive(true);
+            _scrollDot.transform.SetAsLastSibling();
             UpdateVisuals(_currentStep);
         }
 

--- a/Assets/Tests/PlayMode/StepProgressBarTests.cs
+++ b/Assets/Tests/PlayMode/StepProgressBarTests.cs
@@ -149,7 +149,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         }
 
         [UnityTest]
-        public IEnumerator ScrollDot_BecomesInactive_WhenStepChanges()
+        public IEnumerator ScrollDot_RemainsActive_WhenStepChanges()
         {
             yield return null;
 
@@ -161,8 +161,8 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             _progressBar.SimulateStepChange(1);
 
-            Assert.IsFalse(_progressBar.IsScrollDotActive,
-                "ScrollDot should be inactive after step change.");
+            Assert.IsTrue(_progressBar.IsScrollDotActive,
+                "ScrollDot should remain active after step change until scroll completes.");
         }
 
         [UnityTest]
@@ -197,7 +197,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         }
 
         [UnityTest]
-        public IEnumerator DepartureSphere_ReturnsToCurrent_AfterStepChange()
+        public IEnumerator DepartureSphere_StaysCompleted_DuringActiveScroll_AfterStepChange()
         {
             yield return null;
 
@@ -207,9 +207,11 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             _progressBar.SimulateStepChange(1);
             yield return null;
 
-            Assert.IsFalse(_progressBar.IsScrollDotActive);
+            Assert.IsTrue(_progressBar.IsScrollDotActive,
+                "ScrollDot should remain active after step change until scroll completes.");
             Assert.AreEqual(_progressBar.CompletedColor, _progressBar.GetSphereColor(0));
-            Assert.AreEqual(_progressBar.CurrentColor, _progressBar.GetSphereColor(1));
+            Assert.AreEqual(_progressBar.CompletedColor, _progressBar.GetSphereColor(1),
+                "Current sphere should show CompletedColor while scroll dot is active.");
             Assert.AreEqual(_progressBar.UpcomingColor, _progressBar.GetSphereColor(2));
         }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 Doc detaille : `Assets/doc/premier-jet-roguelite.html`
 
 # Project Structure
-Generated: 2026-04-01 (updated feature/123-progress-bar-duplicate-dot)
+Generated: 2026-04-01 (updated feature/124-progress-bar-dot-jump)
 
 .github/
 └── workflows/


### PR DESCRIPTION
## Summary
- ScrollDot no longer stops at ~85% when enemies spawn — it continues moving until conveyor scroll fully completes
- Removed `StopDotScroll()` from `OnStepChanged` — dot lifecycle is now governed solely by conveyor events
- Added `StopDotScroll()` at start of `Rebuild` for clean state reset during level/defeat transitions
- ScrollDot is now 20% bigger than spheres for better visibility
- ScrollDot always renders on top of spheres (SetAsLastSibling)
- Added `UpdateVisuals` call in `OnConveyorScrollComplete` to repaint sphere colors after dot disappears

## Test plan
- [ ] Scroll dot glides smoothly to destination without jumping
- [ ] Dot remains visible on top of white spheres at all times
- [ ] Current step sphere turns blue (not white) after scroll completes
- [ ] Defeat reset rebuilds progress bar cleanly
- [ ] All 133 play mode + 45 edit mode tests pass

Closes #124

Generated with Claude Code