### PR TITLE
feat(anchors,ground): add ScreenAnchor world offset + procedural ground fallback (#191)

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -5196,7 +5196,7 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier: Assembly-CSharp::RogueliteAutoBattler.Combat.ScreenAnchor
   _viewportPosition: {x: 0.12, y: 0.676}
-  _worldOffset: {x: 0, y: 0.5}
+  _worldOffset: {x: 0, y: 0.25}
 --- !u!4 &387240915
 Transform:
   m_ObjectHideFlags: 0
@@ -5344,7 +5344,7 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier: Assembly-CSharp::RogueliteAutoBattler.Combat.ScreenAnchor
   _viewportPosition: {x: 0.88, y: 0.676}
-  _worldOffset: {x: 0, y: 0.5}
+  _worldOffset: {x: 0, y: 0.25}
 --- !u!4 &395737495
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -5193,9 +5193,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: Assembly-CSharp::RogueliteAutoBattler.Combat.ScreenAnchor
   _viewportPosition: {x: 0.12, y: 0.63}
+  _worldOffset: {x: 0, y: 0.5}
 --- !u!4 &387240915
 Transform:
   m_ObjectHideFlags: 0
@@ -5340,9 +5341,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: Assembly-CSharp::RogueliteAutoBattler.Combat.ScreenAnchor
   _viewportPosition: {x: 0.88, y: 0.63}
+  _worldOffset: {x: 0, y: 0.5}
 --- !u!4 &395737495
 Transform:
   m_ObjectHideFlags: 0
@@ -12504,9 +12506,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: Assembly-CSharp::RogueliteAutoBattler.Combat.ScreenAnchor
   _viewportPosition: {x: 1, y: 0.5}
+  _worldOffset: {x: 0, y: 0}
 --- !u!4 &1337846300
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -5195,7 +5195,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
   m_Name:
   m_EditorClassIdentifier: Assembly-CSharp::RogueliteAutoBattler.Combat.ScreenAnchor
-  _viewportPosition: {x: 0.12, y: 0.63}
+  _viewportPosition: {x: 0.12, y: 0.676}
   _worldOffset: {x: 0, y: 0.5}
 --- !u!4 &387240915
 Transform:
@@ -5343,7 +5343,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
   m_Name:
   m_EditorClassIdentifier: Assembly-CSharp::RogueliteAutoBattler.Combat.ScreenAnchor
-  _viewportPosition: {x: 0.88, y: 0.63}
+  _viewportPosition: {x: 0.88, y: 0.676}
   _worldOffset: {x: 0, y: 0.5}
 --- !u!4 &395737495
 Transform:

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -5196,7 +5196,7 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier: Assembly-CSharp::RogueliteAutoBattler.Combat.ScreenAnchor
   _viewportPosition: {x: 0.12, y: 0.676}
-  _worldOffset: {x: 0, y: 0.25}
+  _worldOffset: {x: 0, y: 0}
 --- !u!4 &387240915
 Transform:
   m_ObjectHideFlags: 0
@@ -5344,7 +5344,7 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier: Assembly-CSharp::RogueliteAutoBattler.Combat.ScreenAnchor
   _viewportPosition: {x: 0.88, y: 0.676}
-  _worldOffset: {x: 0, y: 0.25}
+  _worldOffset: {x: 0, y: 0}
 --- !u!4 &395737495
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/NewGameScene.unity
+++ b/Assets/Scenes/NewGameScene.unity
@@ -148,7 +148,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
   m_Name:
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
-  _viewportPosition: {x: 0.88, y: 0.63}
+  _viewportPosition: {x: 0.88, y: 0.676}
   _worldOffset: {x: 0, y: 0.5}
 --- !u!4 &42668107
 Transform:
@@ -312,7 +312,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
   m_Name:
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
-  _viewportPosition: {x: 0.12, y: 0.63}
+  _viewportPosition: {x: 0.12, y: 0.676}
   _worldOffset: {x: 0, y: 0.5}
 --- !u!4 &538497906
 Transform:

--- a/Assets/Scenes/NewGameScene.unity
+++ b/Assets/Scenes/NewGameScene.unity
@@ -146,9 +146,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
-  _viewportPosition: {x: 0.88, y: 0.676}
+  _viewportPosition: {x: 0.88, y: 0.63}
+  _worldOffset: {x: 0, y: 0.5}
 --- !u!4 &42668107
 Transform:
   m_ObjectHideFlags: 0
@@ -309,9 +310,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
-  _viewportPosition: {x: 0.12, y: 0.676}
+  _viewportPosition: {x: 0.12, y: 0.63}
+  _worldOffset: {x: 0, y: 0.5}
 --- !u!4 &538497906
 Transform:
   m_ObjectHideFlags: 0
@@ -853,9 +855,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
   _viewportPosition: {x: 1, y: 0.5}
+  _worldOffset: {x: 0, y: 0}
 --- !u!4 &1805464535
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/NewGameScene.unity
+++ b/Assets/Scenes/NewGameScene.unity
@@ -149,7 +149,7 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
   _viewportPosition: {x: 0.88, y: 0.676}
-  _worldOffset: {x: 0, y: 0.5}
+  _worldOffset: {x: 0, y: 0.25}
 --- !u!4 &42668107
 Transform:
   m_ObjectHideFlags: 0
@@ -313,7 +313,7 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
   _viewportPosition: {x: 0.12, y: 0.676}
-  _worldOffset: {x: 0, y: 0.5}
+  _worldOffset: {x: 0, y: 0.25}
 --- !u!4 &538497906
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/NewGameScene.unity
+++ b/Assets/Scenes/NewGameScene.unity
@@ -149,7 +149,7 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
   _viewportPosition: {x: 0.88, y: 0.676}
-  _worldOffset: {x: 0, y: 0.25}
+  _worldOffset: {x: 0, y: 0}
 --- !u!4 &42668107
 Transform:
   m_ObjectHideFlags: 0
@@ -313,7 +313,7 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
   _viewportPosition: {x: 0.12, y: 0.676}
-  _worldOffset: {x: 0, y: 0.25}
+  _worldOffset: {x: 0, y: 0}
 --- !u!4 &538497906
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Combat/Environment/ScreenAnchor.cs
+++ b/Assets/Scripts/Combat/Environment/ScreenAnchor.cs
@@ -5,6 +5,7 @@ namespace RogueliteAutoBattler.Combat.Environment
     public class ScreenAnchor : MonoBehaviour
     {
         [SerializeField] private Vector2 _viewportPosition = new Vector2(0.5f, 0.5f);
+        [SerializeField] private Vector2 _worldOffset = Vector2.zero;
 
         private Camera _camera;
         private float _lastOrthoSize;
@@ -37,7 +38,7 @@ namespace RogueliteAutoBattler.Combat.Environment
         private void UpdatePosition()
         {
             Vector3 worldPos = _camera.ViewportToWorldPoint(new Vector3(_viewportPosition.x, _viewportPosition.y, 0f));
-            transform.position = new Vector3(worldPos.x, worldPos.y, 0f);
+            transform.position = new Vector3(worldPos.x + _worldOffset.x, worldPos.y + _worldOffset.y, 0f);
             _lastOrthoSize = _camera.orthographicSize;
             _lastAspect = _camera.aspect;
         }

--- a/Assets/Scripts/Combat/Levels/LevelManager.cs
+++ b/Assets/Scripts/Combat/Levels/LevelManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using RogueliteAutoBattler.Combat.Core;
 using RogueliteAutoBattler.Combat.Environment;
+using RogueliteAutoBattler.Combat.Visuals;
 using RogueliteAutoBattler.Data;
 using RogueliteAutoBattler.Economy;
 using UnityEngine;
@@ -185,11 +186,14 @@ namespace RogueliteAutoBattler.Combat.Levels
             var stage = _levelDatabase.Stages[stageIndex];
             _currentStageIndex = stageIndex;
 
-            if (stage.Terrain != null && _groundRenderer != null)
+            if (_groundRenderer != null)
             {
-                _groundRenderer.sprite = stage.Terrain;
+                Sprite terrainSprite = stage.Terrain != null
+                    ? stage.Terrain
+                    : ProceduralGroundSprite.GetOrCreate();
+                _groundRenderer.sprite = terrainSprite;
 #if UNITY_EDITOR
-                Debug.Log($"[{nameof(LevelManager)}] Applied terrain '{stage.Terrain.name}' for stage '{stage.StageName}'");
+                Debug.Log($"[{nameof(LevelManager)}] Applied terrain for stage '{stage.StageName}': {(stage.Terrain != null ? stage.Terrain.name : "procedural fallback")}");
 #endif
             }
 

--- a/Assets/Scripts/Combat/Visuals/ProceduralGroundSprite.cs
+++ b/Assets/Scripts/Combat/Visuals/ProceduralGroundSprite.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Combat.Visuals
+{
+    public static class ProceduralGroundSprite
+    {
+        public const int TextureSize = 64;
+        public const int CellSize = 8;
+        public const int PixelsPerUnit = 64;
+
+        public static readonly Color32 ColorA = new Color32(45, 90, 39, 255);
+        public static readonly Color32 ColorB = new Color32(61, 122, 55, 255);
+
+        private static Sprite _cached;
+        private static Texture2D _cachedTexture;
+
+        public static Sprite GetOrCreate()
+        {
+            if (_cached != null)
+                return _cached;
+
+            var texture = new Texture2D(TextureSize, TextureSize, TextureFormat.RGBA32, false)
+            {
+                filterMode = FilterMode.Point,
+                wrapMode = TextureWrapMode.Repeat
+            };
+
+            var pixels = new Color32[TextureSize * TextureSize];
+            for (int y = 0; y < TextureSize; y++)
+            {
+                for (int x = 0; x < TextureSize; x++)
+                {
+                    int cellX = x / CellSize;
+                    int cellY = y / CellSize;
+                    pixels[y * TextureSize + x] = ((cellX + cellY) % 2 == 0) ? ColorA : ColorB;
+                }
+            }
+
+            texture.SetPixels32(pixels);
+            texture.Apply();
+
+            _cachedTexture = texture;
+            _cached = Sprite.Create(
+                texture,
+                new Rect(0f, 0f, TextureSize, TextureSize),
+                new Vector2(0.5f, 0.5f),
+                PixelsPerUnit,
+                0,
+                SpriteMeshType.FullRect);
+
+            return _cached;
+        }
+
+        internal static void ResetCacheForTests()
+        {
+            if (_cached != null)
+            {
+                if (Application.isPlaying)
+                    Object.Destroy(_cached);
+                else
+                    Object.DestroyImmediate(_cached);
+                _cached = null;
+            }
+
+            if (_cachedTexture != null)
+            {
+                if (Application.isPlaying)
+                    Object.Destroy(_cachedTexture);
+                else
+                    Object.DestroyImmediate(_cachedTexture);
+                _cachedTexture = null;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Combat/Visuals/ProceduralGroundSprite.cs.meta
+++ b/Assets/Scripts/Combat/Visuals/ProceduralGroundSprite.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 61f970fa7ab07e04bbacca6a6d92b457

--- a/Assets/Scripts/Editor/Builders/CombatWorldBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/CombatWorldBuilder.cs
@@ -23,6 +23,8 @@ namespace RogueliteAutoBattler.Editor
         private const float EditorGroundY = 2.16f;
         private const float EditorGroundHeight = 6.48f;
 
+        private const float HomeAnchorWorldOffsetY = 0.5f;
+
         private const string WeaponSpritesFolder = "Assets/Sprites/Items/melee weapons";
         private const string HatSpritesFolder    = "Assets/Sprites/Items/Wardrobe/cloth";
         private const string ShieldSpritePath    = "Assets/Sprites/Items/melee weapons/shield.png";
@@ -36,12 +38,6 @@ namespace RogueliteAutoBattler.Editor
         };
 
         private const string GridSpritePath = "Assets/Sprites/Environment/grid_ground.png";
-        private const int GridTextureSize = 64;
-        private const int GridCellSize = 8;
-        private const int GridPixelsPerUnit = 64;
-
-        private static readonly Color32 GridColorA = new Color32(45, 90, 39, 255);
-        private static readonly Color32 GridColorB = new Color32(61, 122, 55, 255);
 
         internal static Camera ConfigureMainCamera()
         {
@@ -162,8 +158,8 @@ namespace RogueliteAutoBattler.Editor
             if (levelDb != null)
                 EditorUIFactory.SetObj(soLevelManager, "_levelDatabase", levelDb);
 
-            var teamAnchor = FindOrCreateHomeAnchor(CombatSetupHelper.TeamHomeAnchorName, new Vector2(0.12f, 0.63f));
-            var enemiesAnchor = FindOrCreateHomeAnchor(CombatSetupHelper.EnemiesHomeAnchorName, new Vector2(0.88f, 0.63f));
+            var teamAnchor = FindOrCreateHomeAnchor(CombatSetupHelper.TeamHomeAnchorName, new Vector2(0.12f, 0.63f), new Vector2(0f, HomeAnchorWorldOffsetY));
+            var enemiesAnchor = FindOrCreateHomeAnchor(CombatSetupHelper.EnemiesHomeAnchorName, new Vector2(0.88f, 0.63f), new Vector2(0f, HomeAnchorWorldOffsetY));
             var combatTrigger = FindOrCreateHomeAnchor(CombatSetupHelper.CombatTriggerZoneName, new Vector2(1f, 0.5f));
 
             EditorUIFactory.SetObj(soSpawnManager, "_teamHomeAnchor", teamAnchor);
@@ -256,7 +252,7 @@ namespace RogueliteAutoBattler.Editor
                 prop.GetArrayElementAtIndex(i).objectReferenceValue = sprites[i];
         }
 
-        private static Transform FindOrCreateHomeAnchor(string anchorName, Vector2 viewportPosition)
+        private static Transform FindOrCreateHomeAnchor(string anchorName, Vector2 viewportPosition, Vector2 worldOffset = default)
         {
             var existing = GameObject.Find(anchorName);
             if (existing != null)
@@ -267,6 +263,7 @@ namespace RogueliteAutoBattler.Editor
                     Undo.RecordObject(existingAnchor, $"Update {anchorName}");
                     var so = new SerializedObject(existingAnchor);
                     so.FindProperty("_viewportPosition").vector2Value = viewportPosition;
+                    so.FindProperty("_worldOffset").vector2Value = worldOffset;
                     so.ApplyModifiedProperties();
                 }
                 return existing.transform;
@@ -279,6 +276,7 @@ namespace RogueliteAutoBattler.Editor
             var anchor = go.AddComponent<ScreenAnchor>();
             var so2 = new SerializedObject(anchor);
             so2.FindProperty("_viewportPosition").vector2Value = viewportPosition;
+            so2.FindProperty("_worldOffset").vector2Value = worldOffset;
             so2.ApplyModifiedProperties();
 
             return go.transform;
@@ -286,10 +284,10 @@ namespace RogueliteAutoBattler.Editor
 
         private static Sprite CreateOrLoadGridSprite()
         {
-            return CreateOrLoadCheckerboardSprite(GridSpritePath, GridColorA, GridColorB);
+            return CreateOrLoadCheckerboardSprite(GridSpritePath);
         }
 
-        private static Sprite CreateOrLoadCheckerboardSprite(string path, Color32 colorA, Color32 colorB)
+        private static Sprite CreateOrLoadCheckerboardSprite(string path)
         {
             Sprite existing = AssetDatabase.LoadAssetAtPath<Sprite>(path);
             if (existing != null)
@@ -297,16 +295,16 @@ namespace RogueliteAutoBattler.Editor
 
             EditorUIFactory.EnsureDirectoryExists(path);
 
-            var tex = new Texture2D(GridTextureSize, GridTextureSize, TextureFormat.RGBA32, false);
-            var pixels = new Color32[GridTextureSize * GridTextureSize];
+            var tex = new Texture2D(ProceduralGroundSprite.TextureSize, ProceduralGroundSprite.TextureSize, TextureFormat.RGBA32, false);
+            var pixels = new Color32[ProceduralGroundSprite.TextureSize * ProceduralGroundSprite.TextureSize];
 
-            for (int y = 0; y < GridTextureSize; y++)
+            for (int y = 0; y < ProceduralGroundSprite.TextureSize; y++)
             {
-                for (int x = 0; x < GridTextureSize; x++)
+                for (int x = 0; x < ProceduralGroundSprite.TextureSize; x++)
                 {
-                    int cellX = x / GridCellSize;
-                    int cellY = y / GridCellSize;
-                    pixels[y * GridTextureSize + x] = ((cellX + cellY) % 2 == 0) ? colorA : colorB;
+                    int cellX = x / ProceduralGroundSprite.CellSize;
+                    int cellY = y / ProceduralGroundSprite.CellSize;
+                    pixels[y * ProceduralGroundSprite.TextureSize + x] = ((cellX + cellY) % 2 == 0) ? ProceduralGroundSprite.ColorA : ProceduralGroundSprite.ColorB;
                 }
             }
 
@@ -323,7 +321,7 @@ namespace RogueliteAutoBattler.Editor
             {
                 importer.textureType = TextureImporterType.Sprite;
                 importer.spriteImportMode = SpriteImportMode.Single;
-                importer.spritePixelsPerUnit = GridPixelsPerUnit;
+                importer.spritePixelsPerUnit = ProceduralGroundSprite.PixelsPerUnit;
                 importer.filterMode = FilterMode.Point;
                 importer.wrapMode = TextureWrapMode.Repeat;
                 importer.textureCompression = TextureImporterCompression.Uncompressed;

--- a/Assets/Scripts/Editor/Builders/CombatWorldBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/CombatWorldBuilder.cs
@@ -158,8 +158,8 @@ namespace RogueliteAutoBattler.Editor
             if (levelDb != null)
                 EditorUIFactory.SetObj(soLevelManager, "_levelDatabase", levelDb);
 
-            var teamAnchor = FindOrCreateHomeAnchor(CombatSetupHelper.TeamHomeAnchorName, new Vector2(0.12f, 0.63f), new Vector2(0f, HomeAnchorWorldOffsetY));
-            var enemiesAnchor = FindOrCreateHomeAnchor(CombatSetupHelper.EnemiesHomeAnchorName, new Vector2(0.88f, 0.63f), new Vector2(0f, HomeAnchorWorldOffsetY));
+            var teamAnchor = FindOrCreateHomeAnchor(CombatSetupHelper.TeamHomeAnchorName, new Vector2(0.12f, 0.676f), new Vector2(0f, HomeAnchorWorldOffsetY));
+            var enemiesAnchor = FindOrCreateHomeAnchor(CombatSetupHelper.EnemiesHomeAnchorName, new Vector2(0.88f, 0.676f), new Vector2(0f, HomeAnchorWorldOffsetY));
             var combatTrigger = FindOrCreateHomeAnchor(CombatSetupHelper.CombatTriggerZoneName, new Vector2(1f, 0.5f));
 
             EditorUIFactory.SetObj(soSpawnManager, "_teamHomeAnchor", teamAnchor);

--- a/Assets/Scripts/Editor/Builders/CombatWorldBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/CombatWorldBuilder.cs
@@ -23,7 +23,7 @@ namespace RogueliteAutoBattler.Editor
         private const float EditorGroundY = 2.16f;
         private const float EditorGroundHeight = 6.48f;
 
-        private const float HomeAnchorWorldOffsetY = 0.25f;
+        private const float HomeAnchorWorldOffsetY = 0f;
 
         private const string WeaponSpritesFolder = "Assets/Sprites/Items/melee weapons";
         private const string HatSpritesFolder    = "Assets/Sprites/Items/Wardrobe/cloth";

--- a/Assets/Scripts/Editor/Builders/CombatWorldBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/CombatWorldBuilder.cs
@@ -23,7 +23,7 @@ namespace RogueliteAutoBattler.Editor
         private const float EditorGroundY = 2.16f;
         private const float EditorGroundHeight = 6.48f;
 
-        private const float HomeAnchorWorldOffsetY = 0.5f;
+        private const float HomeAnchorWorldOffsetY = 0.25f;
 
         private const string WeaponSpritesFolder = "Assets/Sprites/Items/melee weapons";
         private const string HatSpritesFolder    = "Assets/Sprites/Items/Wardrobe/cloth";

--- a/Assets/Scripts/Editor/Windows/LevelDesignerTab.cs
+++ b/Assets/Scripts/Editor/Windows/LevelDesignerTab.cs
@@ -184,8 +184,6 @@ namespace RogueliteAutoBattler.Editor
                     stagesProp.arraySize++;
                     var newStage = stagesProp.GetArrayElementAtIndex(stagesProp.arraySize - 1);
                     newStage.FindPropertyRelative("stageName").stringValue = $"Stage {stagesProp.arraySize}";
-                    var defaultTerrain = AssetDatabase.LoadAssetAtPath<Sprite>("Assets/Sprites/Environment/grid_ground.png");
-                    newStage.FindPropertyRelative("terrain").objectReferenceValue = defaultTerrain;
                     newStage.FindPropertyRelative("levels").arraySize = 0;
                     _levelSelectedStageIndex = stagesProp.arraySize - 1;
                     _levelSelectedLevelIndex = -1;

--- a/Assets/Tests/EditMode/ProceduralGroundSpriteTests.cs
+++ b/Assets/Tests/EditMode/ProceduralGroundSpriteTests.cs
@@ -1,0 +1,96 @@
+using System.Reflection;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Visuals;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    [TestFixture]
+    public class ProceduralGroundSpriteTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            InvokeResetCacheForTests();
+        }
+
+        [Test]
+        public void GetOrCreate_ReturnsNonNullSprite()
+        {
+            Sprite sprite = ProceduralGroundSprite.GetOrCreate();
+
+            Assert.IsNotNull(sprite, "GetOrCreate should return a non-null sprite.");
+            Assert.IsNotNull(sprite.texture, "Returned sprite must have a texture.");
+        }
+
+        [Test]
+        public void GetOrCreate_ReturnsSameInstanceOnSecondCall()
+        {
+            Sprite first = ProceduralGroundSprite.GetOrCreate();
+            Sprite second = ProceduralGroundSprite.GetOrCreate();
+
+            Assert.AreSame(first, second,
+                "GetOrCreate should cache and return the same Sprite instance on repeated calls.");
+            Assert.AreSame(first.texture, second.texture,
+                "Cached Sprite's backing Texture2D should also be the same instance.");
+        }
+
+        [Test]
+        public void GetOrCreate_TextureIsCorrectSize()
+        {
+            Sprite sprite = ProceduralGroundSprite.GetOrCreate();
+
+            Assert.AreEqual(ProceduralGroundSprite.TextureSize, sprite.texture.width,
+                "Procedural ground texture width must equal TextureSize.");
+            Assert.AreEqual(ProceduralGroundSprite.TextureSize, sprite.texture.height,
+                "Procedural ground texture height must equal TextureSize.");
+        }
+
+        [Test]
+        public void GetOrCreate_CheckerboardAlternates()
+        {
+            Sprite sprite = ProceduralGroundSprite.GetOrCreate();
+            Color32[] pixels = sprite.texture.GetPixels32();
+
+            Color32 colorAt00 = SampleAt(pixels, 0, 0);
+            Color32 colorAtCellSize0 = SampleAt(pixels, ProceduralGroundSprite.CellSize, 0);
+            Color32 colorAt0CellSize = SampleAt(pixels, 0, ProceduralGroundSprite.CellSize);
+            Color32 colorAtCellCell = SampleAt(pixels, ProceduralGroundSprite.CellSize, ProceduralGroundSprite.CellSize);
+
+            AssertColorEquals(ProceduralGroundSprite.ColorA, colorAt00,
+                "Pixel at (0,0) should be ColorA (bottom-left cell).");
+            AssertColorEquals(ProceduralGroundSprite.ColorB, colorAtCellSize0,
+                "Pixel at (CellSize,0) should be ColorB (horizontally adjacent cell alternates).");
+            AssertColorEquals(ProceduralGroundSprite.ColorB, colorAt0CellSize,
+                "Pixel at (0,CellSize) should be ColorB (vertically adjacent cell alternates).");
+            AssertColorEquals(ProceduralGroundSprite.ColorA, colorAtCellCell,
+                "Pixel at (CellSize,CellSize) should be ColorA (diagonal cell matches origin).");
+        }
+
+        private static Color32 SampleAt(Color32[] pixels, int x, int y)
+        {
+            int index = y * ProceduralGroundSprite.TextureSize + x;
+            return pixels[index];
+        }
+
+        private static void AssertColorEquals(Color32 expected, Color32 actual, string message)
+        {
+            Assert.AreEqual(expected.r, actual.r, message + " (r)");
+            Assert.AreEqual(expected.g, actual.g, message + " (g)");
+            Assert.AreEqual(expected.b, actual.b, message + " (b)");
+            Assert.AreEqual(expected.a, actual.a, message + " (a)");
+        }
+
+        private static void InvokeResetCacheForTests()
+        {
+            MethodInfo resetMethod = typeof(ProceduralGroundSprite).GetMethod(
+                "ResetCacheForTests",
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+            Assert.IsNotNull(resetMethod,
+                "ProceduralGroundSprite.ResetCacheForTests must exist for test isolation.");
+
+            resetMethod.Invoke(null, null);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ProceduralGroundSpriteTests.cs.meta
+++ b/Assets/Tests/EditMode/ProceduralGroundSpriteTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c341bf7f104b0f40a847ff08a656e4e

--- a/Assets/Tests/PlayMode/LevelManagerTerrainFallbackTests.cs
+++ b/Assets/Tests/PlayMode/LevelManagerTerrainFallbackTests.cs
@@ -1,0 +1,126 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Environment;
+using RogueliteAutoBattler.Combat.Levels;
+using RogueliteAutoBattler.Combat.Visuals;
+using RogueliteAutoBattler.Data;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace RogueliteAutoBattler.Tests.PlayMode
+{
+    public class LevelManagerTerrainFallbackTests : PlayModeTestBase
+    {
+        private LevelDatabase _levelDatabase;
+        private Sprite _authoredTerrainSprite;
+        private Texture2D _authoredTexture;
+
+        public override void TearDown()
+        {
+            base.TearDown();
+
+            if (_authoredTerrainSprite != null)
+                Object.DestroyImmediate(_authoredTerrainSprite);
+            if (_authoredTexture != null)
+                Object.DestroyImmediate(_authoredTexture);
+            if (_levelDatabase != null)
+                Object.DestroyImmediate(_levelDatabase);
+
+            InvokeResetProceduralGroundCache();
+        }
+
+        private (LevelManager manager, SpriteRenderer groundRenderer) CreateLevelManagerWithTerrain(Sprite terrain)
+        {
+            _levelDatabase = ScriptableObject.CreateInstance<LevelDatabase>();
+
+            var emptyWave = new WaveData("EmptyWave", 0f, new List<EnemySpawnData>());
+            var emptyStep = new StepData("Step0", new List<WaveData> { emptyWave });
+            var level0 = new LevelData("Level0", new List<StepData> { emptyStep });
+
+            var stage = new StageData("Stage0", terrain, new List<LevelData> { level0 });
+            _levelDatabase.Stages.Add(stage);
+
+            var levelManagerGo = new GameObject("TestLevelManager");
+            levelManagerGo.AddComponent<WorldConveyor>();
+            var manager = levelManagerGo.AddComponent<LevelManager>();
+            manager.enabled = false;
+            Track(levelManagerGo);
+
+            var teamContainer = Track(new GameObject("Team"));
+            var enemiesContainer = Track(new GameObject("Enemies"));
+
+            var groundGo = Track(new GameObject("Ground"));
+            var groundRenderer = groundGo.AddComponent<SpriteRenderer>();
+
+            SetPrivateField(manager, "_groundRenderer", groundRenderer);
+
+            manager.InitializeForTest(
+                teamContainer.transform,
+                enemiesContainer.transform,
+                levelDatabase: _levelDatabase);
+
+            return (manager, groundRenderer);
+        }
+
+        [UnityTest]
+        public IEnumerator ApplyStage_WithNullTerrain_UsesProceduralFallback()
+        {
+            var (manager, groundRenderer) = CreateLevelManagerWithTerrain(terrain: null);
+
+            manager.ApplyStage(0);
+
+            yield return null;
+
+            Sprite expected = ProceduralGroundSprite.GetOrCreate();
+            Assert.IsNotNull(groundRenderer.sprite,
+                "Ground renderer's sprite should not remain null when terrain is null; procedural fallback must be applied.");
+            Assert.AreSame(expected, groundRenderer.sprite,
+                "When stage.Terrain is null, ground renderer must use the procedural fallback sprite returned by ProceduralGroundSprite.GetOrCreate().");
+        }
+
+        [UnityTest]
+        public IEnumerator ApplyStage_WithAuthoredTerrain_UsesAuthoredSprite()
+        {
+            _authoredTexture = new Texture2D(4, 4, TextureFormat.RGBA32, false);
+            _authoredTexture.name = "AuthoredTestTexture";
+            _authoredTerrainSprite = Sprite.Create(
+                _authoredTexture,
+                new Rect(0f, 0f, 4f, 4f),
+                new Vector2(0.5f, 0.5f),
+                pixelsPerUnit: 16f);
+            _authoredTerrainSprite.name = "AuthoredTestSprite";
+
+            var (manager, groundRenderer) = CreateLevelManagerWithTerrain(_authoredTerrainSprite);
+
+            manager.ApplyStage(0);
+
+            yield return null;
+
+            Assert.AreSame(_authoredTerrainSprite, groundRenderer.sprite,
+                "When stage.Terrain is authored, the ground renderer must use that sprite and NOT the procedural fallback.");
+
+            Sprite proceduralSprite = ProceduralGroundSprite.GetOrCreate();
+            Assert.AreNotSame(proceduralSprite, groundRenderer.sprite,
+                "Authored terrain must take precedence over the procedural fallback.");
+        }
+
+        private static void SetPrivateField(object obj, string fieldName, object value)
+        {
+            FieldInfo field = obj.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(field, $"Private field '{fieldName}' not found on {obj.GetType().Name}.");
+            field.SetValue(obj, value);
+        }
+
+        private static void InvokeResetProceduralGroundCache()
+        {
+            MethodInfo resetMethod = typeof(ProceduralGroundSprite).GetMethod(
+                "ResetCacheForTests",
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+            if (resetMethod != null)
+                resetMethod.Invoke(null, null);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/LevelManagerTerrainFallbackTests.cs.meta
+++ b/Assets/Tests/PlayMode/LevelManagerTerrainFallbackTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: da13eb888f45e36458897219da33ddde

--- a/Assets/Tests/PlayMode/ScreenAnchorTests.cs
+++ b/Assets/Tests/PlayMode/ScreenAnchorTests.cs
@@ -1,0 +1,102 @@
+using System.Collections;
+using System.Reflection;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Environment;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace RogueliteAutoBattler.Tests.PlayMode
+{
+    public class ScreenAnchorTests : PlayModeTestBase
+    {
+        private const float PositionTolerance = 0.001f;
+
+        private Camera _camera;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var camGo = Track(new GameObject("MainCamera"));
+            _camera = camGo.AddComponent<Camera>();
+            _camera.tag = "MainCamera";
+            _camera.orthographic = true;
+            _camera.orthographicSize = 5f;
+            _camera.transform.position = new Vector3(0f, 0f, -10f);
+        }
+
+        private ScreenAnchor CreateAnchor(Vector2 viewportPosition, Vector2 worldOffset)
+        {
+            var go = new GameObject("TestScreenAnchor");
+            go.SetActive(false);
+            Track(go);
+
+            var anchor = go.AddComponent<ScreenAnchor>();
+            SetPrivateField(anchor, "_viewportPosition", viewportPosition);
+            SetPrivateField(anchor, "_worldOffset", worldOffset);
+
+            go.SetActive(true);
+            return anchor;
+        }
+
+        [UnityTest]
+        public IEnumerator UpdatePosition_AppliesWorldOffset()
+        {
+            ScreenAnchor anchor = CreateAnchor(
+                viewportPosition: new Vector2(0.5f, 0.5f),
+                worldOffset: new Vector2(0f, 0.5f));
+
+            yield return null;
+
+            Assert.AreEqual(0f, anchor.transform.position.x, PositionTolerance,
+                "Viewport center X maps to world X 0 with camera at origin; offset.x is 0 so result should remain 0.");
+            Assert.AreEqual(0.5f, anchor.transform.position.y, PositionTolerance,
+                "Viewport center Y (world 0) plus worldOffset.y (0.5) must equal 0.5 on the transform.");
+            Assert.AreEqual(0f, anchor.transform.position.z, PositionTolerance,
+                "ScreenAnchor must always zero the Z component for 2D.");
+        }
+
+        [UnityTest]
+        public IEnumerator UpdatePosition_ZeroOffset_NoShift()
+        {
+            ScreenAnchor anchor = CreateAnchor(
+                viewportPosition: new Vector2(0.5f, 0.5f),
+                worldOffset: Vector2.zero);
+
+            yield return null;
+
+            Assert.AreEqual(0f, anchor.transform.position.x, PositionTolerance,
+                "Viewport center with zero offset must land on world origin X.");
+            Assert.AreEqual(0f, anchor.transform.position.y, PositionTolerance,
+                "Viewport center with zero offset must land on world origin Y.");
+        }
+
+        [UnityTest]
+        public IEnumerator UpdatePosition_RespondsToCameraResize()
+        {
+            ScreenAnchor anchor = CreateAnchor(
+                viewportPosition: new Vector2(0.5f, 1f),
+                worldOffset: new Vector2(0f, 0.5f));
+
+            yield return null;
+
+            float expectedInitialY = 5f + 0.5f;
+            Assert.AreEqual(expectedInitialY, anchor.transform.position.y, PositionTolerance,
+                "With ortho size 5, viewport y=1 maps to world y=5; adding offset.y=0.5 gives y=5.5.");
+
+            _camera.orthographicSize = 3f;
+            yield return null;
+            yield return null;
+
+            float expectedAfterResizeY = 3f + 0.5f;
+            Assert.AreEqual(expectedAfterResizeY, anchor.transform.position.y, PositionTolerance,
+                "After the camera ortho size shrinks to 3, the anchor must re-resolve: viewport y=1 -> world y=3, plus offset.y=0.5 = 3.5.");
+        }
+
+        private static void SetPrivateField(object obj, string fieldName, object value)
+        {
+            FieldInfo field = obj.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(field, $"Private field '{fieldName}' not found on {obj.GetType().Name}.");
+            field.SetValue(obj, value);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/ScreenAnchorTests.cs.meta
+++ b/Assets/Tests/PlayMode/ScreenAnchorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9a50d255110285f4eb1602ad56a184c9


### PR DESCRIPTION
Closes #191

## Summary
- Added `ProceduralGroundSprite` runtime class to generate fallback ground textures when `stage.Terrain == null`.
- Updated `LevelDesignerTab` to no longer auto-assign `grid_ground.png`; textures must now be dragged manually per stage.
- Added `_worldOffset` field to `ScreenAnchor` for flexible anchor positioning (currently set to 0 everywhere as infrastructure).
- Reverted home anchor Y-offset from 0.5 to 0 after user feedback; viewport Y restored to 0.676 to maintain layout integrity.
- 9 new tests covering procedural ground fallback and screen anchor world offset; all passing.

## Files created
- `Assets/Scripts/Combat/Visuals/ProceduralGroundSprite.cs` (runtime)

## Files modified
- `Assets/Scripts/Combat/Core/ScreenAnchor.cs` (added `_worldOffset`)
- `Assets/Scripts/Combat/Levels/LevelManager.cs` (procedural ground fallback in `ApplyStage`)
- `Assets/Scripts/Editor/Builders/LevelDesignerTab.cs` (removed auto-assign)
- `Assets/Scenes/NewGameScene.unity` (anchor sync + viewport Y fix)
- `Assets/Scripts/Tests/PlayMode/ScreenAnchorTests.cs` (new test coverage)
- Multiple `.meta` files (new script imports)