### PR TITLE
feat(editor): Level Designer additive enemy scaling (#131)

### DIFF
--- a/Assets/Data/LevelDatabase.asset
+++ b/Assets/Data/LevelDatabase.asset
@@ -39,6 +39,27 @@ MonoBehaviour:
               hatSprite: {fileID: 0}
               weaponSprite: {fileID: 0}
               shieldSprite: {fileID: 0}
+      - stepName: Step 2
+        stepType: 0
+        waves:
+        - waveName: Wave
+          spawnDelay: 0
+          enemies:
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
           - enemyName: Enemy
             prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
             hp: 50
@@ -75,36 +96,6 @@ MonoBehaviour:
         - waveName: Wave
           spawnDelay: 0
           enemies:
-          - enemyName: Enemy
-            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
-            hp: 50
-            atk: 10
-            attackSpeed: 1
-            moveSpeed: 2
-            attackRange: 0.5
-            attackType: 0
-            colliderRadius: 0.1
-            goldDrop: 1
-            appearance:
-              headSprite: {fileID: 0}
-              hatSprite: {fileID: 0}
-              weaponSprite: {fileID: 0}
-              shieldSprite: {fileID: 0}
-          - enemyName: Enemy
-            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
-            hp: 50
-            atk: 10
-            attackSpeed: 1
-            moveSpeed: 2
-            attackRange: 0.5
-            attackType: 0
-            colliderRadius: 0.1
-            goldDrop: 1
-            appearance:
-              headSprite: {fileID: 0}
-              hatSprite: {fileID: 0}
-              weaponSprite: {fileID: 0}
-              shieldSprite: {fileID: 0}
           - enemyName: Enemy
             prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
             hp: 50
@@ -201,42 +192,42 @@ MonoBehaviour:
               hatSprite: {fileID: 0}
               weaponSprite: {fileID: 0}
               shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
       - stepName: 'Step 5 [Special]'
         stepType: 1
         waves:
         - waveName: Wave
           spawnDelay: 0
           enemies:
-          - enemyName: Enemy
-            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
-            hp: 50
-            atk: 10
-            attackSpeed: 1
-            moveSpeed: 2
-            attackRange: 0.5
-            attackType: 0
-            colliderRadius: 0.1
-            goldDrop: 1
-            appearance:
-              headSprite: {fileID: 0}
-              hatSprite: {fileID: 0}
-              weaponSprite: {fileID: 0}
-              shieldSprite: {fileID: 0}
-          - enemyName: Enemy
-            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
-            hp: 50
-            atk: 10
-            attackSpeed: 1
-            moveSpeed: 2
-            attackRange: 0.5
-            attackType: 0
-            colliderRadius: 0.1
-            goldDrop: 1
-            appearance:
-              headSprite: {fileID: 0}
-              hatSprite: {fileID: 0}
-              weaponSprite: {fileID: 0}
-              shieldSprite: {fileID: 0}
           - enemyName: Enemy
             prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
             hp: 50
@@ -384,12 +375,132 @@ MonoBehaviour:
               hatSprite: {fileID: 0}
               weaponSprite: {fileID: 0}
               shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
       - stepName: Step 8
         stepType: 0
         waves:
         - waveName: Wave
           spawnDelay: 0
           enemies:
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
           - enemyName: Enemy
             prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
             hp: 50
@@ -516,42 +627,72 @@ MonoBehaviour:
               hatSprite: {fileID: 0}
               weaponSprite: {fileID: 0}
               shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
+          - enemyName: Enemy
+            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
+            hp: 50
+            atk: 10
+            attackSpeed: 1
+            moveSpeed: 2
+            attackRange: 0.5
+            attackType: 0
+            colliderRadius: 0.1
+            goldDrop: 1
+            appearance:
+              headSprite: {fileID: 0}
+              hatSprite: {fileID: 0}
+              weaponSprite: {fileID: 0}
+              shieldSprite: {fileID: 0}
       - stepName: 'Step 10 [Special]'
         stepType: 1
         waves:
         - waveName: Wave
           spawnDelay: 0
           enemies:
-          - enemyName: Enemy
-            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
-            hp: 50
-            atk: 10
-            attackSpeed: 1
-            moveSpeed: 2
-            attackRange: 0.5
-            attackType: 0
-            colliderRadius: 0.1
-            goldDrop: 1
-            appearance:
-              headSprite: {fileID: 0}
-              hatSprite: {fileID: 0}
-              weaponSprite: {fileID: 0}
-              shieldSprite: {fileID: 0}
-          - enemyName: Enemy
-            prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
-            hp: 50
-            atk: 10
-            attackSpeed: 1
-            moveSpeed: 2
-            attackRange: 0.5
-            attackType: 0
-            colliderRadius: 0.1
-            goldDrop: 1
-            appearance:
-              headSprite: {fileID: 0}
-              hatSprite: {fileID: 0}
-              weaponSprite: {fileID: 0}
-              shieldSprite: {fileID: 0}
           - enemyName: Enemy
             prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
             hp: 50

--- a/Assets/Data/TeamDatabase.asset
+++ b/Assets/Data/TeamDatabase.asset
@@ -17,9 +17,9 @@ MonoBehaviour:
     prefab: {fileID: 1000000000000000001, guid: ade0afb480cc21d43ab799f99637abc6, type: 3}
     maxHp: 100
     atk: 100
-    attackSpeed: 1
+    attackSpeed: 3
     moveSpeed: 5
-    regenHpPerSecond: 1
+    regenHpPerSecond: 20
     colliderRadius: 0.1
     appearance:
       headSprite: {fileID: 0}

--- a/Assets/Scripts/Editor/Windows/LevelDesignerTab.cs
+++ b/Assets/Scripts/Editor/Windows/LevelDesignerTab.cs
@@ -44,19 +44,11 @@ namespace RogueliteAutoBattler.Editor
         private readonly Dictionary<string, bool> _levelFoldouts = new Dictionary<string, bool>();
 
         private int _autoBuilderStepCount = 10;
-        private int _autoBuilderWavesPerStep = 1;
-        private float _autoBuilderWaveSpawnDelay = 5f;
-        private int _autoBuilderEnemiesPerWave = 3;
-        private int _autoBuilderEnemyCountOverride = 5;
-        private int _autoBuilderEnemyOverrideFrequency = 3;
         private int _autoBuilderSpecialStepFrequency = 5;
-        private int _autoBuilderSpecialWavesPerStep = 1;
-        private float _autoBuilderSpecialWaveSpawnDelay = 5f;
-        private int _autoBuilderSpecialEnemiesPerWave = 5;
-        private int _autoBuilderSpecialEnemyCountOverride = 8;
-        private int _autoBuilderSpecialEnemyOverrideFrequency = 2;
+        private AutoBuilderStepParams _autoBuilderNormal  = new AutoBuilderStepParams(1, 5f, 3, 2, 2);
+        private AutoBuilderStepParams _autoBuilderSpecial = new AutoBuilderStepParams(1, 5f, 5, 2, 2);
 
-        private const int AutoBuilderMinFrequency = 2;
+        private const int AutoBuilderMinFrequency = 1;
         private const int StepTypeNormalEnumIndex      = (int)StepType.Normal;
         private const int StepTypeSpecialEnumIndex     = (int)StepType.Special;
         private const int AttackTypeMeleeEnumIndex     = (int)AttackType.Melee;
@@ -511,31 +503,13 @@ namespace RogueliteAutoBattler.Editor
 
                 GUILayout.Space(4f);
                 EditorGUILayout.LabelField("Normal Steps", EditorStyles.boldLabel);
-                _autoBuilderWavesPerStep = Mathf.Max(1,
-                    EditorGUILayout.IntField("Waves", _autoBuilderWavesPerStep));
-                _autoBuilderWaveSpawnDelay = Mathf.Max(0f,
-                    EditorGUILayout.FloatField("Wave Delay (s)", _autoBuilderWaveSpawnDelay));
-                _autoBuilderEnemiesPerWave = Mathf.Max(1,
-                    EditorGUILayout.IntField("Enemies", _autoBuilderEnemiesPerWave));
-                _autoBuilderEnemyCountOverride = Mathf.Max(1,
-                    EditorGUILayout.IntField("Override Count", _autoBuilderEnemyCountOverride));
-                _autoBuilderEnemyOverrideFrequency = Mathf.Max(AutoBuilderMinFrequency,
-                    EditorGUILayout.IntField("Override Every", _autoBuilderEnemyOverrideFrequency));
+                DrawAutoBuilderStepParamFields(ref _autoBuilderNormal);
 
                 GUILayout.Space(4f);
                 EditorGUILayout.LabelField("Special Steps", EditorStyles.boldLabel);
                 _autoBuilderSpecialStepFrequency = Mathf.Max(AutoBuilderMinFrequency,
                     EditorGUILayout.IntField("Special Every", _autoBuilderSpecialStepFrequency));
-                _autoBuilderSpecialWavesPerStep = Mathf.Max(1,
-                    EditorGUILayout.IntField("Waves", _autoBuilderSpecialWavesPerStep));
-                _autoBuilderSpecialWaveSpawnDelay = Mathf.Max(0f,
-                    EditorGUILayout.FloatField("Wave Delay (s)", _autoBuilderSpecialWaveSpawnDelay));
-                _autoBuilderSpecialEnemiesPerWave = Mathf.Max(1,
-                    EditorGUILayout.IntField("Enemies", _autoBuilderSpecialEnemiesPerWave));
-                _autoBuilderSpecialEnemyCountOverride = Mathf.Max(1,
-                    EditorGUILayout.IntField("Override Count", _autoBuilderSpecialEnemyCountOverride));
-                _autoBuilderSpecialEnemyOverrideFrequency = Mathf.Max(AutoBuilderMinFrequency,
-                    EditorGUILayout.IntField("Override Every", _autoBuilderSpecialEnemyOverrideFrequency));
+                DrawAutoBuilderStepParamFields(ref _autoBuilderSpecial);
 
                 GUILayout.Space(6f);
 
@@ -545,6 +519,20 @@ namespace RogueliteAutoBattler.Editor
                 GUILayout.FlexibleSpace();
             }
             GUILayout.EndVertical();
