### PR TITLE
fix(combat): health bar visual updates during HP regen (#146)

### DIFF
--- a/.claude/STRUCTURE.md
+++ b/.claude/STRUCTURE.md
@@ -1,5 +1,5 @@
 # Project Structure
-Generated: 2026-04-02 (updated feature/129-level-designer-auto-builder)
+Generated: 2026-04-04 (updated feature/146-healthbar-regen-visual)
 
 .github/
 └── workflows/
@@ -58,6 +58,9 @@ Assets/
 │   │   │   ├── ScreenAnchor.cs
 │   │   │   └── WorldConveyor.cs
 │   │   ├── Levels/
+│   │   │   ├── AllyTargetManager.cs
+│   │   │   ├── DefeatHandler.cs
+│   │   │   ├── EnemySpawner.cs
 │   │   │   └── LevelManager.cs
 │   │   └── Visuals/
 │   │       ├── CharacterAppearance.cs
@@ -71,10 +74,17 @@ Assets/
 │   │       ├── HealthBar.cs
 │   │       └── VisualEquipmentTestLoop.cs
 │   ├── Common/
-│   │   └── SortingLayers.cs
+│   │   ├── PhysicsLayers.cs
+│   │   ├── SortingLayers.cs
+│   │   └── StaticPool.cs
 │   ├── Core/
 │   │   ├── CanvasFactory.cs
 │   │   └── GameBootstrap.cs
+│   ├── Data/
+│   │   ├── DamageNumberConfig.cs
+│   │   ├── LevelDataTypes.cs
+│   │   ├── LevelDatabase.cs
+│   │   └── TeamDatabase.cs
 │   ├── Economy/
 │   │   ├── GoldFormatter.cs
 │   │   └── GoldWallet.cs
@@ -92,11 +102,6 @@ Assets/
 │   │       ├── SettingsWindow.cs
 │   │       └── TeamBuilderTab.cs
 │   ├── Items/  (empty)
-│   ├── ScriptableObjects/
-│   │   ├── DamageNumberConfig.cs
-│   │   ├── LevelDataTypes.cs
-│   │   ├── LevelDatabase.cs
-│   │   └── TeamDatabase.cs
 │   ├── Services/
 │   │   └── Local/  (empty)
 │   ├── UI/
@@ -132,7 +137,7 @@ Assets/
 │   ├── UniversalRenderPipelineGlobalSettings.asset
 │   └── UniversalRP.asset
 ├── Sprites/
-│   ├── Characters/  (155 files)
+│   ├── Characters/  (154 files)
 │   ├── Effects/  (25 files)
 │   ├── Environment/
 │   │   ├── backgroundtest.png
@@ -145,7 +150,7 @@ Assets/
 ├── Tests/
 │   ├── EditMode/
 │   │   ├── Tests.EditMode.asmdef
-│   │   ├── EditModeTestBase.cs
+│   │   ├── AttackSlotRegistryTests.cs
 │   │   ├── CombatStatsDamageEventTests.cs
 │   │   ├── CombatStatsTests.cs
 │   │   ├── FormationLayoutTests.cs
@@ -157,6 +162,7 @@ Assets/
 │       ├── TestUtils/
 │       │   ├── PlayModeTestBase.cs
 │       │   └── TestCharacterFactory.cs
+│       ├── AnimationEventRelayTests.cs
 │       ├── BattleIndicatorBadgeTests.cs
 │       ├── CanvasFactoryTests.cs
 │       ├── CharacterAppearanceTests.cs
@@ -164,6 +170,7 @@ Assets/
 │       ├── CoinFlyServiceTests.cs
 │       ├── CoinFlyTests.cs
 │       ├── CombatControllerTests.cs
+│       ├── CombatSetupHelperTests.cs
 │       ├── CombatSpawnManagerTests.cs
 │       ├── CombatStatsRegenTests.cs
 │       ├── DamageNumberServiceTests.cs
@@ -173,15 +180,17 @@ Assets/
 │       ├── GoldHudBadgeTests.cs
 │       ├── GoldWalletTests.cs
 │       ├── HealthBarTrailTests.cs
-│       ├── LevelManagerTotalLevelsTests.cs
-│       ├── StepProgressBarTests.cs
 │       ├── LevelManagerDefeatResetTests.cs
 │       ├── LevelManagerDefeatTests.cs
 │       ├── LevelManagerEventTests.cs
 │       ├── LevelManagerStepTransitionTests.cs
+│       ├── LevelManagerTotalLevelsTests.cs
+│       ├── NavigationManagerTests.cs
+│       ├── ScreenStackTests.cs
+│       ├── StepProgressBarTests.cs
+│       ├── UIScreenTests.cs
 │       ├── VisualEquipmentTestLoopTests.cs
 │       └── WorldConveyorTests.cs
-├── _Recovery/  (1 file)
 └── TextMesh Pro/  (173 files — TMP package: fonts, shaders, examples)
 
 ProjectSettings/  (Unity defaults)

--- a/Assets/Scripts/Combat/Core/CombatStats.cs
+++ b/Assets/Scripts/Combat/Core/CombatStats.cs
@@ -28,6 +28,7 @@ namespace RogueliteAutoBattler.Combat.Core
         }
 
         public event System.Action<int, int> OnDamageTaken;
+        public event System.Action<int, int> OnHealed;
         public event System.Action OnDied;
 
         public void TakeDamage(int damage)
