### PR TITLE
chore(ci): allow feat/* prefix in protect-dev workflow

### DIFF
--- a/.github/workflows/protect-dev.yml
+++ b/.github/workflows/protect-dev.yml
@@ -14,6 +14,7 @@ jobs:
           echo "Source branch: $SOURCE"
 
           if [[ "$SOURCE" == feature/* ]] || \
+             [[ "$SOURCE" == feat/* ]] || \
              [[ "$SOURCE" == fix/* ]] || \
              [[ "$SOURCE" == refactor/* ]] || \
              [[ "$SOURCE" == chore/* ]] || \
@@ -21,7 +22,7 @@ jobs:
             echo "Allowed: $SOURCE can target dev."
           else
             echo "BLOCKED: '$SOURCE' cannot target dev."
-            echo "Only feature/*, fix/*, refactor/*, chore/*, test/* branches may merge into dev."
+            echo "Only feature/*, feat/*, fix/*, refactor/*, chore/*, test/* branches may merge into dev."
             echo "Release and hotfix branches must target main."
             exit 1
           fi


### PR DESCRIPTION
Closes N/A

## Summary
Adds `feat/*` to the allowed source prefixes in protect-dev.yml so branches using the conventional-commit abbreviated prefix no longer fail the CI check. This aligns the workflow constraints with the abbreviated commit message format already in use.

## Files created
None

## Files modified
.github/workflows/protect-dev.yml