+        }
+
+        private static void DrawAutoBuilderStepParamFields(ref AutoBuilderStepParams stepParams)
+        {
+            stepParams.wavesPerStep = Mathf.Max(1,
+                EditorGUILayout.IntField("Waves", stepParams.wavesPerStep));
+            stepParams.waveSpawnDelay = Mathf.Max(0f,
+                EditorGUILayout.FloatField("Wave Delay (s)", stepParams.waveSpawnDelay));
+            stepParams.enemiesPerWave = Mathf.Max(1,
+                EditorGUILayout.IntField("Enemies", stepParams.enemiesPerWave));
+            stepParams.enemyAddCount = Mathf.Max(0,
+                EditorGUILayout.IntField("Add Count", stepParams.enemyAddCount));
+            stepParams.enemyAddFrequency = Mathf.Max(AutoBuilderMinFrequency,
+                EditorGUILayout.IntField("Add Every", stepParams.enemyAddFrequency));
         }
 
         private void ExecuteAutoBuilder(SerializedProperty stepsProp)
@@ -561,6 +549,7 @@ namespace RogueliteAutoBattler.Editor
             Undo.RecordObject(_levelDatabase, "Auto-Build Level Steps");
 
             stepsProp.arraySize = 0;
+            int normalStepCounter = 0;
             int specialStepCounter = 0;
 
             for (int i = 0; i < _autoBuilderStepCount; i++)
