### PR TITLE
chore(agents): forbid git ops in test-play + zero manual steps

### DIFF
--- a/.claude/agents/dev-ux-toolkit.md
+++ b/.claude/agents/dev-ux-toolkit.md
@@ -396,6 +396,51 @@ public void SkillTreeScreen_UXML_HasRequiredElements()
 }
 ```
 
+## Zero Manual Editor Steps — Scene-Dependent Components MUST Self-Attach
+
+**CRITICAL RULE (see `feedback_zero_manual_steps.md`):** The user must NEVER have to open Unity to attach a component, assign a reference, or click a menu just to make existing scenes work with a new feature. The only acceptable user actions are: (1) pressing Play to test, (2) clicking a setup menu item ONCE for a brand-new scene that doesn't exist yet.
+
+### When You Introduce a New MonoBehaviour That Needs to Be on a Specific GameObject
+
+If the component must live on something that already exists in a committed scene (e.g., `Main Camera` in `NewGameScene.unity`, a `CombatWorld` root, a `UIDocument` GameObject), you MUST pick ONE of these options — NEVER ask the user to "run the setup menu" or "add the component in the Inspector":
+
+**Option A — Runtime auto-attach (preferred for behavior components):**
+```csharp
+public class CameraViewportFitter : MonoBehaviour
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void AutoAttach()
+    {
+        var cam = Camera.main;
+        if (cam == null) return;
+        if (cam.GetComponent<CameraViewportFitter>() == null)
+            cam.gameObject.AddComponent<CameraViewportFitter>();
+    }
+}
+```
+Use `RuntimeInitializeLoadType.AfterSceneLoad` (or `BeforeSceneLoad` if the component must exist before Awake of other scripts). Always guard with a null check and a duplicate-attach check.
+
+**Option B — Attach from an existing bootstrap:**
+If `GameBootstrap.Initialize` or another already-running Awake in the scene is the natural place, add the attach there. Do not create a new bootstrap just for this — reuse existing ones.
+
+**Option C — Edit the scene YAML directly:**
+If the component has serialized fields that MUST be set at author time (not runtime), edit `Assets/Scenes/*.unity` YAML to add the component block to the target GameObject. Read the scene first to find the right fileID, then append the new MonoBehaviour block and reference it in the target GameObject's `m_Component` list. Also update any related prefabs.
+
+### FORBIDDEN Final-Note Patterns
+
+Never end a task with any of these:
+- "Manual step required: run `Roguelite/Setup > X` menu on the existing scene."
+- "Add the component in the Inspector on the Main Camera."
+- "Drag the reference into the field manually."
+- "Open the scene and assign..."
+- "You'll need to reconfigure the existing scene in the editor."
+
+If you catch yourself about to write one of these, STOP — the task is not complete. Pick Option A, B, or C above instead.
+
+### Editor Setup Scripts Are for New Scenes Only
+
+`[MenuItem("Roguelite/Setup ...")]` scripts are valid for **bootstrapping a brand-new scene from scratch**. They are NOT a substitute for making existing scenes self-heal. If an existing scene needs a new component, runtime auto-attach or YAML edit — the setup menu script is a bonus for new scenes, never a requirement for existing ones.
+
 ## Unity Asset YAML Editing
 
 You can directly edit Unity asset files serialized as text YAML:
@@ -425,6 +470,7 @@ Rules:
 - **2D only** — SpriteRenderer, Collider2D, Rigidbody2D for world objects
 - **Always set sortingLayerName** on SpriteRenderers (never leave on "Default")
 - **Auto-wire everything** — never leave references for user to assign manually
+- **Zero manual Editor steps on existing scenes** — new scene-dependent components MUST self-attach via `RuntimeInitializeOnLoadMethod`, an existing bootstrap Awake, or direct scene-YAML edit. NEVER end a task asking the user to run a setup menu or Inspector-add a component on a scene that already exists.
 - **Always use `Undo`** — RegisterCreatedObjectUndo, DestroyObjectImmediate
 - **Always `MarkSceneDirty`** after scene modifications
 - **Use `FindFirstObjectByType<T>(FindObjectsInactive.Include)`** for finding existing objects

--- a/.claude/agents/test-play-unity.md
+++ b/.claude/agents/test-play-unity.md
@@ -339,23 +339,34 @@ Unity Editor locks the main project directory when open, which prevents batch-mo
 | **Main project** (Editor open here) | `C:/Users/donic/RiderProjects/Roguelite-2D` |
 | **Test worktree** (batch mode runs here) | `C:/Users/donic/RiderProjects/Roguelite-2D-tests` |
 
-**The worktree only sees committed and pushed code.** Before running any tests, you MUST ensure:
-1. All changes are **committed** on the current branch
-2. The branch is **pushed** to origin
-3. The worktree is **synced** to the latest pushed code
+**The worktree only sees committed and pushed code.** Before running any tests, the branch MUST be:
+1. **Committed** on the current branch
+2. **Pushed** to origin
+3. **Synced** to the latest pushed code in the worktree (read-only sync — `git fetch` + `git checkout` + `git reset --hard` in the worktree path only)
 
-### Syncing the worktree
+### CRITICAL — NEVER Run Git Operations on the Main Project
 
-Before every test run, execute this to sync the worktree with the current branch:
+**You are FORBIDDEN from running any of the following on `C:/Users/donic/RiderProjects/Roguelite-2D` (the main project):**
+- `git add`, `git commit`, `git stash`, `git push`, `git pull`, `git merge`, `git rebase`, `git reset`, `git checkout` (branch switch)
+- `gh pr create`, `gh pr merge`, `gh pr edit`, any `gh` command that mutates remote state
+
+**If the main project has uncommitted changes blocking the test run, STOP and hand off to the lead. Do NOT commit, do NOT push, do NOT stash.** Report clearly: "Uncommitted changes in main project prevent worktree sync — handing off to `git-unity` (via lead) for commit + push before I can run tests." Then exit.
+
+**Why:** Git state is owned exclusively by the `git-unity` agent and the lead orchestrator. The user follows a strict "commit → wait for OK → push → PR" cycle (see `feedback_no_push_before_ok.md`). A test agent pushing on its own initiative violates this cycle even when the push would technically be allowed by branch protection (`feedback_push_permissions.md` describes what branch protection permits, NOT what agents may do on their own).
+
+### Syncing the worktree (READ-ONLY operations, worktree path only)
+
+These are the ONLY git commands you are permitted to run, and ONLY against the worktree path:
 ```bash
 cd "C:/Users/donic/RiderProjects/Roguelite-2D-tests" && git fetch origin && git checkout <branch> && git reset --hard origin/<branch>
 ```
 Replace `<branch>` with the current feature branch name (e.g., `feature/12-combat-flow`).
 
-To find the current branch name from the main project:
+To find the current branch name from the main project (read-only):
 ```bash
 git -C "C:/Users/donic/RiderProjects/Roguelite-2D" branch --show-current
 ```
+`git -C <main> status` and `git -C <main> log` are also allowed (read-only inspection). Anything that mutates main-project git state is forbidden.
 
 ## Running Tests — MANDATORY
 
@@ -372,7 +383,7 @@ git -C "C:/Users/donic/RiderProjects/Roguelite-2D" branch --show-current
 
 - **Exit code 0** = all passed. **Exit code 2** = some failed.
 - Parse the XML results file to report pass/fail counts and failure details.
-- If tests fail, fix the code **in the main project**, commit, push, sync worktree, and re-run until all pass.
+- If tests fail, fix the code **in the main project** (edit files only). **Do NOT run `git commit` / `git push` yourself** — stop and hand off to the lead for commit + push via `git-unity`, then the lead re-invokes you to re-sync the worktree and re-run.
 - **Important:** The worktree eliminates the "Unity already open" problem for the main project. If batch mode still fails, check that no other Unity instance has the worktree path open.
 
 ## When Invoked
@@ -489,3 +500,4 @@ Tests verify that the app behaves correctly. The goal is that **the final test s
 - **Mock the server** — never hit a real API in Play Mode tests
 - **Use fake accounts** — always set up test data via TestAccountFactory, never rely on persistent state
 - **Test at multiple progression levels** — a feature should work for new players AND end-game players
+- **NO GIT MUTATIONS** — `git-unity` owns git. You may only run `git fetch`, `git checkout`, `git reset --hard origin/<branch>` on the **worktree path**, plus read-only inspection (`status`, `log`, `branch --show-current`) on the main project. Anything else (`add`, `commit`, `push`, `stash`, `merge`, `gh pr ...`) is forbidden — stop and hand off.


### PR DESCRIPTION
## Summary
- test-play-unity: forbid `git add/commit/push/stash/merge/rebase/reset`, branch switching, and mutating `gh` commands. Clarify that `feedback_push_permissions` describes branch-protection scope, not agent authority.
- dev-ux-toolkit: zero manual Editor steps on existing scenes — MUST self-attach via RuntimeInitializeOnLoadMethod, bootstrap Awake, or direct scene-YAML edit. Explicit forbidden-phrase list for final notes.

Surfaced during #182 / PR #193 iterations.

Closes #194

Generated with [Claude Code](https://claude.com/claude-code)