### PR TITLE
fix(ui-toolkit): remove nav tab spacing and borders for flush layout (#181)

### DIFF
--- a/.claude/STRUCTURE.md
+++ b/.claude/STRUCTURE.md
@@ -150,10 +150,14 @@ Assets/
         Village/
           VillageScreen.cs
       Toolkit/
+        BattleIndicatorController.cs
+        CombatHudController.cs
+        GoldBadgeController.cs
         IScreen.cs
         NavigationHost.cs
         NavigationManager.cs
         ScreenStack.cs
+        StepProgressBarController.cs
       Widgets/
         AllyStatsPanel.cs
         BattleIndicatorBadge.cs
@@ -212,6 +216,7 @@ Assets/
       AllyStatsPanelTests.cs
       AnimationEventRelayTests.cs
       BattleIndicatorBadgeTests.cs
+      BattleIndicatorControllerTests.cs
       CanvasFactoryTests.cs
       CharacterAppearanceTests.cs
       CharacterMoverTests.cs
@@ -225,6 +230,7 @@ Assets/
       DamageNumberTests.cs
       FormationRecalculationTests.cs
       GameBootstrapTests.cs
+      GoldBadgeControllerTests.cs
       GoldHudBadgeTests.cs
       GoldWalletTests.cs
       HealthBarTrailTests.cs
@@ -243,6 +249,7 @@ Assets/
       SkillTreeNodeManagerTests.cs
       SkillTreeNodeTests.cs
       SkillTreeScreenTests.cs
+      StepProgressBarControllerTests.cs
       StepProgressBarTests.cs
       UIScreenTests.cs
       UnitSelectionManagerTests.cs
@@ -252,7 +259,11 @@ Assets/
   UI/
     Layouts/
       MainLayout.uxml
+    MainPanelSettings.asset
     Styles/
       MainStyle.uss
+  UI Toolkit/
+    UnityThemes/
+      UnityDefaultRuntimeTheme.tss
 
 ProjectSettings/  (Unity defaults)

--- a/Assets/Scripts/Combat/Visuals/CoinFlyBootstrap.cs
+++ b/Assets/Scripts/Combat/Visuals/CoinFlyBootstrap.cs
@@ -16,12 +16,6 @@ namespace RogueliteAutoBattler.Combat.Visuals
                 return;
             }
 
-            if (_targetBadge == null)
-            {
-                Debug.LogError("[CoinFlyBootstrap] _targetBadge is not assigned. CoinFlyService will not initialize.");
-                return;
-            }
-
             if (_coinSprite == null)
             {
                 Debug.LogError("[CoinFlyBootstrap] _coinSprite is not assigned. CoinFlyService will not initialize.");

--- a/Assets/Scripts/Combat/Visuals/CoinFlyService.cs
+++ b/Assets/Scripts/Combat/Visuals/CoinFlyService.cs
@@ -16,6 +16,10 @@ namespace RogueliteAutoBattler.Combat.Visuals
         private static Canvas _canvas;
         private static Sprite _coinSprite;
 
+        private static Rect _toolkitTargetWorldBound;
+        private static bool _useToolkitTarget;
+        private static Action _onToolkitCoinArrived;
+
         public static bool Suppressed { get; set; }
 
         private const int InitialPoolSize = 5;
@@ -35,6 +39,18 @@ namespace RogueliteAutoBattler.Combat.Visuals
             _pool.Initialize(() => CreateInstance(), InitialPoolSize);
         }
 
+        public static void InitializeToolkitTarget(Rect targetWorldBound, Action onCoinArrived)
+        {
+            _useToolkitTarget = true;
+            _toolkitTargetWorldBound = targetWorldBound;
+            _onToolkitCoinArrived = onCoinArrived;
+        }
+
+        public static void UpdateToolkitTargetBound(Rect worldBound)
+        {
+            _toolkitTargetWorldBound = worldBound;
+        }
+
         public static void Show(Vector3 worldPosition, Action onComplete = null)
         {
             if (!_pool.IsInitialized || Suppressed)
@@ -47,9 +63,20 @@ namespace RogueliteAutoBattler.Combat.Visuals
             RectTransformUtility.ScreenPointToLocalPointInRectangle(
                 _container, screenPoint, uiCamera, out Vector2 startLocal);
 
-            Vector2 targetScreenPoint = RectTransformUtility.WorldToScreenPoint(uiCamera, _targetBadge.position);
-            RectTransformUtility.ScreenPointToLocalPointInRectangle(
-                _container, targetScreenPoint, uiCamera, out Vector2 targetLocal);
+            Vector2 targetLocal;
+            if (_useToolkitTarget)
+            {
+                Vector2 targetScreenPoint = _toolkitTargetWorldBound.center;
+                targetScreenPoint.y = Screen.height - targetScreenPoint.y;
+                RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                    _container, targetScreenPoint, uiCamera, out targetLocal);
+            }
+            else
+            {
+                Vector2 targetScreenPoint = RectTransformUtility.WorldToScreenPoint(uiCamera, _targetBadge.position);
+                RectTransformUtility.ScreenPointToLocalPointInRectangle(
+                    _container, targetScreenPoint, uiCamera, out targetLocal);
+            }
 
             CoinFly coin = _pool.Get();
             coin.Play(startLocal, targetLocal, Duration, () => OnCoinArrived(onComplete));
@@ -57,10 +84,19 @@ namespace RogueliteAutoBattler.Combat.Visuals
 
         private static void OnCoinArrived(Action onComplete)
         {
-            if (_targetBadgeComponent != null)
-                _targetBadgeComponent.Punch(onComplete);
-            else
+            if (_useToolkitTarget)
+            {
+                _onToolkitCoinArrived?.Invoke();
                 onComplete?.Invoke();
+            }
+            else if (_targetBadgeComponent != null)
+            {
+                _targetBadgeComponent.Punch(onComplete);
+            }
+            else
+            {
+                onComplete?.Invoke();
+            }
         }
 
         private static CoinFly CreateInstance()
@@ -97,6 +133,9 @@ namespace RogueliteAutoBattler.Combat.Visuals
             _camera = null;
             _canvas = null;
             _coinSprite = null;
+            _toolkitTargetWorldBound = default;
+            _useToolkitTarget = false;
+            _onToolkitCoinArrived = null;
             Suppressed = false;
         }
 

--- a/Assets/Scripts/Combat/Visuals/CombatWorldVisibility.cs
+++ b/Assets/Scripts/Combat/Visuals/CombatWorldVisibility.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using RogueliteAutoBattler.Combat.Core;
 using RogueliteAutoBattler.UI.Core;
+using RogueliteAutoBattler.UI.Toolkit;
 using UnityEngine;
+using ToolkitNavigationManager = RogueliteAutoBattler.UI.Toolkit.NavigationManager;
 
 namespace RogueliteAutoBattler.Combat.Visuals
 {
@@ -14,6 +16,7 @@ namespace RogueliteAutoBattler.Combat.Visuals
         private int _lastEnemyChildCount;
         private readonly List<Renderer> _rendererBuffer = new List<Renderer>();
         private NavigationManager _cachedNavigationManager;
+        private ToolkitNavigationManager _cachedToolkitNavigationManager;
 
         public bool Visible => _visible;
 
@@ -25,12 +28,21 @@ namespace RogueliteAutoBattler.Combat.Visuals
             _cachedNavigationManager = NavigationManager.Instance;
             if (_cachedNavigationManager != null)
                 _cachedNavigationManager.OnTabChanged += OnTabChanged;
+
+            if (NavigationHost.Instance != null && NavigationHost.Instance.Navigation != null)
+            {
+                _cachedToolkitNavigationManager = NavigationHost.Instance.Navigation;
+                _cachedToolkitNavigationManager.OnTabChanged += OnTabChanged;
+            }
         }
 
         private void OnDestroy()
         {
             if (_cachedNavigationManager != null)
                 _cachedNavigationManager.OnTabChanged -= OnTabChanged;
+
+            if (_cachedToolkitNavigationManager != null)
+                _cachedToolkitNavigationManager.OnTabChanged -= OnTabChanged;
         }
 
         private void OnTabChanged(int tabIndex)

--- a/Assets/Scripts/Combat/Visuals/CombatWorldVisibility.cs
+++ b/Assets/Scripts/Combat/Visuals/CombatWorldVisibility.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using RogueliteAutoBattler.Combat.Core;
 using RogueliteAutoBattler.UI.Core;
-using RogueliteAutoBattler.UI.Toolkit;
 using UnityEngine;
+using ToolkitNavigationHost = RogueliteAutoBattler.UI.Toolkit.NavigationHost;
 using ToolkitNavigationManager = RogueliteAutoBattler.UI.Toolkit.NavigationManager;
 
 namespace RogueliteAutoBattler.Combat.Visuals
