### PR TITLE
feat(combat): add configurable character scale (#127)

### DIFF
--- a/Assets/Scripts/Combat/Core/CharacterMover.cs
+++ b/Assets/Scripts/Combat/Core/CharacterMover.cs
@@ -170,7 +170,8 @@ namespace RogueliteAutoBattler.Combat.Core
                 return;
 
             var s = transform.localScale;
-            s.x = directionX > 0f ? -1f : 1f;
+            float magnitude = Mathf.Abs(s.x);
+            s.x = directionX > 0f ? -magnitude : magnitude;
             transform.localScale = s;
         }
 

--- a/Assets/Scripts/Combat/Core/CombatSetupHelper.cs
+++ b/Assets/Scripts/Combat/Core/CombatSetupHelper.cs
@@ -8,7 +8,6 @@ namespace RogueliteAutoBattler.Combat.Core
     public struct CharacterComponents
     {
         public CombatStats Stats;
-        public CharacterMover Mover;
         public CombatController Controller;
     }
 
@@ -75,7 +74,6 @@ namespace RogueliteAutoBattler.Combat.Core
             return new CharacterComponents
             {
                 Stats = combatStats,
-                Mover = mover,
                 Controller = controller
             };
         }
@@ -93,7 +91,7 @@ namespace RogueliteAutoBattler.Combat.Core
             relay.Initialize(controller);
         }
 
-        public static void RecalculateFormation(Transform container, Transform homeAnchor, bool facingRight, float scaleFactor = 1f)
+        public static void RecalculateFormation(Transform container, Transform homeAnchor, bool facingRight, float characterScale = 1f)
         {
             if (container == null || homeAnchor == null)
                 return;
@@ -115,7 +113,7 @@ namespace RogueliteAutoBattler.Combat.Core
                 return;
 
             Vector2 anchorPos = (Vector2)homeAnchor.position;
-            Vector2[] positions = FormationLayout.GetPositions(anchorPos, aliveList.Count, facingRight, scaleFactor: scaleFactor);
+            Vector2[] positions = FormationLayout.GetPositions(anchorPos, aliveList.Count, facingRight, characterScale: characterScale);
 
             for (int i = 0; i < aliveList.Count; i++)
             {

--- a/Assets/Scripts/Combat/Core/CombatSetupHelper.cs
+++ b/Assets/Scripts/Combat/Core/CombatSetupHelper.cs
@@ -34,7 +34,8 @@ namespace RogueliteAutoBattler.Combat.Core
             string callerName,
             Color? healthBarFillColor = null,
             Color? healthBarTrailColor = null,
-            bool isAlly = true)
+            bool isAlly = true,
+            float characterScale = 1f)
         {
             var combatStats = character.AddComponent<CombatStats>();
             combatStats.InitializeDirect(maxHp, atk, attackSpeed, regenHpPerSecond);
@@ -55,7 +56,7 @@ namespace RogueliteAutoBattler.Combat.Core
 
             var col = character.GetComponent<CircleCollider2D>();
             if (col != null)
-                col.radius = colliderRadius;
+                col.radius = colliderRadius / characterScale;
 
             var controller = character.AddComponent<CombatController>();
             WireAnimationRelay(character, controller, callerName);
@@ -92,7 +93,7 @@ namespace RogueliteAutoBattler.Combat.Core
             relay.Initialize(controller);
         }
 
