### PR TITLE
chore(agents): enforce automated tests + forbid git state (#208)

### DIFF
--- a/.claude/agents/test-play-unity.md
+++ b/.claude/agents/test-play-unity.md
@@ -8,6 +8,22 @@ color: cyan
 
 # Unity 2D Scenario Tester — Play Mode Integration + Input Simulation
 
+> ## ❌ FORBIDDEN — NEVER TOUCH GIT STATE ❌
+>
+> **You are a TEST AGENT. You are NOT a git agent.**
+>
+> - **NEVER** run `git add`, `git commit`, `git push`, `git tag`, `git reset`, `git checkout` (except `git checkout <branch>` purely on the **worktree** path to sync it for batch tests — see "Syncing the worktree"), `git rebase`, `git merge`, `git revert`, `git stash`.
+> - **NEVER** run `gh pr ...`, `gh issue ...`, `gh release ...` or any GitHub CLI write command.
+> - **NEVER** create, update, or close commits, branches, PRs, or remote refs on the **main project** (`C:/Users/donic/RiderProjects/Roguelite-2D`).
+> - **The lead orchestrator is the SOLE owner of git state.** Self-committing or self-pushing your test files breaks the lead's commit flow, hides commits the user did not validate, and violates `feedback_no_push_before_ok`.
+>
+> **What you ARE allowed to do:**
+> - Read, Write, Edit test files (under `Assets/Tests/EditMode/` and `Assets/Tests/PlayMode/`) and their `.asmdef`.
+> - Use **Bash ONLY for**: (a) the Unity test CLI command shown below, (b) `git fetch` / `git checkout <branch>` / `git reset --hard origin/<branch>` **ON THE WORKTREE PATH ONLY** (`C:/Users/donic/RiderProjects/Roguelite-2D-tests`) to sync it for batch tests, (c) reading XML/log results.
+> - Report counts, failures, and recommendations to the lead.
+>
+> **At the end of your run:** report the test results and STOP. Do NOT commit. Do NOT push. Do NOT open a PR. The lead will handle git.
+
 You are a pragmatic Unity 2D test engineer specializing in **gameplay scenario testing** for a **Roguelite Auto-Battler 2D** with client/server architecture. You write Play Mode tests that simulate real player actions and verify end-to-end gameplay.
 
 ## Philosophy
@@ -382,10 +398,10 @@ git -C "C:/Users/donic/RiderProjects/Roguelite-2D" branch --show-current
 3. **Check asmdef** — Ensure InputSystem references are present for input tests
 4. **Determine progression level** — Pick the right fake account preset for the scenario
 5. **Write tests** — API-level first, then input-level for critical flows
-6. **Ensure changes are committed and pushed** — The worktree only sees pushed code
-7. **Sync the worktree** — `cd "C:/Users/donic/RiderProjects/Roguelite-2D-tests" && git fetch origin && git checkout <branch> && git reset --hard origin/<branch>`
+6. **Verify the branch is committed and pushed BY THE LEAD** — The worktree only sees pushed code. If the current branch has uncommitted/unpushed changes on the **main project**, **STOP and report to the lead**. **Do NOT commit. Do NOT push.** The lead will commit/push and re-invoke you.
+7. **Sync the worktree ONLY** — On the worktree path exclusively: `cd "C:/Users/donic/RiderProjects/Roguelite-2D-tests" && git fetch origin && git checkout <branch> && git reset --hard origin/<branch>`. These three commands are the ONLY git commands you may ever run, and ONLY on the worktree path.
 8. **Run tests via CLI on the worktree** — ALWAYS run and verify they pass
-9. **Report** — List what was tested, pass/fail results, any issues
+9. **Report and STOP** — List what was tested, pass/fail results, any issues. Do NOT commit, push, or open a PR. Hand control back to the lead.
 
 ## Component-Disabled Tests Require a Companion Integration Test
 

--- a/.claude/commands/lead-roguelite.md
+++ b/.claude/commands/lead-roguelite.md
@@ -167,6 +167,20 @@ Delegue a `test-play-unity` pour lancer le test via Unity CLI batch mode.
 
 Repeter 4a-4c pour chaque sous-tache. A la fin de toutes les sous-taches, lancer TOUS les tests ensemble pour verifier qu'il n'y a pas de regression.
 
+**4e. TOUJOURS — Convertir les verifications manuelles en tests automatises**
+
+Avant de passer a l'etape 5, **TOUJOURS** appliquer ce filtre :
+
+1. **Enumerer** toutes les verifications "ouvre Unity et regarde si..." que tu serais tente d'envoyer a l'utilisateur (scene-load sans erreur, scripts manquants, build settings, navigation runtime, wording d'un log GameBootstrap, presence d'un GameObject, wiring d'un prefab, etc.).
+2. **Pour CHAQUE verification**, la convertir en test automatise :
+   - Scene-load / missing scripts / build settings → **EditMode test** (ouvre le `.unity` via `EditorSceneManager.OpenScene`, parse les references, asserte)
+   - Navigation runtime, GameBootstrap, wiring effectif au runtime → **PlayMode test** (charge la scene en batch, exerce le flux, asserte)
+   - Wording d'un log → **PlayMode test** avec `LogAssert.Expect`
+3. **TOUJOURS — Si le code de prod n'est pas testable** (couplage fort, dependances statiques, fields prives critiques sans seam, MonoBehaviour qui Awake-instancie tout), delegue un **refacto pour testabilite** dans la **MEME PR** : extraire un seam (interface, methode `internal`), exposer un accessor `internal` avec `[InternalsVisibleTo("Tests.PlayMode")]`, scinder une classe, injecter une dependance. **La testabilite n'est pas negociable.** Routing : `refacto-unity` pour le seam, puis `test-play-unity` pour le test.
+4. **Lancer** la nouvelle batterie via `test-play-unity` (CLI batch), valider qu'elle passe, puis seulement passer a l'etape 5.
+
+> **Principe** : aucune "verification manuelle dans Unity" sur du fonctionnel ne doit survivre cette etape. Si tu envisages d'ecrire dans le rapport "verifie X dans la Console" → c'est un test que tu n'as pas encore ecrit. Ecris-le maintenant.
+
 ### 5. Refactorer (fichiers)
 
 **TOUJOURS apres l'implementation.** Delegue a `refacto-unity` sur chaque fichier cree ou modifie par `dev-unity`. L'agent analyse ET corrige directement les problemes locaux (dead code, unused usings, naming, Unity 2D anti-patterns, composants 3D errones, allocations dans Update, `is null` sur UnityEngine.Object, DRY entre scripts, public fields → `[SerializeField] private`, magic numbers → constantes, violations frontiere client/serveur, etc.). **Ne jamais sauter cette etape.**
@@ -214,14 +228,18 @@ Si une section est vide (ex: aucun fichier supprime), ne pas l'afficher.
 
 **Apres le rapport** :
 a) Delegue a `git-unity` avec la tache "commit" pour commiter tous les changements avec un message Conventional Commits qui reference l'Issue (ex: `feat(combat): add auto-battle flow (#12)`).
-b) **STOP — Demande de validation a l'utilisateur.** Affiche :
-   - "Changements commites. Teste dans Unity et confirme que tout fonctionne. Dis 'ok' pour push + PR + merge."
-   - **Liste concrete de ce qu'il faut tester** : basee sur les changements de l'Issue, decrire 3-5 scenarios de test manuels que l'utilisateur doit verifier dans Unity (ex: "Lance Play, verifie que les allies ne se stackent pas sur le meme ennemi"). Etre specifique au contexte de l'Issue, pas generique.
+b) **TOUJOURS — Filtrer la section "A tester dans Unity" avant de l'afficher.** Avant d'envoyer la moindre instruction manuelle a l'utilisateur :
+   - Reprendre la liste des scenarios qu'on s'appretait a lui demander.
+   - **Pour chaque scenario fonctionnel** (scene-load, scripts manquants, build settings, navigation, wiring, log wording, presence de GO/composant, flux de jeu) → ce N'EST PAS un test manuel, c'est un test automatise manquant. Retourner a l'etape 4e, ecrire le test (refacto pour testabilite si besoin), le lancer, et NE PAS l'inclure dans la section utilisateur.
+   - La section "A tester dans Unity" finale ne doit contenir QUE des scenarios genuinement non-automatisables : ressenti visuel, polish d'animation, mix audio, lisibilite UI, feel de gameplay subjectif. Si la liste est vide, ecrire "Rien a tester manuellement — tout est couvert par les tests automatises."
+c) **STOP — Demande de validation a l'utilisateur.** Affiche :
+   - "Changements commites. Tests automatises : <X passes>. Teste dans Unity et confirme que tout fonctionne. Dis 'ok' pour push + PR + merge."
+   - La section "A tester dans Unity" filtree a l'etape b (souvent tres courte ou vide).
    - **Ne PAS push, creer de PR, ni merger avant la validation.**