@@ -59,6 +60,7 @@ namespace RogueliteAutoBattler.Combat.Core
                 {
                     _regenAccumulator -= heal;
                     _currentHp = Mathf.Min(_maxHp, _currentHp + heal);
+                    OnHealed?.Invoke(heal, _currentHp);
                 }
             }
         }

--- a/Assets/Scripts/Combat/Visuals/HealthBar.cs
+++ b/Assets/Scripts/Combat/Visuals/HealthBar.cs
@@ -55,13 +55,19 @@ namespace RogueliteAutoBattler.Combat.Visuals
             EnsureUnlitMaterial();
             CreateBar();
             if (_hasStats)
+            {
                 _stats.OnDamageTaken += HandleDamageTaken;
+                _stats.OnHealed += HandleHealed;
+            }
         }
 
         private void OnDestroy()
         {
             if (_hasStats)
+            {
                 _stats.OnDamageTaken -= HandleDamageTaken;
+                _stats.OnHealed -= HandleHealed;
+            }
         }
 
         public void SetColors(Color fillColor, Color trailColor)
@@ -123,6 +129,11 @@ namespace RogueliteAutoBattler.Combat.Visuals
             _fillRenderer.sortingOrder = SortingOrderFill;
             _fillRenderer.material = _unlitMaterial;
             _fillTransform = fillGo.transform;
+        }
+
+        private void HandleHealed(int heal, int currentHp)
+        {
+            _fillDirty = true;
         }
 
         private void HandleDamageTaken(int damage, int currentHp)

--- a/Assets/Tests/PlayMode/CombatStatsRegenTests.cs
+++ b/Assets/Tests/PlayMode/CombatStatsRegenTests.cs
@@ -56,5 +56,91 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.AreEqual(100, stats.CurrentHp,
                 "HP should be clamped at MaxHp after regen fully heals.");
         }
+
+        [UnityTest]
+        public IEnumerator OnHealed_FiresWhenRegenApplies()
+        {
+            var charGo = Track(TestCharacterFactory.CreateCombatCharacter(
+                name: "OnHealedChar",
+                maxHp: 100,
+                atk: 10,
+                attackSpeed: 1f,
+                regenHpPerSecond: 20f));
+
+            var stats = charGo.GetComponent<CombatStats>();
+
+            yield return null;
+
+            stats.TakeDamage(50);
+
+            int fireCount = 0;
+            stats.OnHealed += (heal, currentHp) => fireCount++;
+
+            yield return new WaitForSeconds(1.5f);
+
+            Assert.That(fireCount, Is.GreaterThan(0),
+                "OnHealed should have fired at least once during regen.");
+        }
+
+        [UnityTest]
+        public IEnumerator OnHealed_FiresWithCorrectValues()
+        {
+            var charGo = Track(TestCharacterFactory.CreateCombatCharacter(
+                name: "OnHealedValuesChar",
+                maxHp: 100,
+                atk: 10,
+                attackSpeed: 1f,
+                regenHpPerSecond: 20f));
+
+            var stats = charGo.GetComponent<CombatStats>();
+
+            yield return null;
+
+            stats.TakeDamage(50);
+
+            int lastHealAmount = 0;
+            int lastCurrentHp = 0;
+            stats.OnHealed += (heal, currentHp) =>
+            {
+                lastHealAmount = heal;
+                lastCurrentHp = currentHp;
+            };
+
+            yield return new WaitForSeconds(1.5f);
+
+            Assert.That(lastHealAmount, Is.GreaterThan(0),
+                "Heal amount should be positive.");
+            Assert.AreEqual(stats.CurrentHp, lastCurrentHp,
+                "Last reported currentHp should match actual CurrentHp.");
+            Assert.That(lastCurrentHp, Is.GreaterThan(50),
+                "CurrentHp reported by OnHealed should reflect healing above the damaged value.");
+            Assert.That(lastCurrentHp, Is.LessThanOrEqualTo(100),
+                "CurrentHp reported by OnHealed should not exceed MaxHp.");
+        }
+
+        [UnityTest]
+        public IEnumerator OnHealed_DoesNotFireWhenHpIsAtMax()
+        {
+            var charGo = Track(TestCharacterFactory.CreateCombatCharacter(
+                name: "OnHealedMaxHpChar",
+                maxHp: 100,
+                atk: 10,
+                attackSpeed: 1f,
+                regenHpPerSecond: 20f));
+
+            var stats = charGo.GetComponent<CombatStats>();
+
+            yield return null;
+
+            Assert.AreEqual(100, stats.CurrentHp, "HP should start at max.");
+
+            int fireCount = 0;
+            stats.OnHealed += (heal, currentHp) => fireCount++;
+
+            yield return new WaitForSeconds(1f);
+
+            Assert.AreEqual(0, fireCount,
+                "OnHealed should not fire when HP is already at max.");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `OnHealed` event to `CombatStats`, fired in `FixedUpdate` when regen applies
- `HealthBar` subscribes to `OnHealed` and sets `_fillDirty = true` so the green fill bar updates visually during regen
- 3 new PlayMode tests for `OnHealed` event coverage

Closes #146

## Test plan
- [x] EditMode tests: 55 passed
- [x] PlayMode tests: 176 passed (includes 3 new OnHealed tests)
- [x] Manual test: health bar rises smoothly during regen without waiting for enemy hit

Generated with Claude Code