@@ -29,9 +29,10 @@ namespace RogueliteAutoBattler.Combat.Visuals
             if (_cachedNavigationManager != null)
                 _cachedNavigationManager.OnTabChanged += OnTabChanged;
 
-            if (NavigationHost.Instance != null && NavigationHost.Instance.Navigation != null)
+            if (ToolkitNavigationHost.Instance != null
+                && ToolkitNavigationHost.Instance.Navigation != null)
             {
-                _cachedToolkitNavigationManager = NavigationHost.Instance.Navigation;
+                _cachedToolkitNavigationManager = ToolkitNavigationHost.Instance.Navigation;
                 _cachedToolkitNavigationManager.OnTabChanged += OnTabChanged;
             }
         }

--- a/Assets/Scripts/Editor/Builders/CombatHudBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/CombatHudBuilder.cs
@@ -8,7 +8,7 @@ using TMPro;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UI;
-using UnityEngine.UIElements;
+using UIDocument = UnityEngine.UIElements.UIDocument;
 
 namespace RogueliteAutoBattler.Editor
 {

--- a/Assets/Scripts/Editor/Builders/CombatHudBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/CombatHudBuilder.cs
@@ -2,11 +2,13 @@ using RogueliteAutoBattler.Combat.Visuals;
 using RogueliteAutoBattler.Economy;
 using RogueliteAutoBattler.UI.Core;
 using RogueliteAutoBattler.UI.Screens.Combat;
+using RogueliteAutoBattler.UI.Toolkit;
 using RogueliteAutoBattler.UI.Widgets;
 using TMPro;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.UIElements;
 
 namespace RogueliteAutoBattler.Editor
 {
@@ -151,6 +153,43 @@ namespace RogueliteAutoBattler.Editor
             badgeSO.ApplyModifiedProperties();
 
             return screen;
+        }
+
+        internal static void SetupToolkitCombatHud(GameObject navigationHostGo)
+        {
+            UIDocument uiDocument = navigationHostGo.GetComponent<UIDocument>();
+
+            CombatHudController combatHud = navigationHostGo.AddComponent<CombatHudController>();
+            var combatHudSo = new SerializedObject(combatHud);
+            EditorUIFactory.SetObj(combatHudSo, "_uiDocument", uiDocument);
+            combatHudSo.ApplyModifiedProperties();
+
+            var coinFlyOverlayGo = new GameObject("CoinFlyOverlay");
+            GameObjectUtility.SetParentAndAlign(coinFlyOverlayGo, navigationHostGo);
+
+            Canvas canvas = coinFlyOverlayGo.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.sortingOrder = 100;
+
+            CanvasScaler scaler = coinFlyOverlayGo.AddComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1080f, 1920f);
+            scaler.matchWidthOrHeight = 0.5f;
+
+            coinFlyOverlayGo.AddComponent<GraphicRaycaster>();
+
+            var coinFlyPoolGo = new GameObject("CoinFlyPool");
+            GameObjectUtility.SetParentAndAlign(coinFlyPoolGo, coinFlyOverlayGo);
+            RectTransform coinFlyPoolRect = coinFlyPoolGo.AddComponent<RectTransform>();
+            EditorUIFactory.Stretch(coinFlyPoolRect);
+
+            CoinFlyBootstrap bootstrap = coinFlyOverlayGo.AddComponent<CoinFlyBootstrap>();
+            var bootstrapSo = new SerializedObject(bootstrap);
+            EditorUIFactory.SetObj(bootstrapSo, "_coinContainer", coinFlyPoolRect);
+            EditorUIFactory.SetObj(bootstrapSo, "_targetBadge", null);
+            EditorUIFactory.SetObj(bootstrapSo, "_coinSprite",
+                AssetDatabase.GetBuiltinExtraResource<Sprite>("UI/Skin/Knob.psd"));
+            bootstrapSo.ApplyModifiedProperties();
         }
 
         private static void CreateCurrencyBadge(Transform parent, string name, string text,

--- a/Assets/Scripts/Editor/Builders/NewGameSceneBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/NewGameSceneBuilder.cs
@@ -42,6 +42,7 @@ namespace RogueliteAutoBattler.Editor
 
             GameObject navHostGo = NavigationHostBuilder.CreateNavigationHost();
             Undo.RegisterCreatedObjectUndo(navHostGo, "NavigationHost");
+            CombatHudBuilder.SetupToolkitCombatHud(navHostGo);
 
             Undo.CollapseUndoOperations(undoGroup);
             EditorSceneManager.MarkSceneDirty(EditorSceneManager.GetActiveScene());

--- a/Assets/Scripts/UI/Toolkit/BattleIndicatorController.cs
+++ b/Assets/Scripts/UI/Toolkit/BattleIndicatorController.cs
@@ -14,6 +14,8 @@ namespace RogueliteAutoBattler.UI.Toolkit
         private const float StartScale = 0.7f;
         private const string VisibleClass = "announcement-overlay--visible";
 
+        private static readonly WaitForSeconds WaitAnnouncementHold = new WaitForSeconds(HoldDuration);
+
         private readonly Label _compactLabel;
         private readonly VisualElement _announcementOverlay;
         private readonly Label _announcementLabel;
@@ -98,7 +100,7 @@ namespace RogueliteAutoBattler.UI.Toolkit
             _announcementOverlay.style.opacity = new StyleFloat(1f);
             _announcementOverlay.style.scale = new Scale(new Vector3(1f, 1f, 1f));
 
-            yield return new WaitForSeconds(HoldDuration);
+            yield return WaitAnnouncementHold;
 
             elapsed = 0f;
             while (elapsed < FadeOutDuration)

--- a/Assets/Scripts/UI/Toolkit/BattleIndicatorController.cs
+++ b/Assets/Scripts/UI/Toolkit/BattleIndicatorController.cs
@@ -1,0 +1,135 @@
+using System.Collections;
+using RogueliteAutoBattler.Combat.Levels;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace RogueliteAutoBattler.UI.Toolkit
+{
+    public class BattleIndicatorController
+    {
+        private const float FadeInDuration = 0.2f;
+        private const float HoldDuration = 1.2f;
+        private const float FadeOutDuration = 0.4f;
+        private const float PeakScale = 1.1f;
+        private const float StartScale = 0.7f;
+        private const string VisibleClass = "announcement-overlay--visible";
+
+        private readonly Label _compactLabel;
+        private readonly VisualElement _announcementOverlay;
+        private readonly Label _announcementLabel;
+        private readonly MonoBehaviour _coroutineHost;
+
+        private LevelManager _levelManager;
+        private Coroutine _announcementCoroutine;
+
+        public BattleIndicatorController(
+            Label compactLabel,
+            VisualElement announcementOverlay,
+            Label announcementLabel,
+            MonoBehaviour coroutineHost)
+        {
+            _compactLabel = compactLabel;
+            _announcementOverlay = announcementOverlay;
+            _announcementLabel = announcementLabel;
+            _coroutineHost = coroutineHost;
+        }
+
+        public void Initialize()
+        {
+            var managers = Object.FindObjectsByType<LevelManager>(FindObjectsSortMode.None);
+            if (managers.Length == 0)
+            {
+                return;
+            }
+
+            _levelManager = managers[0];
+            _levelManager.OnLevelStarted += OnLevelChanged;
+            UpdateCompactLabel(_levelManager.CurrentStageIndex, _levelManager.CurrentLevelIndex);
+        }
+
+        public void Dispose()
+        {
+            if (_levelManager != null)
+            {
+                _levelManager.OnLevelStarted -= OnLevelChanged;
+            }
+        }
+
+        private void OnLevelChanged(int stageIndex, int levelIndex)
+        {
+            UpdateCompactLabel(stageIndex, levelIndex);
+            PlayAnnouncement(stageIndex, levelIndex);
+        }
+
+        private void UpdateCompactLabel(int stageIndex, int levelIndex)
+        {
+            _compactLabel.text = $"{stageIndex + 1}-{levelIndex + 1}";
+        }
+
+        private void PlayAnnouncement(int stageIndex, int levelIndex)
+        {
+            if (_announcementCoroutine != null)
+            {
+                _coroutineHost.StopCoroutine(_announcementCoroutine);
+            }
+
+            _announcementCoroutine = _coroutineHost.StartCoroutine(AnnouncementCoroutine(stageIndex, levelIndex));
+        }
+
+        private IEnumerator AnnouncementCoroutine(int stageIndex, int levelIndex)
+        {
+            _announcementLabel.text = $"Stage {stageIndex + 1} - Level {levelIndex + 1}";
+            _announcementOverlay.AddToClassList(VisibleClass);
+
+            float elapsed = 0f;
+            while (elapsed < FadeInDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / FadeInDuration);
+                float easeOut = 1f - (1f - t) * (1f - t);
+
+                _announcementOverlay.style.opacity = new StyleFloat(Mathf.Lerp(0f, 1f, easeOut));
+                float scale = Mathf.Lerp(StartScale, PeakScale, easeOut);
+                _announcementOverlay.style.scale = new Scale(new Vector3(scale, scale, 1f));
+
+                yield return null;
+            }
+
+            _announcementOverlay.style.opacity = new StyleFloat(1f);
+            _announcementOverlay.style.scale = new Scale(new Vector3(1f, 1f, 1f));
+
+            yield return new WaitForSeconds(HoldDuration);
+
+            elapsed = 0f;
+            while (elapsed < FadeOutDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / FadeOutDuration);
+                float easeIn = t * t;
+
+                _announcementOverlay.style.opacity = new StyleFloat(Mathf.Lerp(1f, 0f, easeIn));
+                float scale = Mathf.Lerp(1f, PeakScale, easeIn);
+                _announcementOverlay.style.scale = new Scale(new Vector3(scale, scale, 1f));
+
+                yield return null;
+            }
+
+            _announcementOverlay.style.opacity = new StyleFloat(0f);
+            _announcementOverlay.style.scale = new Scale(new Vector3(1f, 1f, 1f));
+            _announcementOverlay.RemoveFromClassList(VisibleClass);
+
+            _announcementCoroutine = null;
+        }
+
+        internal string CompactText => _compactLabel.text;
+        internal float AnnouncementOpacity => _announcementOverlay.resolvedStyle.opacity;
+        internal string AnnouncementText => _announcementLabel.text;
+
+        internal void InitializeForTest(LevelManager levelManager)
+        {
+            _levelManager = levelManager;
+            _levelManager.OnLevelStarted += OnLevelChanged;
+            UpdateCompactLabel(_levelManager.CurrentStageIndex, _levelManager.CurrentLevelIndex);
+        }
+    }
+}