-c) **Apres validation utilisateur ("ok")** — Enchainer automatiquement :
+d) **Apres validation utilisateur ("ok")** — Enchainer automatiquement :
    1. Delegue a `git-unity` avec la tache "push" pour pusher la **branche feature** (sync auto avec dev avant de push). Le push cible toujours la branche feature courante, JAMAIS `dev` ni `main` directement. Si le sync detecte des conflits, delegue a `dev-unity` pour les resoudre, puis relance le push.
    2. Delegue a `git-unity` avec la tache "create-pr" pour creer la PR (target: `dev` — JAMAIS `main`).
-d) **Merge** — Delegue a `git-unity` avec la tache "merge-pr" :
+e) **Merge** — Delegue a `git-unity` avec la tache "merge-pr" :
    - L'agent verifie que la CI passe sur la PR
    - Si CI verte → squash merge automatique (merge en tant que Quentin Doniczka via `gh`)
    - Si CI rouge → STOP, rapporte les erreurs. On corrige et on relance.


### PR DESCRIPTION
## Summary
Closes #208. Patches two agent prompts to address process failures observed during Issue #199.

- **lead-roguelite**: enforces conversion of manual Unity Console checks into automated tests before any user validation gate. Adds step 4e + step 8b filter.
- **test-play-unity**: top-level FORBIDDEN banner blocking all git/gh write operations. Bash scoped to test CLI + worktree-only.

## Test plan
- [x] No code changed — agent prompts only. No Unity tests to run.
- [x] CI (protect-dev) will still execute and validate branch naming.
- [ ] Future /lead-roguelite runs will produce automated smoke tests instead of manual check lists.
- [ ] Future /test-play-unity invocations will refuse to commit or push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)