@@ -578,30 +567,24 @@ namespace RogueliteAutoBattler.Editor
                 stepElement.FindPropertyRelative("stepType").enumValueIndex =
                     isSpecialStep ? StepTypeSpecialEnumIndex : StepTypeNormalEnumIndex;
 
-                int enemyCount;
-                int wavesCount;
-                float waveDelay;
+                AutoBuilderStepParams activeParams;
+                int stepCounter;
                 if (isSpecialStep)
                 {
                     specialStepCounter++;
-                    bool hasSpecialOverride =
-                        specialStepCounter % _autoBuilderSpecialEnemyOverrideFrequency == 0;
-                    enemyCount = hasSpecialOverride
-                        ? _autoBuilderSpecialEnemyCountOverride
-                        : _autoBuilderSpecialEnemiesPerWave;
-                    wavesCount = _autoBuilderSpecialWavesPerStep;
-                    waveDelay = _autoBuilderSpecialWaveSpawnDelay;
+                    activeParams = _autoBuilderSpecial;
+                    stepCounter = specialStepCounter;
                 }
                 else
                 {
-                    bool hasEnemyOverride =
-                        oneBasedIndex % _autoBuilderEnemyOverrideFrequency == 0;
-                    enemyCount = hasEnemyOverride
-                        ? _autoBuilderEnemyCountOverride
-                        : _autoBuilderEnemiesPerWave;
-                    wavesCount = _autoBuilderWavesPerStep;
-                    waveDelay = _autoBuilderWaveSpawnDelay;
+                    normalStepCounter++;
+                    activeParams = _autoBuilderNormal;
+                    stepCounter = normalStepCounter;
                 }