--- a/Assets/Scripts/UI/Toolkit/BattleIndicatorController.cs.meta
+++ b/Assets/Scripts/UI/Toolkit/BattleIndicatorController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 780cf705012395a4ca7fb9ed14cb9f92

--- a/Assets/Scripts/UI/Toolkit/CombatHudController.cs
+++ b/Assets/Scripts/UI/Toolkit/CombatHudController.cs
@@ -11,8 +11,6 @@ namespace RogueliteAutoBattler.UI.Toolkit
         private BattleIndicatorController _battleIndicator;
         private StepProgressBarController _stepProgressBar;
 
-        public VisualElement GoldBadgeElement { get; private set; }
-
         internal GoldBadgeController GoldBadge => _goldBadge;
         internal BattleIndicatorController BattleIndicator => _battleIndicator;
         internal StepProgressBarController StepProgressBar => _stepProgressBar;
@@ -32,49 +30,12 @@ namespace RogueliteAutoBattler.UI.Toolkit
                 return;
             }
 
-            VisualElement goldBadgeElement = root.Q<VisualElement>("gold-badge");
-            if (goldBadgeElement == null)
-            {
-                Debug.LogWarning("[CombatHudController] Element 'gold-badge' not found.");
-                return;
-            }
-
-            Label goldLabel = root.Q<Label>("gold-label");
-            if (goldLabel == null)
-            {
-                Debug.LogWarning("[CombatHudController] Element 'gold-label' not found.");
-                return;
-            }
-
-            Label battleCompactLabel = root.Q<Label>("battle-compact-label");
-            if (battleCompactLabel == null)
-            {
-                Debug.LogWarning("[CombatHudController] Element 'battle-compact-label' not found.");
-                return;
-            }
-
-            VisualElement announcementOverlay = root.Q<VisualElement>("announcement-overlay");
-            if (announcementOverlay == null)
-            {
-                Debug.LogWarning("[CombatHudController] Element 'announcement-overlay' not found.");
-                return;
-            }
-
-            Label announcementLabel = root.Q<Label>("announcement-label");
-            if (announcementLabel == null)
-            {
-                Debug.LogWarning("[CombatHudController] Element 'announcement-label' not found.");
-                return;
-            }
-
-            VisualElement stepProgressContainer = root.Q<VisualElement>("step-progress-container");
-            if (stepProgressContainer == null)
-            {
-                Debug.LogWarning("[CombatHudController] Element 'step-progress-container' not found.");
-                return;
-            }
-
-            GoldBadgeElement = goldBadgeElement;
+            if (!TryQuery<VisualElement>(root, "gold-badge", out VisualElement goldBadgeElement)) return;
+            if (!TryQuery<Label>(root, "gold-label", out Label goldLabel)) return;
+            if (!TryQuery<Label>(root, "battle-compact-label", out Label battleCompactLabel)) return;
+            if (!TryQuery<VisualElement>(root, "announcement-overlay", out VisualElement announcementOverlay)) return;
+            if (!TryQuery<Label>(root, "announcement-label", out Label announcementLabel)) return;
+            if (!TryQuery<VisualElement>(root, "step-progress-container", out VisualElement stepProgressContainer)) return;
 
             _goldBadge = new GoldBadgeController(goldBadgeElement, goldLabel, this);
             _battleIndicator = new BattleIndicatorController(battleCompactLabel, announcementOverlay, announcementLabel, this);
@@ -95,6 +56,16 @@ namespace RogueliteAutoBattler.UI.Toolkit
         private void Update()
         {
             _stepProgressBar?.UpdateDotPosition();
+        }
+
+        private static bool TryQuery<T>(VisualElement root, string elementName, out T result)
+            where T : VisualElement
+        {
+            result = root.Q<T>(elementName);
+            if (result != null) return true;
+
+            Debug.LogWarning($"[CombatHudController] Element '{elementName}' not found.");
+            return false;
         }
     }
 }

--- a/Assets/Scripts/UI/Toolkit/CombatHudController.cs
+++ b/Assets/Scripts/UI/Toolkit/CombatHudController.cs
@@ -1,0 +1,100 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace RogueliteAutoBattler.UI.Toolkit
+{
+    public class CombatHudController : MonoBehaviour
+    {
+        [SerializeField] private UIDocument _uiDocument;
+
+        private GoldBadgeController _goldBadge;
+        private BattleIndicatorController _battleIndicator;
+        private StepProgressBarController _stepProgressBar;
+
+        public VisualElement GoldBadgeElement { get; private set; }
+
+        internal GoldBadgeController GoldBadge => _goldBadge;
+        internal BattleIndicatorController BattleIndicator => _battleIndicator;
+        internal StepProgressBarController StepProgressBar => _stepProgressBar;
+
+        private void Awake()
+        {
+            if (_uiDocument == null)
+            {
+                Debug.LogWarning("[CombatHudController] UIDocument is not assigned.");
+                return;
+            }
+
+            VisualElement root = _uiDocument.rootVisualElement;
+            if (root == null)
+            {
+                Debug.LogWarning("[CombatHudController] rootVisualElement is null.");
+                return;
+            }
+
+            VisualElement goldBadgeElement = root.Q<VisualElement>("gold-badge");
+            if (goldBadgeElement == null)
+            {
+                Debug.LogWarning("[CombatHudController] Element 'gold-badge' not found.");
+                return;
+            }
+
+            Label goldLabel = root.Q<Label>("gold-label");
+            if (goldLabel == null)
+            {
+                Debug.LogWarning("[CombatHudController] Element 'gold-label' not found.");
+                return;
+            }
+
+            Label battleCompactLabel = root.Q<Label>("battle-compact-label");
+            if (battleCompactLabel == null)
+            {
+                Debug.LogWarning("[CombatHudController] Element 'battle-compact-label' not found.");
+                return;
+            }
+
+            VisualElement announcementOverlay = root.Q<VisualElement>("announcement-overlay");
+            if (announcementOverlay == null)
+            {
+                Debug.LogWarning("[CombatHudController] Element 'announcement-overlay' not found.");
+                return;
+            }
+
+            Label announcementLabel = root.Q<Label>("announcement-label");
+            if (announcementLabel == null)
+            {
+                Debug.LogWarning("[CombatHudController] Element 'announcement-label' not found.");
+                return;
+            }
+
+            VisualElement stepProgressContainer = root.Q<VisualElement>("step-progress-container");
+            if (stepProgressContainer == null)
+            {
+                Debug.LogWarning("[CombatHudController] Element 'step-progress-container' not found.");
+                return;
+            }
+
+            GoldBadgeElement = goldBadgeElement;
+
+            _goldBadge = new GoldBadgeController(goldBadgeElement, goldLabel, this);
+            _battleIndicator = new BattleIndicatorController(battleCompactLabel, announcementOverlay, announcementLabel, this);
+            _stepProgressBar = new StepProgressBarController(stepProgressContainer);
+
+            _goldBadge.Initialize();
+            _battleIndicator.Initialize();
+            _stepProgressBar.Initialize();
+        }
+
+        private void OnDestroy()
+        {
+            _goldBadge?.Dispose();
+            _battleIndicator?.Dispose();
+            _stepProgressBar?.Dispose();
+        }
+
+        private void Update()
+        {
+            _stepProgressBar?.UpdateDotPosition();
+        }
+    }
+}

