### PR TITLE
feat(scene): add NewGameScene builder — fresh scene for UI Toolkit migration (#179)

### DIFF
--- a/Assets/Scenes/NewGameScene.unity
+++ b/Assets/Scenes/NewGameScene.unity
@@ -1,0 +1,218 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 2
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &963787536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 963787539}
+  - component: {fileID: 963787538}
+  - component: {fileID: 963787537}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &963787537
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963787536}
+  m_Enabled: 1
+--- !u!20 &963787538
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963787536}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &963787539
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963787536}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 963787539}

--- a/Assets/Scenes/NewGameScene.unity.meta
+++ b/Assets/Scenes/NewGameScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 56c86fa15f8858747a580ae7e408291b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/Builders/NewGameSceneBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/NewGameSceneBuilder.cs
@@ -1,0 +1,44 @@
+using RogueliteAutoBattler.Core;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace RogueliteAutoBattler.Editor
+{
+    internal static class NewGameSceneBuilder
+    {
+        [MenuItem("Roguelite/Setup New Game Scene")]
+        private static void SetupNewGameScene()
+        {
+            GameObject existingWorld = GameObject.Find(GameBootstrap.CombatWorldName);
+            if (existingWorld != null)
+            {
+                if (!EditorUtility.DisplayDialog("CombatWorld Exists", "Replace existing CombatWorld?", "Replace", "Cancel"))
+                    return;
+            }
+
+            Undo.IncrementCurrentGroup();
+            int undoGroup = Undo.GetCurrentGroup();
+            Undo.SetCurrentGroupName("Setup New Game Scene");
+
+            if (existingWorld != null)
+                Undo.DestroyObjectImmediate(existingWorld);
+
+            EventSystem existingEs = Object.FindFirstObjectByType<EventSystem>(FindObjectsInactive.Include);
+            if (existingEs != null)
+                Undo.DestroyObjectImmediate(existingEs.gameObject);
+
+            CombatWorldBuilder.ConfigureMainCamera();
+            GameObject combatWorld = CombatWorldBuilder.CreateCombatWorld();
+
+            GameObject esGo = SetupNavigationSceneEditor.CreateEventSystem();
+            Undo.RegisterCreatedObjectUndo(esGo, "EventSystem");
+
+            Undo.CollapseUndoOperations(undoGroup);
+            EditorSceneManager.MarkSceneDirty(EditorSceneManager.GetActiveScene());
+            Selection.activeGameObject = combatWorld;
+            Debug.Log("[SetupNewGameScene] Done. CombatWorld + EventSystem created. GameBootstrap auto-discovers refs at runtime.");
+        }
+    }
+}

--- a/Assets/Scripts/Editor/Builders/SetupNavigationSceneEditor.cs
+++ b/Assets/Scripts/Editor/Builders/SetupNavigationSceneEditor.cs
@@ -98,7 +98,7 @@ namespace RogueliteAutoBattler.Editor
             Undo.RegisterCreatedObjectUndo(canvasGo, "UICanvas");
         }
 
-        private static GameObject CreateEventSystem()
+        internal static GameObject CreateEventSystem()
         {
             var go = new GameObject("EventSystem");
             go.AddComponent<EventSystem>();

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 Doc detaille : `Assets/doc/premier-jet-roguelite.html`
 
 # Project Structure
-Generated: 2026-04-14
+Generated: 2026-04-15
 
 .github/
   workflows/
@@ -33,7 +33,7 @@ Generated: 2026-04-14
     protect-main.yml
 
 Assets/
-  Animations/  (24 files: .anim + .controller)
+  Animations/  (23 files: .anim + .controller)
   Audio/  (empty)
   Data/
     Adventurers/  (empty)
@@ -43,6 +43,7 @@ Assets/
     DamageNumberConfig.asset
     LevelDatabase.asset
     SkillTreeData.asset
+    SkillTreeProgress.asset
     TeamDatabase.asset
   doc/
     MedievalFantasyCharacters/  (14 files)
@@ -67,6 +68,7 @@ Assets/
     UI/  (empty)
   Scenes/
     GameScene.unity
+    NewGameScene.unity
   Scripts/
     RogueliteAutoBattler.Runtime.asmdef
     AssemblyInfo.cs
@@ -129,6 +131,7 @@ Assets/
         CombatHudBuilder.cs
         CombatInfoBuilder.cs
         CombatWorldBuilder.cs
+        NewGameSceneBuilder.cs
         RoundedRectSpriteGenerator.cs
         SetupNavigationSceneEditor.cs
         SkillTreeBuilder.cs


### PR DESCRIPTION
## Summary
- New Editor menu item `Roguelite/Setup New Game Scene` that creates CombatWorld + EventSystem in a fresh scene
- Reuses existing `CombatWorldBuilder` methods — no duplication
- Made `SetupNavigationSceneEditor.CreateEventSystem()` internal for cross-builder access
- First step of UI Toolkit migration (Milestone #10)

## Test plan
- [ ] Open NewGameScene.unity → Roguelite/Setup New Game Scene → CombatWorld hierarchy created
- [ ] Play → allies spawn and fight (world-space only, no UI expected)
- [ ] Console: no errors (Canvas/NavigationManager absence is handled gracefully)
- [ ] Re-run menu item → "Replace existing CombatWorld?" dialog appears

Closes #179

Generated with Claude Code