+
+                int enemyCount = activeParams.ComputeEnemyCount(stepCounter);
+                int wavesCount = activeParams.wavesPerStep;
+                float waveDelay = activeParams.waveSpawnDelay;
 
                 var wavesProp = stepElement.FindPropertyRelative("waves");
                 wavesProp.arraySize = wavesCount;
@@ -988,6 +971,32 @@ namespace RogueliteAutoBattler.Editor
             _selectedRowStyle.hover.background  = _selectedRowTexture;
             _selectedRowStyle.hover.textColor   = Color.white;
             return _selectedRowStyle;
+        }
+
+        private struct AutoBuilderStepParams
+        {
+            internal int   wavesPerStep;
+            internal float waveSpawnDelay;
+            internal int   enemiesPerWave;
+            internal int   enemyAddCount;
+            internal int   enemyAddFrequency;
+
+            internal AutoBuilderStepParams(
+                int wavesPerStep, float waveSpawnDelay, int enemiesPerWave,
+                int enemyAddCount, int enemyAddFrequency)
+            {
+                this.wavesPerStep     = wavesPerStep;
+                this.waveSpawnDelay   = waveSpawnDelay;
+                this.enemiesPerWave   = enemiesPerWave;
+                this.enemyAddCount    = enemyAddCount;
+                this.enemyAddFrequency = enemyAddFrequency;
+            }
+
+            internal int ComputeEnemyCount(int stepCounter)
+            {
+                return enemiesPerWave
+                    + (stepCounter / enemyAddFrequency) * enemyAddCount;
+            }
         }
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 Doc detaille : `Assets/doc/premier-jet-roguelite.html`
 
 # Project Structure
-Generated: 2026-04-02 (updated feature/129-level-designer-auto-builder)
+Generated: 2026-04-02 (updated feature/131-level-designer-additive-scaling)
 
 .github/
 └── workflows/
@@ -207,7 +207,7 @@ Assets/
 │       ├── LevelManagerStepTransitionTests.cs
 │       ├── VisualEquipmentTestLoopTests.cs
 │       └── WorldConveyorTests.cs
-├── _Recovery/  (1 file)
+├── _Recovery/  (4 files)
 └── TextMesh Pro/  (173 files — TMP package: fonts, shaders, examples)
 
 ProjectSettings/  (Unity defaults)


### PR DESCRIPTION
Closes #131

## Summary
- Replace Override enemy count system with additive scaling in Level Designer auto-builder
- Formula: `base + (stepCounter / frequency) * addCount` — produces escalating staircase pattern (e.g., 3, 5, 5, 7, 7, 9...)
- DRY refactor: extracted `AutoBuilderStepParams` struct with `ComputeEnemyCount()` method
- Added separate `normalStepCounter` for accurate tracking when special steps interrupt the sequence
- Lowered min frequency to 1 (allows linear ramp), allowed add count of 0 (no scaling)

## Test plan
- [ ] Open Roguelite > Game Designer > Level Designer
- [ ] Verify "Add Count" / "Add Every" labels (no more "Override")
- [ ] Generate with base=3, add=2, every=2 → expect 3, 5, 5, 7, 7, 9
- [ ] Test add=0 → all waves same base count