-        public static void RecalculateFormation(Transform container, Transform homeAnchor, bool facingRight)
+        public static void RecalculateFormation(Transform container, Transform homeAnchor, bool facingRight, float scaleFactor = 1f)
         {
             if (container == null || homeAnchor == null)
                 return;
@@ -114,7 +115,7 @@ namespace RogueliteAutoBattler.Combat.Core
                 return;
 
             Vector2 anchorPos = (Vector2)homeAnchor.position;
-            Vector2[] positions = FormationLayout.GetPositions(anchorPos, aliveList.Count, facingRight);
+            Vector2[] positions = FormationLayout.GetPositions(anchorPos, aliveList.Count, facingRight, scaleFactor: scaleFactor);
 
             for (int i = 0; i < aliveList.Count; i++)
             {

--- a/Assets/Scripts/Combat/Core/CombatSpawnManager.cs
+++ b/Assets/Scripts/Combat/Core/CombatSpawnManager.cs
@@ -41,7 +41,7 @@ namespace RogueliteAutoBattler.Combat.Core
             Vector2 anchorPos = teamAnchor != null ? (Vector2)teamAnchor.position : Vector2.zero;
 
             var allies = _teamDatabase.Allies;
-            Vector2[] positions = FormationLayout.GetPositions(anchorPos, allies.Count, facingRight: true);
+            Vector2[] positions = FormationLayout.GetPositions(anchorPos, allies.Count, facingRight: true, scaleFactor: _characterScale);
 
             for (int i = 0; i < allies.Count; i++)
             {
@@ -89,7 +89,8 @@ namespace RogueliteAutoBattler.Combat.Core
                 homeOffset,
                 data.ColliderRadius,
                 data.Appearance,
-                nameof(CombatSpawnManager));
+                nameof(CombatSpawnManager),
+                characterScale: _characterScale);
             components.Controller.SetAttackerFacing(true);
         }
     }

--- a/Assets/Scripts/Combat/Core/CombatSpawnManager.cs
+++ b/Assets/Scripts/Combat/Core/CombatSpawnManager.cs
@@ -14,7 +14,10 @@ namespace RogueliteAutoBattler.Combat.Core
         [Header("Anchors")]
         [SerializeField] private Transform _teamHomeAnchor;
 
-        private static readonly Vector3 FacingRightScale = new Vector3(-1f, 1f, 1f);
+        [Header("Scale")]
+        [SerializeField] private float _characterScale = 1.5f;
+
+        public float CharacterScale => _characterScale;
 
         private void Start()
         {
@@ -53,11 +56,12 @@ namespace RogueliteAutoBattler.Combat.Core
             SpawnAllies();
         }
 
-        internal void InitializeForTest(TeamDatabase teamDatabase, Transform teamContainer, Transform teamHomeAnchor)
+        internal void InitializeForTest(TeamDatabase teamDatabase, Transform teamContainer, Transform teamHomeAnchor, float characterScale = 1.5f)
         {
             _teamDatabase = teamDatabase;
             _teamContainer = teamContainer;
             _teamHomeAnchor = teamHomeAnchor;
+            _characterScale = characterScale;
         }
 
         private void SpawnAlly(AllySpawnData data, Transform homeAnchor, Vector2 spawnPos, Vector2 homeOffset)
@@ -72,7 +76,7 @@ namespace RogueliteAutoBattler.Combat.Core
 
             var ally = Instantiate(data.Prefab, new Vector3(spawnPos.x, spawnPos.y, 0f), Quaternion.identity, _teamContainer);
             ally.name = data.AllyName;