--- a/Assets/Scripts/UI/Toolkit/CombatHudController.cs.meta
+++ b/Assets/Scripts/UI/Toolkit/CombatHudController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f3cdba403856b014e8b79d936162777c

--- a/Assets/Scripts/UI/Toolkit/GoldBadgeController.cs
+++ b/Assets/Scripts/UI/Toolkit/GoldBadgeController.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections;
+using RogueliteAutoBattler.Economy;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace RogueliteAutoBattler.UI.Toolkit
+{
+    public class GoldBadgeController
+    {
+        private const float PeakScale = 1.15f;
+        private const float HalfDuration = 0.075f;
+
+        private readonly VisualElement _badgeRoot;
+        private readonly Label _goldLabel;
+        private readonly MonoBehaviour _coroutineHost;
+
+        private GoldWallet _wallet;
+        private Coroutine _punchCoroutine;
+
+        internal string DisplayText => _goldLabel.text;
+
+        public GoldBadgeController(VisualElement badgeRoot, Label goldLabel, MonoBehaviour coroutineHost)
+        {
+            _badgeRoot = badgeRoot;
+            _goldLabel = goldLabel;
+            _coroutineHost = coroutineHost;
+        }
+
+        public void Initialize()
+        {
+            var wallets = UnityEngine.Object.FindObjectsByType<GoldWallet>(FindObjectsSortMode.None);
+            if (wallets.Length == 0)
+            {
+                return;
+            }
+
+            _wallet = wallets[0];
+            _wallet.OnGoldChanged += OnGoldChanged;
+            _goldLabel.text = GoldFormatter.Format(_wallet.Gold);
+        }
+
+        internal void InitializeForTest(GoldWallet wallet)
+        {
+            _wallet = wallet;
+            _wallet.OnGoldChanged += OnGoldChanged;
+            _goldLabel.text = GoldFormatter.Format(_wallet.Gold);
+        }
+
+        public void Dispose()
+        {
+            if (_wallet != null)
+            {
+                _wallet.OnGoldChanged -= OnGoldChanged;
+            }
+        }
+
+        public void Punch(Action onComplete = null)
+        {
+            if (_punchCoroutine != null)
+            {
+                _coroutineHost.StopCoroutine(_punchCoroutine);
+            }
+
+            _punchCoroutine = _coroutineHost.StartCoroutine(PunchCoroutine(onComplete));
+        }
+
+        private void OnGoldChanged(int total)
+        {
+            _goldLabel.text = GoldFormatter.Format(total);
+            Punch();
+        }
+
+        private IEnumerator PunchCoroutine(Action onComplete)
+        {
+            float elapsed = 0f;
+
+            while (elapsed < HalfDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / HalfDuration);
+                float easeOut = 1f - (1f - t) * (1f - t);
+                float scale = Mathf.Lerp(1f, PeakScale, easeOut);
+                _badgeRoot.style.scale = new Scale(new Vector3(scale, scale, 1f));
+                yield return null;
+            }
+
+            elapsed = 0f;
+
+            while (elapsed < HalfDuration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / HalfDuration);
+                float easeIn = t * t;
+                float scale = Mathf.Lerp(PeakScale, 1f, easeIn);
+                _badgeRoot.style.scale = new Scale(new Vector3(scale, scale, 1f));
+                yield return null;
+            }
+
+            _badgeRoot.style.scale = new Scale(new Vector3(1f, 1f, 1f));
+            _punchCoroutine = null;
+            onComplete?.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/UI/Toolkit/GoldBadgeController.cs.meta
+++ b/Assets/Scripts/UI/Toolkit/GoldBadgeController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6a29f626c20db3247bf75bd13201bfc9

--- a/Assets/Scripts/UI/Toolkit/StepProgressBarController.cs
+++ b/Assets/Scripts/UI/Toolkit/StepProgressBarController.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+using RogueliteAutoBattler.Combat.Environment;
+using RogueliteAutoBattler.Combat.Levels;
+using RogueliteAutoBattler.Data;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace RogueliteAutoBattler.UI.Toolkit
+{
+    public class StepProgressBarController
+    {
+        private const string SphereClass = "step-sphere";
+        private const string SphereSpecialClass = "step-sphere--special";
+        private const string SphereCompletedClass = "step-sphere--completed";
+        private const string SphereCurrentClass = "step-sphere--current";
+        private const string SphereUpcomingClass = "step-sphere--upcoming";
+        private const string LineClass = "step-line";
+        private const string LineCompletedClass = "step-line--completed";
+        private const string LineUpcomingClass = "step-line--upcoming";
+        private const string ScrollDotClass = "step-scroll-dot";
+
+        private readonly VisualElement _container;
+        private readonly List<VisualElement> _spheres = new List<VisualElement>();
+        private readonly List<VisualElement> _lines = new List<VisualElement>();
+
+        private VisualElement _scrollDot;
+        private LevelManager _levelManager;
+        private WorldConveyor _conveyor;
+        private int _currentStep;
+        private bool _dotActive;
+        private int _dotFromIndex;
+        private int _dotToIndex;
+        private Func<int, StepType> _getStepType;
+
+        public StepProgressBarController(VisualElement container)
+        {
+            _container = container;
+        }
+
+        public void Initialize()
+        {
+            var managers = UnityEngine.Object.FindObjectsByType<LevelManager>(FindObjectsSortMode.None);
+            if (managers.Length == 0)
+            {
+                return;
+            }
+
+            _levelManager = managers[0];
+            _conveyor = _levelManager.GetComponent<WorldConveyor>();
+            _getStepType = _levelManager.GetStepType;
+
+            _levelManager.OnLevelStarted += OnLevelChanged;
+            _levelManager.OnStepStarted += OnStepChanged;
+
+            if (_conveyor != null)
+            {
+                _conveyor.OnScrollStarted += OnConveyorScrollStarted;
+                _conveyor.OnScrollComplete += OnConveyorScrollComplete;
+            }
+
+            Rebuild(_levelManager.TotalStepsInCurrentLevel, _levelManager.CurrentStepIndex);
+        }
+
+        public void Dispose()
+        {
+            if (_levelManager != null)
+            {
+                _levelManager.OnLevelStarted -= OnLevelChanged;
+                _levelManager.OnStepStarted -= OnStepChanged;
+            }
+
+            if (_conveyor != null)
+            {
+                _conveyor.OnScrollStarted -= OnConveyorScrollStarted;
+                _conveyor.OnScrollComplete -= OnConveyorScrollComplete;
+            }
+        }
+
+        public void UpdateDotPosition()
+        {
+            if (!_dotActive || _conveyor == null) return;
+            if (_dotFromIndex < 0 || _dotFromIndex >= _spheres.Count) return;
+
+            float fromX = _spheres[_dotFromIndex].worldBound.center.x;
+            float toX;
+
+            if (_dotToIndex < _spheres.Count)
+            {
+                toX = _spheres[_dotToIndex].worldBound.center.x;
+            }
+            else
+            {
+                toX = _container.worldBound.xMax;
+            }
+
+            float t = _conveyor.ScrollProgress;
+            float dotX = Mathf.Lerp(fromX, toX, t);
+
+            float dotWidth = _scrollDot.resolvedStyle.width;
+            float dotHeight = _scrollDot.resolvedStyle.height;
+
+            float dotLocalX = dotX - _container.worldBound.x - (dotWidth / 2f);
+            float dotLocalY = (_container.resolvedStyle.height - dotHeight) / 2f;
+
+            _scrollDot.style.left = dotLocalX;
+            _scrollDot.style.top = dotLocalY;
+        }
+
+        private void Rebuild(int totalSteps, int currentStep)
+        {
+            StopDotScroll();
+            _spheres.Clear();
+            _lines.Clear();
+            _container.Clear();
+
+            for (int i = 0; i < totalSteps; i++)
+            {
+                var sphere = new VisualElement();
+                sphere.AddToClassList(SphereClass);
+
+                if (_getStepType != null && _getStepType(i) == StepType.Special)
+                {
+                    sphere.AddToClassList(SphereSpecialClass);
+                }
+
+                _spheres.Add(sphere);
+                _container.Add(sphere);
+
+                if (i < totalSteps - 1)
+                {
+                    var line = new VisualElement();
+                    line.AddToClassList(LineClass);
+                    _lines.Add(line);
+                    _container.Add(line);
+                }
+            }
+
+            _scrollDot = new VisualElement();
+            _scrollDot.AddToClassList(ScrollDotClass);
+            _scrollDot.style.display = DisplayStyle.None;
+            _scrollDot.style.position = Position.Absolute;
+            _container.Add(_scrollDot);
+
+            UpdateVisuals(currentStep);
+        }
+
+        private void UpdateVisuals(int currentStep)
+        {
+            _currentStep = currentStep;
+
+            for (int i = 0; i < _spheres.Count; i++)
+            {
+                if (i < currentStep)
+                {
+                    SetSphereState(_spheres[i], SphereCompletedClass);
+                }
+                else if (i == currentStep)
+                {
+                    SetSphereState(_spheres[i], _dotActive ? SphereCompletedClass : SphereCurrentClass);
+                }
+                else
+                {
+                    SetSphereState(_spheres[i], SphereUpcomingClass);
+                }
+            }
+
+            for (int i = 0; i < _lines.Count; i++)
+            {
+                if (i < currentStep)
+                {
+                    SetLineState(_lines[i], LineCompletedClass);
+                }
+                else
+                {
+                    SetLineState(_lines[i], LineUpcomingClass);
+                }
+            }
+        }
+
+        private void SetSphereState(VisualElement sphere, string stateClass)
+        {
+            sphere.RemoveFromClassList(SphereCompletedClass);
+            sphere.RemoveFromClassList(SphereCurrentClass);
+            sphere.RemoveFromClassList(SphereUpcomingClass);
+            sphere.AddToClassList(stateClass);
+        }
+
+        private void SetLineState(VisualElement line, string stateClass)
+        {
+            line.RemoveFromClassList(LineCompletedClass);
+            line.RemoveFromClassList(LineUpcomingClass);
+            line.AddToClassList(stateClass);
+        }
+
+        private void OnLevelChanged(int stageIndex, int levelIndex)
+        {
+            Rebuild(_levelManager.TotalStepsInCurrentLevel, 0);
+        }
+
+        private void OnStepChanged(int stepIndex)
+        {
+            UpdateVisuals(stepIndex);
+        }
+
+        private void OnConveyorScrollStarted()
+        {
+            int toIndex = _currentStep + 1;
+            if (toIndex <= _spheres.Count)
+            {
+                StartDotScroll(_currentStep, toIndex);
+            }
+        }
+
+        private void OnConveyorScrollComplete()
+        {
+            StopDotScroll();
+            UpdateVisuals(_currentStep);
+        }
+
+        private void StartDotScroll(int fromIndex, int toIndex)
+        {
+            _dotFromIndex = fromIndex;
+            _dotToIndex = toIndex;
+            _dotActive = true;
+            _scrollDot.style.display = DisplayStyle.Flex;
+            _scrollDot.BringToFront();
+            UpdateVisuals(_currentStep);
+        }
+
+        private void StopDotScroll()
+        {
+            if (!_dotActive) return;
+            _dotActive = false;
+            if (_scrollDot != null)
+            {
+                _scrollDot.style.display = DisplayStyle.None;
+            }
+        }
+
+        internal int SphereCount => _spheres.Count;
+        internal int LineCount => _lines.Count;
+        internal bool IsScrollDotActive => _dotActive;
+
+        internal bool SphereHasClass(int index, string className) =>
+            _spheres[index].ClassListContains(className);
+
+        internal void InitializeForTest(LevelManager levelManager)
+        {
+            _levelManager = levelManager;
+            _conveyor = _levelManager.GetComponent<WorldConveyor>();
+            _getStepType = _levelManager.GetStepType;
+
+            _levelManager.OnLevelStarted += OnLevelChanged;
+            _levelManager.OnStepStarted += OnStepChanged;
+
+            if (_conveyor != null)
+            {
+                _conveyor.OnScrollStarted += OnConveyorScrollStarted;
+                _conveyor.OnScrollComplete += OnConveyorScrollComplete;
+            }
+
+            Rebuild(_levelManager.TotalStepsInCurrentLevel, _levelManager.CurrentStepIndex);
+        }
+
+        internal void SimulateStepChange(int stepIndex) => OnStepChanged(stepIndex);
+        internal void SimulateScrollStart() => OnConveyorScrollStarted();
+    }
+}

--- a/Assets/Scripts/UI/Toolkit/StepProgressBarController.cs.meta
+++ b/Assets/Scripts/UI/Toolkit/StepProgressBarController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7afdb33d226cb9a40939303a25a433ad

--- a/Assets/Tests/PlayMode/BattleIndicatorControllerTests.cs
+++ b/Assets/Tests/PlayMode/BattleIndicatorControllerTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Environment;
+using RogueliteAutoBattler.Combat.Levels;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.UI.Toolkit;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace RogueliteAutoBattler.Tests.PlayMode
+{
+    public class BattleIndicatorControllerTests : PlayModeTestBase
+    {
+        private LevelManager _levelManager;
+        private LevelDatabase _levelDatabase;
+        private Label _compactLabel;
+        private VisualElement _announcementOverlay;
+        private Label _announcementLabel;
+        private BattleIndicatorController _controller;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _levelDatabase = ScriptableObject.CreateInstance<LevelDatabase>();
+            var wave = new WaveData("W1", 0f, new List<EnemySpawnData>());
+            var step = new StepData("Step0", new List<WaveData> { wave });
+            var level1 = new LevelData("Level1", new List<StepData> { step });
+            var level2 = new LevelData("Level2", new List<StepData> { step });
+            var stage = new StageData("Stage1", null, new List<LevelData> { level1, level2 });
+            _levelDatabase.Stages.Add(stage);
+
+            var levelManagerGo = new GameObject("LevelManager");
+            levelManagerGo.AddComponent<WorldConveyor>();
+            _levelManager = levelManagerGo.AddComponent<LevelManager>();
+            _levelManager.enabled = false;
+            Track(levelManagerGo);
+
+            var teamContainer = Track(new GameObject("Team"));
+            var enemiesContainer = Track(new GameObject("Enemies"));
+            _levelManager.InitializeForTest(
+                teamContainer.transform,
+                enemiesContainer.transform,
+                levelDatabase: _levelDatabase);
+
+            _compactLabel = new Label();
+            _announcementOverlay = new VisualElement();
+            _announcementLabel = new Label();
+
+            _controller = new BattleIndicatorController(
+                _compactLabel,
+                _announcementOverlay,
+                _announcementLabel,
+                _levelManager);
+            _controller.InitializeForTest(_levelManager);
+        }
+
+        public override void TearDown()
+        {
+            base.TearDown();
+
+            if (_levelDatabase != null)
+                Object.DestroyImmediate(_levelDatabase);
+        }
+
+        [Test]
+        public void CompactLabel_ShowsInitialValue()
+        {
+            Assert.AreEqual("1-1", _controller.CompactText);
+        }
+
+        [Test]
+        public void CompactLabel_Updates_OnLevelStarted()
+        {
+            _levelManager.StartLevel(1);
+
+            Assert.AreEqual("1-2", _controller.CompactText);
+        }
+
+        [Test]
+        public void AnnouncementText_Updates_OnLevelStarted()
+        {
+            _levelManager.StartLevel(1);
+
+            Assert.AreEqual("Stage 1 - Level 2", _controller.AnnouncementText);
+        }
+
+        [Test]
+        public void Dispose_UnsubscribesFromLevelManager()
+        {
+            _controller.Dispose();
+
+            _levelManager.StartLevel(1);
+
+            Assert.AreEqual("1-1", _controller.CompactText);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/BattleIndicatorControllerTests.cs.meta
+++ b/Assets/Tests/PlayMode/BattleIndicatorControllerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 89bc97d7a5cda9a48a93b4fbe349f7bc

--- a/Assets/Tests/PlayMode/GoldBadgeControllerTests.cs
+++ b/Assets/Tests/PlayMode/GoldBadgeControllerTests.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using NUnit.Framework;
+using RogueliteAutoBattler.Economy;
+using RogueliteAutoBattler.UI.Toolkit;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace RogueliteAutoBattler.Tests.PlayMode
+{
+    public class GoldBadgeControllerTests : PlayModeTestBase
+    {
+        private GoldWallet _wallet;
+        private VisualElement _badgeRoot;
+        private Label _goldLabel;
+        private GoldBadgeController _controller;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var walletGo = new GameObject("GoldWallet");
+            Track(walletGo);
+            _wallet = walletGo.AddComponent<GoldWallet>();
+
+            _badgeRoot = new VisualElement();
+            _goldLabel = new Label();
+
+            _controller = new GoldBadgeController(_badgeRoot, _goldLabel, _wallet);
+            _controller.InitializeForTest(_wallet);
+        }
+
+        [Test]
+        public void GoldLabel_ShowsZero_OnInitialize()
+        {
+            Assert.AreEqual("0", _controller.DisplayText);
+        }
+
+        [Test]
+        public void GoldLabel_Updates_WhenGoldAdded()
+        {
+            _wallet.Add(500);
+
+            Assert.AreEqual("500", _controller.DisplayText);
+        }
+
+        [Test]
+        public void GoldLabel_FormatsCompact_WhenGoldLarge()
+        {
+            _wallet.Add(1500);
+
+            Assert.AreEqual("1.5K", _controller.DisplayText);
+        }
+
+        [Test]
+        public void Dispose_UnsubscribesFromWallet()
+        {
+            _controller.Dispose();
+
+            _wallet.Add(999);
+
+            Assert.AreEqual("0", _controller.DisplayText);
+        }
+
+        [UnityTest]
+        public IEnumerator Punch_ChangesScale()
+        {
+            _controller.Punch();
+
+            yield return new WaitForSeconds(0.05f);
+
+            Scale scaleValue = _badgeRoot.style.scale.value;
+            Assert.Greater(scaleValue.value.x, 1.0f,
+                "Badge root scale X should be greater than 1.0 during punch peak.");
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/GoldBadgeControllerTests.cs
+++ b/Assets/Tests/PlayMode/GoldBadgeControllerTests.cs
@@ -69,8 +69,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             yield return new WaitForSeconds(0.05f);
 
             Scale scaleValue = _badgeRoot.style.scale.value;
-            Assert.Greater(scaleValue.value.x, 1.0f,
-                "Badge root scale X should be greater than 1.0 during punch peak.");
+            Assert.Greater(scaleValue.value.x, 1.0f);
         }
     }
 }

--- a/Assets/Tests/PlayMode/GoldBadgeControllerTests.cs.meta
+++ b/Assets/Tests/PlayMode/GoldBadgeControllerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2048f63abaa09394abae26906df28fa9

--- a/Assets/Tests/PlayMode/StepProgressBarControllerTests.cs
+++ b/Assets/Tests/PlayMode/StepProgressBarControllerTests.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Environment;
+using RogueliteAutoBattler.Combat.Levels;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.UI.Toolkit;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace RogueliteAutoBattler.Tests.PlayMode
+{
+    public class StepProgressBarControllerTests : PlayModeTestBase
+    {
+        private const float NeverSpawnDelay = 999f;
+
+        private LevelManager _levelManager;
+        private LevelDatabase _levelDatabase;
+        private VisualElement _container;
+        private StepProgressBarController _controller;
+
+        [SetUp]
+        public void SetUp()
+        {
+            (_levelDatabase, _levelManager, _controller, _container) = BuildSetup(3);
+        }
+
+        private (LevelDatabase database, LevelManager levelManager, StepProgressBarController controller, VisualElement container)
+            BuildSetup(int stepCount, string prefix = "")
+        {
+            var database = ScriptableObject.CreateInstance<LevelDatabase>();
+            var delayedWave = new WaveData("W1", NeverSpawnDelay, new List<EnemySpawnData>());
+
+            var steps = new List<StepData>();
+            for (int i = 0; i < stepCount; i++)
+            {
+                steps.Add(new StepData("Step" + i, new List<WaveData> { delayedWave }));
+            }
+
+            var level = new LevelData("Level0", steps);
+            var stage = new StageData("Stage0", null, new List<LevelData> { level });
+            database.Stages.Add(stage);
+
+            var levelManagerGo = new GameObject(prefix + "LevelManager");
+            levelManagerGo.AddComponent<WorldConveyor>();
+            var levelManager = levelManagerGo.AddComponent<LevelManager>();
+            levelManager.enabled = false;
+            Track(levelManagerGo);
+
+            var teamContainer = Track(new GameObject(prefix + "Team"));
+            var enemiesContainer = Track(new GameObject(prefix + "Enemies"));
+            levelManager.InitializeForTest(
+                teamContainer.transform,
+                enemiesContainer.transform,
+                levelDatabase: database);
+
+            var container = new VisualElement();
+            var controller = new StepProgressBarController(container);
+            controller.InitializeForTest(levelManager);
+
+            return (database, levelManager, controller, container);
+        }
+
+        public override void TearDown()
+        {
+            base.TearDown();
+
+            if (_levelDatabase != null)
+                Object.DestroyImmediate(_levelDatabase);
+        }
+
+        [Test]
+        public void Rebuild_CreatesCorrectSphereCount()
+        {
+            Assert.AreEqual(3, _controller.SphereCount);
+        }
+
+        [Test]
+        public void Rebuild_CreatesCorrectLineCount()
+        {
+            Assert.AreEqual(2, _controller.LineCount);
+        }
+
+        [Test]
+        public void FirstSphere_HasCurrentClass()
+        {
+            Assert.IsTrue(_controller.SphereHasClass(0, "step-sphere--current"));
+        }
+
+        [Test]
+        public void OnStepStarted_UpdatesSphereClasses()
+        {
+            _controller.SimulateStepChange(1);
+
+            Assert.IsTrue(_controller.SphereHasClass(0, "step-sphere--completed"));
+            Assert.IsTrue(_controller.SphereHasClass(1, "step-sphere--current"));
+            Assert.IsTrue(_controller.SphereHasClass(2, "step-sphere--upcoming"));
+        }
+
+        [Test]
+        public void ScrollDot_BecomesActive_OnScrollStart()
+        {
+            _controller.SimulateScrollStart();
+
+            Assert.IsTrue(_controller.IsScrollDotActive);
+        }
+
+        [Test]
+        public void SingleStepLevel_ShowsOneSphereNoLines()
+        {
+            var (singleDatabase, _, singleController, _) = BuildSetup(1, "Single");
+
+            Assert.AreEqual(1, singleController.SphereCount);
+            Assert.AreEqual(0, singleController.LineCount);
+
+            Object.DestroyImmediate(singleDatabase);
+        }
+
+        [Test]
+        public void Dispose_UnsubscribesFromEvents()
+        {
+            var database = ScriptableObject.CreateInstance<LevelDatabase>();
+            var delayedWave = new WaveData("W1", NeverSpawnDelay, new List<EnemySpawnData>());
+
+            var threeStepLevel = new LevelData("Level0", new List<StepData>
+            {
+                new StepData("S0", new List<WaveData> { delayedWave }),
+                new StepData("S1", new List<WaveData> { delayedWave }),
+                new StepData("S2", new List<WaveData> { delayedWave })
+            });
+            var twoStepLevel = new LevelData("Level1", new List<StepData>
+            {
+                new StepData("S0", new List<WaveData> { delayedWave }),
+                new StepData("S1", new List<WaveData> { delayedWave })
+            });
+            var stage = new StageData("Stage0", null, new List<LevelData> { threeStepLevel, twoStepLevel });
+            database.Stages.Add(stage);
+
+            var levelManagerGo = new GameObject("DisposeLevelManager");
+            levelManagerGo.AddComponent<WorldConveyor>();
+            var levelManager = levelManagerGo.AddComponent<LevelManager>();
+            levelManager.enabled = false;
+            Track(levelManagerGo);
+
+            var teamContainer = Track(new GameObject("DisposeTeam"));
+            var enemiesContainer = Track(new GameObject("DisposeEnemies"));
+            levelManager.InitializeForTest(
+                teamContainer.transform,
+                enemiesContainer.transform,
+                levelDatabase: database);
+
+            var container = new VisualElement();
+            var controller = new StepProgressBarController(container);
+            controller.InitializeForTest(levelManager);
+
+            Assert.AreEqual(3, controller.SphereCount);
+
+            controller.Dispose();
+            levelManager.StartLevel(1);
+
+            Assert.AreEqual(3, controller.SphereCount,
+                "SphereCount should remain 3 after Dispose since OnLevelStarted is unsubscribed.");
+
+            Object.DestroyImmediate(database);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/StepProgressBarControllerTests.cs
+++ b/Assets/Tests/PlayMode/StepProgressBarControllerTests.cs
@@ -157,8 +157,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             controller.Dispose();
             levelManager.StartLevel(1);
 
-            Assert.AreEqual(3, controller.SphereCount,
-                "SphereCount should remain 3 after Dispose since OnLevelStarted is unsubscribed.");
+            Assert.AreEqual(3, controller.SphereCount);
 
             Object.DestroyImmediate(database);
         }

--- a/Assets/Tests/PlayMode/StepProgressBarControllerTests.cs.meta
+++ b/Assets/Tests/PlayMode/StepProgressBarControllerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5f3e472984554e74e915e43b07a3e4de

--- a/Assets/UI Toolkit.meta
+++ b/Assets/UI Toolkit.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a7b5a95de130565408a87fc314316401
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI Toolkit/UnityThemes.meta
+++ b/Assets/UI Toolkit/UnityThemes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b495a8180312a774c9f99ae2a0cf54fe
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss
+++ b/Assets/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss
@@ -1,0 +1,1 @@
+@import url("unity-theme://default");

--- a/Assets/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss.meta
+++ b/Assets/UI Toolkit/UnityThemes/UnityDefaultRuntimeTheme.tss.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8ae2873d5a74b834f94e2ef1de233e62
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12388, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0
+  unsupportedSelectorAction: 0

--- a/Assets/UI/Layouts/MainLayout.uxml
+++ b/Assets/UI/Layouts/MainLayout.uxml
@@ -2,7 +2,23 @@
     <ui:Style src="../Styles/MainStyle.uss" />
     <ui:VisualElement name="root" class="root">
         <ui:VisualElement name="game-area" class="game-area" picking-mode="Ignore">
-            <ui:VisualElement name="screen-default" class="screen-container screen-default" picking-mode="Ignore" />
+            <ui:VisualElement name="screen-default" class="screen-container screen-default" picking-mode="Ignore">
+                <ui:VisualElement name="hud-overlay" picking-mode="Ignore" class="hud-overlay">
+                    <ui:VisualElement name="hud-top-bar" picking-mode="Ignore" class="hud-top-bar">
+                        <ui:VisualElement name="gold-badge" class="gold-badge">
+                            <ui:VisualElement name="gold-icon" class="gold-icon" />
+                            <ui:Label name="gold-label" text="0" class="gold-label" />
+                        </ui:VisualElement>
+                        <ui:VisualElement name="battle-indicator" class="battle-indicator">
+                            <ui:Label name="battle-compact-label" text="1-1" class="battle-compact-label" />
+                        </ui:VisualElement>
+                    </ui:VisualElement>
+                    <ui:VisualElement name="step-progress-container" class="step-progress-container" />
+                    <ui:VisualElement name="announcement-overlay" picking-mode="Ignore" class="announcement-overlay">
+                        <ui:Label name="announcement-label" class="announcement-label" />
+                    </ui:VisualElement>
+                </ui:VisualElement>
+            </ui:VisualElement>
             <ui:VisualElement name="screen-village" class="screen-container hidden">
                 <ui:VisualElement class="screen-placeholder screen-village-bg">
                     <ui:Label text="VILLAGE" class="screen-placeholder-label" />

--- a/Assets/UI/MainPanelSettings.asset
+++ b/Assets/UI/MainPanelSettings.asset
@@ -1,0 +1,52 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19101, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: MainPanelSettings
+  m_EditorClassIdentifier: UnityEngine.dll::UnityEngine.UIElements.PanelSettings
+  themeUss: {fileID: -4733365628477956816, guid: 8ae2873d5a74b834f94e2ef1de233e62, type: 3}
+  m_DisableNoThemeWarning: 0
+  m_TargetTexture: {fileID: 0}
+  m_RenderMode: 0
+  m_ColliderUpdateMode: 0
+  m_ColliderIsTrigger: 1
+  m_ScaleMode: 2
+  m_ReferenceSpritePixelsPerUnit: 100
+  m_PixelsPerUnit: 100
+  m_Scale: 1
+  m_ReferenceDpi: 96
+  m_FallbackDpi: 96
+  m_ReferenceResolution: {x: 1080, y: 1920}
+  m_ScreenMatchMode: 0
+  m_Match: 0.5
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+  m_BindingLogLevel: 0
+  m_ClearDepthStencil: 1
+  m_ClearColor: 0
+  m_ColorClearValue: {r: 0, g: 0, b: 0, a: 0}
+  m_VertexBudget: 0
+  m_TextureSlotCount: 8
+  m_DynamicAtlasSettings:
+    m_MinAtlasSize: 64
+    m_MaxAtlasSize: 4096
+    m_MaxSubTextureSize: 64
+    m_ActiveFilters: 31
+  m_AtlasBlitShader: {fileID: 9101, guid: 0000000000000000f000000000000000, type: 0}
+  m_DefaultShader: {fileID: 9100, guid: 0000000000000000f000000000000000, type: 0}
+  m_RuntimeGaussianBlurShader: {fileID: 20300, guid: 0000000000000000f000000000000000, type: 0}
+  m_RuntimeColorEffectShader: {fileID: 20301, guid: 0000000000000000f000000000000000, type: 0}
+  m_SDFShader: {fileID: 19011, guid: 0000000000000000f000000000000000, type: 0}
+  m_BitmapShader: {fileID: 9001, guid: 0000000000000000f000000000000000, type: 0}
+  m_SpriteShader: {fileID: 19012, guid: 0000000000000000f000000000000000, type: 0}
+  m_ICUDataAsset: {fileID: 0}
+  forceGammaRendering: 0
+  textSettings: {fileID: 0}

--- a/Assets/UI/MainPanelSettings.asset.meta
+++ b/Assets/UI/MainPanelSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 14d9ccb88ef1b36478761c9ea9f314d0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI/Styles/MainStyle.uss
+++ b/Assets/UI/Styles/MainStyle.uss
@@ -6,13 +6,42 @@
     --color-tab-text: #a0a0b0;
     --color-tab-text-active: #ffffff;
     --color-text: #e0e0e0;
+    --color-gold: rgb(255, 215, 0);
     --spacing-xs: 2px;
     --spacing-sm: 4px;
     --spacing-md: 8px;
     --spacing-lg: 16px;
-    --font-size-sm: 12px;
-    --font-size-md: 16px;
-    --font-size-lg: 24px;
+    --font-size-sm: 14px;
+    --font-size-md: 18px;
+    --font-size-lg: 28px;
+    --text-outline-width: 2px;
+    --text-outline-color: rgb(0, 0, 0);
+
+    --nav-height: 10%;
+    --nav-min-height: 80px;
+    --nav-tab-font-size: 28px;
+    --nav-tab-radius: 8px;
+    --nav-tab-margin: 4px;
+
+    --hud-gold-font-size: 36px;
+    --hud-gold-icon-size: 56px;
+    --hud-gold-badge-min-width: 180px;
+    --hud-gold-label-min-width: 90px;
+    --hud-badge-bg: rgba(0, 0, 0, 0.63);
+    --hud-badge-radius: 28px;
+    --hud-battle-font-size: 42px;
+    --hud-battle-margin-top: 80px;
+    --hud-battle-margin-bottom: 16px;
+    --hud-announcement-font-size: 56px;
+    --hud-step-height: 28px;
+    --hud-step-sphere-size: 16px;
+    --hud-step-sphere-special-size: 24px;
+    --hud-step-line-height: 4px;
+    --hud-step-dot-size: 18px;
+    --hud-step-padding: 15%;
+    --hud-step-color-completed: rgb(255, 255, 255);
+    --hud-step-color-current: rgb(100, 149, 237);
+    --hud-step-color-upcoming: rgba(255, 255, 255, 0.3);
 }
 
 .root {
@@ -21,6 +50,9 @@
     width: 100%;
     height: 100%;
     background-color: rgba(0, 0, 0, 0);
+    -unity-font-definition: url("/Assets/Fonts/Bangers.ttf");
+    -unity-text-outline-width: var(--text-outline-width);
+    -unity-text-outline-color: var(--text-outline-color);
 }
 
 .game-area {
@@ -40,18 +72,19 @@
 
 .nav-bar {
     flex-direction: row;
-    height: 8%;
-    min-height: 48px;
+    height: var(--nav-height);
+    min-height: var(--nav-min-height);
     background-color: var(--color-nav-bg);
-    padding: var(--spacing-xs);
+    padding: 0;
 }
 
 .tab-button {
     flex-grow: 1;
-    margin: var(--spacing-xs);
-    border-radius: var(--spacing-sm);
-    font-size: var(--font-size-md);
+    margin: 0;
+    border-radius: 0;
+    font-size: var(--nav-tab-font-size);
     -unity-text-align: middle-center;
+    -unity-font-style: bold;
     border-width: 0;
     transition: background-color 0.2s ease, color 0.2s ease;
 }
@@ -77,7 +110,7 @@
 }
 
 .screen-placeholder-label {
-    font-size: 48px;
+    font-size: var(--hud-announcement-font-size);
     color: #ffffff;
     -unity-font-style: bold;
     -unity-text-align: middle-center;
@@ -110,102 +143,97 @@
     flex-direction: column;
 }
 
-.hud-top-bar {
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    padding-top: 8px;
-    padding-left: 16px;
-    padding-right: 16px;
-}
-
 .gold-badge {
+    position: absolute;
+    right: 8px;
+    top: 8px;
     flex-direction: row;
     align-items: center;
-    background-color: rgba(0, 0, 0, 0.63);
-    border-radius: 16px;
-    padding: 6px 12px;
-    margin-right: 12px;
+    background-color: var(--hud-badge-bg);
+    border-radius: var(--hud-badge-radius);
+    padding: 10px 20px;
+    min-width: var(--hud-gold-badge-min-width);
 }
 
 .gold-icon {
-    width: 24px;
-    height: 24px;
-    background-color: rgb(255, 215, 0);
+    width: var(--hud-gold-icon-size);
+    height: var(--hud-gold-icon-size);
+    background-color: var(--color-gold);
     border-radius: 50%;
 }
 
 .gold-label {
-    font-size: 20px;
-    color: rgb(255, 215, 0);
-    margin-left: 6px;
+    font-size: var(--hud-gold-font-size);
+    color: var(--color-gold);
+    margin-left: 10px;
     -unity-font-style: bold;
-}
-
-.battle-indicator {
-    align-items: center;
+    min-width: var(--hud-gold-label-min-width);
+    -unity-text-align: middle-right;
 }
 
 .battle-compact-label {
-    font-size: 20px;
+    font-size: var(--hud-battle-font-size);
     color: rgb(255, 255, 255);
     -unity-font-style: bold;
+    -unity-text-align: middle-center;
+    margin-top: var(--hud-battle-margin-top);
+    margin-bottom: var(--hud-battle-margin-bottom);
 }
 
 .step-progress-container {
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    height: 20px;
-    margin-top: 8px;
-    padding-left: 32px;
-    padding-right: 32px;
+    height: var(--hud-step-height);
+    margin-top: var(--spacing-md);
+    padding-left: var(--hud-step-padding);
+    padding-right: var(--hud-step-padding);
 }
 
 .step-sphere {
-    width: 12px;
-    height: 12px;
+    width: var(--hud-step-sphere-size);
+    height: var(--hud-step-sphere-size);
     border-radius: 50%;
     transition: background-color 0.2s;
 }
 
 .step-sphere--special {
-    width: 18px;
-    height: 18px;
+    width: var(--hud-step-sphere-special-size);
+    height: var(--hud-step-sphere-special-size);
 }
 
 .step-sphere--completed {
-    background-color: rgb(255, 255, 255);
+    background-color: var(--hud-step-color-completed);
 }
 
 .step-sphere--current {
-    background-color: rgb(100, 149, 237);
+    background-color: var(--hud-step-color-current);
 }
 
 .step-sphere--upcoming {
-    background-color: rgba(255, 255, 255, 0.3);
+    background-color: var(--hud-step-color-upcoming);
 }
 
 .step-line {
     flex-grow: 1;
-    height: 3px;
+    height: var(--hud-step-line-height);
     min-width: 4px;
 }
 
 .step-line--completed {
-    background-color: rgb(255, 255, 255);
+    background-color: var(--hud-step-color-completed);
 }
 
 .step-line--upcoming {
-    background-color: rgba(255, 255, 255, 0.3);
+    background-color: var(--hud-step-color-upcoming);
 }
 
 .step-scroll-dot {
     position: absolute;
-    width: 14px;
-    height: 14px;
+    width: var(--hud-step-dot-size);
+    height: var(--hud-step-dot-size);
     border-radius: 50%;
-    background-color: rgb(100, 149, 237);
+    background-color: var(--hud-step-color-current);
     display: none;
 }
 
@@ -224,7 +252,7 @@
 }
 
 .announcement-label {
-    font-size: 48px;
+    font-size: var(--hud-announcement-font-size);
     -unity-font-style: bold;
     color: rgb(255, 255, 255);
 }

--- a/Assets/UI/Styles/MainStyle.uss
+++ b/Assets/UI/Styles/MainStyle.uss
@@ -102,3 +102,129 @@
 .screen-shop-bg {
     background-color: rgba(233, 196, 106, 220);
 }
+
+.hud-overlay {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    flex-direction: column;
+}
+
+.hud-top-bar {
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding-top: 8px;
+    padding-left: 16px;
+    padding-right: 16px;
+}
+
+.gold-badge {
+    flex-direction: row;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.63);
+    border-radius: 16px;
+    padding: 6px 12px;
+    margin-right: 12px;
+}
+
+.gold-icon {
+    width: 24px;
+    height: 24px;
+    background-color: rgb(255, 215, 0);
+    border-radius: 50%;
+}
+
+.gold-label {
+    font-size: 20px;
+    color: rgb(255, 215, 0);
+    margin-left: 6px;
+    -unity-font-style: bold;
+}
+
+.battle-indicator {
+    align-items: center;
+}
+
+.battle-compact-label {
+    font-size: 20px;
+    color: rgb(255, 255, 255);
+    -unity-font-style: bold;
+}
+
+.step-progress-container {
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    height: 20px;
+    margin-top: 8px;
+    padding-left: 32px;
+    padding-right: 32px;
+}
+
+.step-sphere {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    transition: background-color 0.2s;
+}
+
+.step-sphere--special {
+    width: 18px;
+    height: 18px;
+}
+
+.step-sphere--completed {
+    background-color: rgb(255, 255, 255);
+}
+
+.step-sphere--current {
+    background-color: rgb(100, 149, 237);
+}
+
+.step-sphere--upcoming {
+    background-color: rgba(255, 255, 255, 0.3);
+}
+
+.step-line {
+    flex-grow: 1;
+    height: 3px;
+    min-width: 4px;
+}
+
+.step-line--completed {
+    background-color: rgb(255, 255, 255);
+}
+
+.step-line--upcoming {
+    background-color: rgba(255, 255, 255, 0.3);
+}
+
+.step-scroll-dot {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background-color: rgb(100, 149, 237);
+    display: none;
+}
+
+.announcement-overlay {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    display: none;
+}
+
+.announcement-overlay--visible {
+    display: flex;
+}
+
+.announcement-label {
+    font-size: 48px;
+    -unity-font-style: bold;
+    color: rgb(255, 255, 255);
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,10 +176,14 @@ Assets/
         Village/
           VillageScreen.cs
       Toolkit/
+        BattleIndicatorController.cs
+        CombatHudController.cs
+        GoldBadgeController.cs
         IScreen.cs
         NavigationHost.cs
         NavigationManager.cs
         ScreenStack.cs
+        StepProgressBarController.cs
       Widgets/
         AllyStatsPanel.cs
         BattleIndicatorBadge.cs
@@ -238,6 +242,7 @@ Assets/
       AllyStatsPanelTests.cs
       AnimationEventRelayTests.cs
       BattleIndicatorBadgeTests.cs
+      BattleIndicatorControllerTests.cs
       CanvasFactoryTests.cs
       CharacterAppearanceTests.cs
       CharacterMoverTests.cs
@@ -251,6 +256,7 @@ Assets/
       DamageNumberTests.cs
       FormationRecalculationTests.cs
       GameBootstrapTests.cs
+      GoldBadgeControllerTests.cs
       GoldHudBadgeTests.cs
       GoldWalletTests.cs
       HealthBarTrailTests.cs
@@ -269,6 +275,7 @@ Assets/
       SkillTreeNodeManagerTests.cs
       SkillTreeNodeTests.cs
       SkillTreeScreenTests.cs
+      StepProgressBarControllerTests.cs
       StepProgressBarTests.cs
       UIScreenTests.cs
       UnitSelectionManagerTests.cs
@@ -278,7 +285,11 @@ Assets/
   UI/
     Layouts/
       MainLayout.uxml
+    MainPanelSettings.asset
     Styles/
       MainStyle.uss
+  UI Toolkit/
+    UnityThemes/
+      UnityDefaultRuntimeTheme.tss
 
 ProjectSettings/  (Unity defaults)


### PR DESCRIPTION
## Summary
- Removed padding from nav-bar, margin and border-radius from tab buttons
- Tabs now fill the bar edge-to-edge with zero gaps

Closes #181

## Test plan
- [x] Tabs flush against screen edges and each other
- [x] No rounded corners on tabs