-            ally.transform.localScale = FacingRightScale;
+            ally.transform.localScale = new Vector3(-_characterScale, _characterScale, 1f);
 
             var components = CombatSetupHelper.AssembleCharacter(
                 ally,

--- a/Assets/Scripts/Combat/Core/CombatSpawnManager.cs
+++ b/Assets/Scripts/Combat/Core/CombatSpawnManager.cs
@@ -14,8 +14,9 @@ namespace RogueliteAutoBattler.Combat.Core
         [Header("Anchors")]
         [SerializeField] private Transform _teamHomeAnchor;
 
+        private const float DefaultCharacterScale = 1.5f;
         [Header("Scale")]
-        [SerializeField] private float _characterScale = 1.5f;
+        [SerializeField] private float _characterScale = DefaultCharacterScale;
 
         public float CharacterScale => _characterScale;
 
@@ -41,7 +42,7 @@ namespace RogueliteAutoBattler.Combat.Core
             Vector2 anchorPos = teamAnchor != null ? (Vector2)teamAnchor.position : Vector2.zero;
 
             var allies = _teamDatabase.Allies;
-            Vector2[] positions = FormationLayout.GetPositions(anchorPos, allies.Count, facingRight: true, scaleFactor: _characterScale);
+            Vector2[] positions = FormationLayout.GetPositions(anchorPos, allies.Count, facingRight: true, characterScale: _characterScale);
 
             for (int i = 0; i < allies.Count; i++)
             {
@@ -56,7 +57,7 @@ namespace RogueliteAutoBattler.Combat.Core
             SpawnAllies();
         }
 
-        internal void InitializeForTest(TeamDatabase teamDatabase, Transform teamContainer, Transform teamHomeAnchor, float characterScale = 1.5f)
+        internal void InitializeForTest(TeamDatabase teamDatabase, Transform teamContainer, Transform teamHomeAnchor, float characterScale = DefaultCharacterScale)
         {
             _teamDatabase = teamDatabase;
             _teamContainer = teamContainer;

--- a/Assets/Scripts/Combat/Core/FormationLayout.cs
+++ b/Assets/Scripts/Combat/Core/FormationLayout.cs
@@ -14,12 +14,12 @@ namespace RogueliteAutoBattler.Combat.Core
             bool facingRight,
             float ySpacing = DefaultYSpacing,
             float columnSpacing = DefaultColumnSpacing,
-            float scaleFactor = 1f)
+            float characterScale = 1f)
         {
             if (count <= 0) return System.Array.Empty<Vector2>();
 
-            float scaledYSpacing = ySpacing * scaleFactor;
-            float scaledColumnSpacing = columnSpacing * scaleFactor;
+            float scaledYSpacing = ySpacing * characterScale;
+            float scaledColumnSpacing = columnSpacing * characterScale;
 
             var positions = new Vector2[count];
 

--- a/Assets/Scripts/Combat/Core/FormationLayout.cs
+++ b/Assets/Scripts/Combat/Core/FormationLayout.cs
@@ -13,25 +13,29 @@ namespace RogueliteAutoBattler.Combat.Core
             int count,
             bool facingRight,
             float ySpacing = DefaultYSpacing,
-            float columnSpacing = DefaultColumnSpacing)
+            float columnSpacing = DefaultColumnSpacing,
+            float scaleFactor = 1f)
         {
             if (count <= 0) return System.Array.Empty<Vector2>();
+
+            float scaledYSpacing = ySpacing * scaleFactor;
+            float scaledColumnSpacing = columnSpacing * scaleFactor;
 
             var positions = new Vector2[count];
 
             if (count <= MaxPerColumn)
             {
-                FillColumn(positions, 0, count, anchor.x, anchor.y, ySpacing);
+                FillColumn(positions, 0, count, anchor.x, anchor.y, scaledYSpacing);
             }
             else
             {
                 int frontCount = Mathf.CeilToInt(count / 2f);
                 int backCount = count - frontCount;
 
-                float backOffsetX = facingRight ? -columnSpacing : columnSpacing;
+                float backOffsetX = facingRight ? -scaledColumnSpacing : scaledColumnSpacing;
 
-                FillColumn(positions, 0, frontCount, anchor.x, anchor.y, ySpacing);
-                FillColumn(positions, frontCount, backCount, anchor.x + backOffsetX, anchor.y, ySpacing);
+                FillColumn(positions, 0, frontCount, anchor.x, anchor.y, scaledYSpacing);
+                FillColumn(positions, frontCount, backCount, anchor.x + backOffsetX, anchor.y, scaledYSpacing);
             }
 
             return positions;

--- a/Assets/Scripts/Combat/Levels/LevelManager.cs
+++ b/Assets/Scripts/Combat/Levels/LevelManager.cs
@@ -200,8 +200,9 @@ namespace RogueliteAutoBattler.Combat.Levels
                 ? (Vector2)_enemiesHomeAnchor.position
                 : new Vector2(FallbackEnemySpawnX, 0f);
             Vector2 spawnAnchor = new Vector2(anchorPos.x + _enemySpawnOffscreenX, anchorPos.y);
-            Vector2[] spawnPositions = FormationLayout.GetPositions(spawnAnchor, wave.Enemies.Count, facingRight: false);
-            Vector2[] homePositions = FormationLayout.GetPositions(anchorPos, wave.Enemies.Count, facingRight: false);
+            float scaleFactor = CurrentScaleFactor;
+            Vector2[] spawnPositions = FormationLayout.GetPositions(spawnAnchor, wave.Enemies.Count, facingRight: false, scaleFactor: scaleFactor);
+            Vector2[] homePositions = FormationLayout.GetPositions(anchorPos, wave.Enemies.Count, facingRight: false, scaleFactor: scaleFactor);
 
             for (int i = 0; i < wave.Enemies.Count; i++)
             {
@@ -405,7 +406,7 @@ namespace RogueliteAutoBattler.Combat.Levels
 
             ClearAllyTargets();
             AttackSlotRegistry.Clear();
-            CombatSetupHelper.RecalculateFormation(_teamContainer, _teamHomeAnchor, facingRight: true);
+            CombatSetupHelper.RecalculateFormation(_teamContainer, _teamHomeAnchor, facingRight: true, scaleFactor: CurrentScaleFactor);
 
             if (_conveyor != null && scrollDistance > 0f)
             {
@@ -506,7 +507,7 @@ namespace RogueliteAutoBattler.Combat.Levels
 #endif
             ClearEnemyTargets();
             AttackSlotRegistry.Clear();
-            CombatSetupHelper.RecalculateFormation(_enemiesContainer, _enemiesHomeAnchor, facingRight: false);
+            CombatSetupHelper.RecalculateFormation(_enemiesContainer, _enemiesHomeAnchor, facingRight: false, scaleFactor: CurrentScaleFactor);
             StartCoroutine(DefeatResetCoroutine());
         }
 
@@ -577,10 +578,10 @@ namespace RogueliteAutoBattler.Combat.Levels
         internal void ClearEnemyTargetsForTest() => ClearEnemyTargets();
 
         internal void RecalculateAllyFormationForTest() =>
-            CombatSetupHelper.RecalculateFormation(_teamContainer, _teamHomeAnchor, facingRight: true);
+            CombatSetupHelper.RecalculateFormation(_teamContainer, _teamHomeAnchor, facingRight: true, scaleFactor: CurrentScaleFactor);
 
         internal void RecalculateEnemyFormationForTest() =>
-            CombatSetupHelper.RecalculateFormation(_enemiesContainer, _enemiesHomeAnchor, facingRight: false);
+            CombatSetupHelper.RecalculateFormation(_enemiesContainer, _enemiesHomeAnchor, facingRight: false, scaleFactor: CurrentScaleFactor);
 
         private static void IgnoreCollisionWithOppositeTeam(GameObject character, Transform oppositeContainer)
         {

--- a/Assets/Scripts/Combat/Levels/LevelManager.cs
+++ b/Assets/Scripts/Combat/Levels/LevelManager.cs
@@ -228,6 +228,9 @@ namespace RogueliteAutoBattler.Combat.Levels
             GameObject enemy = Instantiate(data.Prefab, spawnPosition, Quaternion.identity, _enemiesContainer);
             enemy.name = data.EnemyName;
 
+            float scale = _spawnManager != null ? _spawnManager.CharacterScale : 1f;
+            enemy.transform.localScale = new Vector3(scale, scale, 1f);
+
             var components = CombatSetupHelper.AssembleCharacter(
                 enemy,
                 data.Hp,

--- a/Assets/Scripts/Combat/Levels/LevelManager.cs
+++ b/Assets/Scripts/Combat/Levels/LevelManager.cs
@@ -73,7 +73,7 @@ namespace RogueliteAutoBattler.Combat.Levels
 
         private float CombatZoneX => _combatTriggerZone != null ? _combatTriggerZone.position.x : float.MaxValue;
 
-        private float CurrentScaleFactor => _spawnManager != null ? _spawnManager.CharacterScale : 1f;
+        private float CharacterScale => _spawnManager != null ? _spawnManager.CharacterScale : 1f;
 
         private bool TryGetCurrentStage(out StageData stage)
         {
@@ -200,9 +200,9 @@ namespace RogueliteAutoBattler.Combat.Levels
                 ? (Vector2)_enemiesHomeAnchor.position
                 : new Vector2(FallbackEnemySpawnX, 0f);
             Vector2 spawnAnchor = new Vector2(anchorPos.x + _enemySpawnOffscreenX, anchorPos.y);
-            float scaleFactor = CurrentScaleFactor;
-            Vector2[] spawnPositions = FormationLayout.GetPositions(spawnAnchor, wave.Enemies.Count, facingRight: false, scaleFactor: scaleFactor);
-            Vector2[] homePositions = FormationLayout.GetPositions(anchorPos, wave.Enemies.Count, facingRight: false, scaleFactor: scaleFactor);
+            float characterScale = CharacterScale;
+            Vector2[] spawnPositions = FormationLayout.GetPositions(spawnAnchor, wave.Enemies.Count, facingRight: false, characterScale: characterScale);
+            Vector2[] homePositions = FormationLayout.GetPositions(anchorPos, wave.Enemies.Count, facingRight: false, characterScale: characterScale);
 
             for (int i = 0; i < wave.Enemies.Count; i++)
             {
@@ -231,7 +231,7 @@ namespace RogueliteAutoBattler.Combat.Levels
             GameObject enemy = Instantiate(data.Prefab, spawnPosition, Quaternion.identity, _enemiesContainer);
             enemy.name = data.EnemyName;
 
-            float scale = _spawnManager != null ? _spawnManager.CharacterScale : 1f;
+            float scale = CharacterScale;
             enemy.transform.localScale = new Vector3(scale, scale, 1f);
 
             var components = CombatSetupHelper.AssembleCharacter(
@@ -406,7 +406,7 @@ namespace RogueliteAutoBattler.Combat.Levels
 
             ClearAllyTargets();
             AttackSlotRegistry.Clear();
-            CombatSetupHelper.RecalculateFormation(_teamContainer, _teamHomeAnchor, facingRight: true, scaleFactor: CurrentScaleFactor);
+            CombatSetupHelper.RecalculateFormation(_teamContainer, _teamHomeAnchor, facingRight: true, characterScale: CharacterScale);
 
             if (_conveyor != null && scrollDistance > 0f)
             {
@@ -507,7 +507,7 @@ namespace RogueliteAutoBattler.Combat.Levels
 #endif
             ClearEnemyTargets();
             AttackSlotRegistry.Clear();
-            CombatSetupHelper.RecalculateFormation(_enemiesContainer, _enemiesHomeAnchor, facingRight: false, scaleFactor: CurrentScaleFactor);
+            CombatSetupHelper.RecalculateFormation(_enemiesContainer, _enemiesHomeAnchor, facingRight: false, characterScale: CharacterScale);
             StartCoroutine(DefeatResetCoroutine());
         }
 
@@ -578,10 +578,10 @@ namespace RogueliteAutoBattler.Combat.Levels
         internal void ClearEnemyTargetsForTest() => ClearEnemyTargets();
 
         internal void RecalculateAllyFormationForTest() =>
-            CombatSetupHelper.RecalculateFormation(_teamContainer, _teamHomeAnchor, facingRight: true, scaleFactor: CurrentScaleFactor);
+            CombatSetupHelper.RecalculateFormation(_teamContainer, _teamHomeAnchor, facingRight: true, characterScale: CharacterScale);
 
         internal void RecalculateEnemyFormationForTest() =>
-            CombatSetupHelper.RecalculateFormation(_enemiesContainer, _enemiesHomeAnchor, facingRight: false, scaleFactor: CurrentScaleFactor);
+            CombatSetupHelper.RecalculateFormation(_enemiesContainer, _enemiesHomeAnchor, facingRight: false, characterScale: CharacterScale);
 
         private static void IgnoreCollisionWithOppositeTeam(GameObject character, Transform oppositeContainer)
         {

--- a/Assets/Scripts/Combat/Levels/LevelManager.cs
+++ b/Assets/Scripts/Combat/Levels/LevelManager.cs
@@ -73,6 +73,8 @@ namespace RogueliteAutoBattler.Combat.Levels
 
         private float CombatZoneX => _combatTriggerZone != null ? _combatTriggerZone.position.x : float.MaxValue;
 
+        private float CurrentScaleFactor => _spawnManager != null ? _spawnManager.CharacterScale : 1f;
+
         private bool TryGetCurrentStage(out StageData stage)
         {
             stage = null;
@@ -244,7 +246,8 @@ namespace RogueliteAutoBattler.Combat.Levels
                 data.Appearance,
                 nameof(LevelManager),
                 healthBarFillColor: HealthBar.EnemyFillColor,
-                isAlly: false);
+                isAlly: false,
+                characterScale: scale);
 
             IgnoreCollisionWithOppositeTeam(enemy, _teamContainer);
 

--- a/Assets/Scripts/Combat/Visuals/HealthBar.cs
+++ b/Assets/Scripts/Combat/Visuals/HealthBar.cs
@@ -205,7 +205,7 @@ namespace RogueliteAutoBattler.Combat.Visuals
             }
             else
             {
-                Debug.LogWarning($"[HealthBar] Shader '{UnlitShaderName}' not found. HP bar may render black. Falling back to default sprite material.");
+                Debug.LogWarning($"[{nameof(HealthBar)}] Shader '{UnlitShaderName}' not found. HP bar may render black. Falling back to default sprite material.");
             }
         }
     }

--- a/Assets/Scripts/Combat/Visuals/HealthBar.cs
+++ b/Assets/Scripts/Combat/Visuals/HealthBar.cs
@@ -83,7 +83,7 @@ namespace RogueliteAutoBattler.Combat.Visuals
             var pivotGo = new GameObject("HealthBar_Pivot");
             pivotGo.transform.SetParent(transform, false);
             pivotGo.transform.localPosition = new Vector3(0f, _yOffset, 0f);
-            ApplyFlipCompensation(pivotGo.transform);
+            ApplyScaleCompensation(pivotGo.transform);
             _pivotTransform = pivotGo.transform;
 
             var bgGo = new GameObject("BG");
@@ -143,7 +143,7 @@ namespace RogueliteAutoBattler.Combat.Visuals
             if (!_hasStats || _stats.MaxHp <= 0)
                 return;
 
-            ApplyFlipCompensation(_pivotTransform);
+            ApplyScaleCompensation(_pivotTransform);
 
             if (!_fillDirty && !_isTrailLerping)
                 return;
@@ -172,11 +172,14 @@ namespace RogueliteAutoBattler.Combat.Visuals
             _trailFillTransform.localScale = trailScale;
         }
 
-        private void ApplyFlipCompensation(Transform pivot)
+        private void ApplyScaleCompensation(Transform pivot)
         {
             float sign = transform.localScale.x < 0f ? -1f : 1f;
+            float parentMagnitude = Mathf.Abs(transform.localScale.x);
+            float inverseScale = parentMagnitude > 0.001f ? 1f / parentMagnitude : 1f;
             var pivotScale = pivot.localScale;
-            pivotScale.x = sign;
+            pivotScale.x = sign * inverseScale;
+            pivotScale.y = inverseScale;
             pivot.localScale = pivotScale;
         }
 

--- a/Assets/Tests/EditMode/FormationLayoutTests.cs
+++ b/Assets/Tests/EditMode/FormationLayoutTests.cs
@@ -108,7 +108,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
         [Test]
         public void GetPositions_WithScaleFactor_SpacingScaled()
         {
-            Vector2[] positions = FormationLayout.GetPositions(Vector2.zero, 3, true, scaleFactor: 1.5f);
+            Vector2[] positions = FormationLayout.GetPositions(Vector2.zero, 3, true, characterScale: 1.5f);
 
             Assert.AreEqual(3, positions.Length);
 
@@ -124,7 +124,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
         [Test]
         public void GetPositions_SixUnits_WithScaleFactor_ColumnSpacingScaled()
         {
-            Vector2[] positions = FormationLayout.GetPositions(Vector2.zero, 6, facingRight: true, scaleFactor: 1.5f);
+            Vector2[] positions = FormationLayout.GetPositions(Vector2.zero, 6, facingRight: true, characterScale: 1.5f);
 
             Assert.AreEqual(6, positions.Length);
 

--- a/Assets/Tests/EditMode/FormationLayoutTests.cs
+++ b/Assets/Tests/EditMode/FormationLayoutTests.cs
@@ -104,5 +104,39 @@ namespace RogueliteAutoBattler.Tests.EditMode
                 Assert.That(positions[i].x, Is.EqualTo(1.5f).Within(0.01f));
             }
         }
+
+        [Test]
+        public void GetPositions_WithScaleFactor_SpacingScaled()
+        {
+            Vector2[] positions = FormationLayout.GetPositions(Vector2.zero, 3, true, scaleFactor: 1.5f);
+
+            Assert.AreEqual(3, positions.Length);
+
+            Assert.That(positions[0].y, Is.EqualTo(0.75f).Within(0.01f));
+            Assert.That(positions[1].y, Is.EqualTo(0.0f).Within(0.01f));
+            Assert.That(positions[2].y, Is.EqualTo(-0.75f).Within(0.01f));
+
+            Assert.That(positions[0].x, Is.EqualTo(0f).Within(0.01f));
+            Assert.That(positions[1].x, Is.EqualTo(0f).Within(0.01f));
+            Assert.That(positions[2].x, Is.EqualTo(0f).Within(0.01f));
+        }
+
+        [Test]
+        public void GetPositions_SixUnits_WithScaleFactor_ColumnSpacingScaled()
+        {
+            Vector2[] positions = FormationLayout.GetPositions(Vector2.zero, 6, facingRight: true, scaleFactor: 1.5f);
+
+            Assert.AreEqual(6, positions.Length);
+
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.That(positions[i].x, Is.EqualTo(0f).Within(0.01f));
+            }
+
+            for (int i = 3; i < 6; i++)
+            {
+                Assert.That(positions[i].x, Is.EqualTo(-0.75f).Within(0.01f));
+            }
+        }
     }
 }

--- a/Assets/Tests/PlayMode/CharacterMoverTests.cs
+++ b/Assets/Tests/PlayMode/CharacterMoverTests.cs
@@ -208,5 +208,38 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.That(charGo.transform.localScale.x, Is.EqualTo(1f).Within(0.01f),
                 "FlipToward(-1) should set localScale.x to 1 (face left, native).");
         }
+
+        [UnityTest]
+        public IEnumerator FlipToward_PreservesScaleMagnitude()
+        {
+            var charGo = Track(TestCharacterFactory.CreateMoverCharacter(
+                name: "ScaledFlipper",
+                moveSpeed: 2f,
+                position: new Vector2(0f, 0f)));
+
+            charGo.transform.localScale = new Vector3(1.5f, 1.5f, 1f);
+
+            var mover = charGo.GetComponent<CharacterMover>();
+
+            yield return null;
+
+            mover.FlipToward(1f);
+            yield return null;
+
+            Assert.That(charGo.transform.localScale.x, Is.EqualTo(-1.5f).Within(0.01f),
+                "FlipToward(+1) should flip to -1.5 preserving magnitude.");
+
+            mover.FlipToward(-1f);
+            yield return null;
+
+            Assert.That(charGo.transform.localScale.x, Is.EqualTo(1.5f).Within(0.01f),
+                "FlipToward(-1) should flip to +1.5 preserving magnitude.");
+
+            mover.FlipToward(1f);
+            yield return null;
+
+            Assert.That(charGo.transform.localScale.x, Is.EqualTo(-1.5f).Within(0.01f),
+                "FlipToward(+1) again should be -1.5 with no drift.");
+        }
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 Doc detaille : `Assets/doc/premier-jet-roguelite.html`
 
 # Project Structure
-Generated: 2026-04-01 (updated feature/124-progress-bar-dot-jump)
+Generated: 2026-04-01 (updated feature/127-configurable-character-scale)
 
 .github/
 └── workflows/


### PR DESCRIPTION
## Summary
- Add configurable `_characterScale` field (default 1.5) on `CombatSpawnManager`, exposed in Inspector
- Apply scale uniformly to allies and enemies on spawn
- `CharacterMover.FlipToward()` preserves scale magnitude instead of hardcoded ±1
- `HealthBar` inverse-scale compensation keeps bar dimensions consistent
- `FormationLayout` spacing scales proportionally with character size
- `CombatSetupHelper` compensates collider radius to maintain world-space collision behavior
- 3 new tests: FlipToward magnitude preservation, formation scale factor (2 tests)

Closes #127

## Test plan
- [ ] Play mode: verify allies and enemies appear 1.5x larger
- [ ] Health bars maintain consistent size regardless of character scale
- [ ] Formation spacing adapts — no character overlap
- [ ] Character flip preserves scale magnitude (no size jumps)
- [ ] Change `_characterScale` in Inspector and verify it takes effect
- [ ] All 181 tests pass (47 EditMode + 134 PlayMode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)