### PR TITLE
fix(ui): gold HUD label now updates when wallet changes (#215)

### DIFF
--- a/Assets/Scenes/NewGameScene.unity
+++ b/Assets/Scenes/NewGameScene.unity
@@ -119,7 +119,7 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &42668105
+--- !u!1 &99438885
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -127,57 +127,11 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 42668107}
-  - component: {fileID: 42668106}
-  m_Layer: 0
-  m_Name: EnemiesHomeAnchor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &42668106
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 42668105}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
-  m_Name:
-  m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
-  _viewportPosition: {x: 0.88, y: 0.676}
-  _worldOffset: {x: 0, y: 0}
---- !u!4 &42668107
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 42668105}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &262517386
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 262517387}
-  - component: {fileID: 262517391}
-  - component: {fileID: 262517390}
-  - component: {fileID: 262517389}
-  - component: {fileID: 262517388}
+  - component: {fileID: 99438886}
+  - component: {fileID: 99438890}
+  - component: {fileID: 99438889}
+  - component: {fileID: 99438888}
+  - component: {fileID: 99438887}
   m_Layer: 0
   m_Name: CoinFlyOverlay
   m_TagString: Untagged
@@ -185,48 +139,48 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &262517387
+--- !u!224 &99438886
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 262517386}
+  m_GameObject: {fileID: 99438885}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1492525375}
-  m_Father: {fileID: 1310849134}
+  - {fileID: 1844134014}
+  m_Father: {fileID: 1081560413}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!114 &262517388
+--- !u!114 &99438887
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 262517386}
+  m_GameObject: {fileID: 99438885}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 519d03253457b0f4daa795481e765b38, type: 3}
   m_Name: 
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Visuals.CoinFlyBootstrap
-  _coinContainer: {fileID: 1492525375}
+  _coinContainer: {fileID: 1844134014}
   _targetBadge: {fileID: 0}
   _coinSprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
---- !u!114 &262517389
+--- !u!114 &99438888
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 262517386}
+  m_GameObject: {fileID: 99438885}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
@@ -237,13 +191,13 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &262517390
+--- !u!114 &99438889
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 262517386}
+  m_GameObject: {fileID: 99438885}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
@@ -260,13 +214,13 @@ MonoBehaviour:
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
   m_PresetInfoIsWorld: 0
---- !u!223 &262517391
+--- !u!223 &99438890
 Canvas:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 262517386}
+  m_GameObject: {fileID: 99438885}
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 0
@@ -283,7 +237,7 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 100
   m_TargetDisplay: 0
---- !u!1 &538497904
+--- !u!1 &165795980
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -291,53 +245,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 538497906}
-  - component: {fileID: 538497905}
-  m_Layer: 0
-  m_Name: TeamHomeAnchor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &538497905
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 538497904}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
-  m_Name:
-  m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
-  _viewportPosition: {x: 0.12, y: 0.676}
-  _worldOffset: {x: 0, y: 0}
---- !u!4 &538497906
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 538497904}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &567262800
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 567262801}
+  - component: {fileID: 165795981}
   m_Layer: 0
   m_Name: Team
   m_TagString: Untagged
@@ -345,22 +253,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &567262801
+--- !u!4 &165795981
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 567262800}
+  m_GameObject: {fileID: 165795980}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2040358759}
+  m_Father: {fileID: 1142825307}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &717122624
+--- !u!1 &299682636
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -368,9 +276,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 717122627}
-  - component: {fileID: 717122626}
-  - component: {fileID: 717122625}
+  - component: {fileID: 299682639}
+  - component: {fileID: 299682638}
+  - component: {fileID: 299682637}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -378,13 +286,13 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &717122625
+--- !u!114 &299682637
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 717122624}
+  m_GameObject: {fileID: 299682636}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
@@ -409,13 +317,13 @@ MonoBehaviour:
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0
   m_ScrollDeltaPerTick: 6
---- !u!114 &717122626
+--- !u!114 &299682638
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 717122624}
+  m_GameObject: {fileID: 299682636}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
@@ -424,13 +332,13 @@ MonoBehaviour:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
---- !u!4 &717122627
+--- !u!4 &299682639
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 717122624}
+  m_GameObject: {fileID: 299682636}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -439,7 +347,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &963787536
+--- !u!1 &871303881
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -447,227 +355,45 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 963787539}
-  - component: {fileID: 963787538}
-  - component: {fileID: 963787537}
+  - component: {fileID: 871303883}
+  - component: {fileID: 871303882}
   m_Layer: 0
-  m_Name: Main Camera
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!81 &963787537
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963787536}
-  m_Enabled: 1
---- !u!20 &963787538
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963787536}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 2
-  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_Iso: 200
-  m_ShutterSpeed: 0.005
-  m_Aperture: 16
-  m_FocusDistance: 10
-  m_FocalLength: 50
-  m_BladeCount: 5
-  m_Curvature: {x: 2, y: 11}
-  m_BarrelClipping: 0.25
-  m_Anamorphism: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 1
-  orthographic size: 5.4
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &963787539
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963787536}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1202350666
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1202350667}
-  m_Layer: 0
-  m_Name: Enemies
+  m_Name: TeamHomeAnchor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1202350667
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1202350666}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2040358759}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1226718478
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1226718481}
-  - component: {fileID: 1226718479}
-  - component: {fileID: 1226718480}
-  m_Layer: 0
-  m_Name: Ground
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &1226718479
-SpriteRenderer:
-  serializedVersion: 2
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1226718478}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 1436502655}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: -10
-  m_MaskInteraction: 0
-  m_Sprite: {fileID: 21300000, guid: 9e2df879d43e01849b415d9fd931b7ed, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 2
-  m_Size: {x: 200, y: 6.48}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_SpriteSortPoint: 0
---- !u!114 &1226718480
+--- !u!114 &871303882
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1226718478}
+  m_GameObject: {fileID: 871303881}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 619dfd52e55902a418aea05a2822a8f5, type: 3}
+  m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.GroundFitter
-  _groundWidth: 200
---- !u!4 &1226718481
+  m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
+  _viewportPosition: {x: 0.12, y: 0.676}
+  _worldOffset: {x: 0, y: 0}
+--- !u!4 &871303883
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1226718478}
+  m_GameObject: {fileID: 871303881}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 95.96, y: 2.16, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2040358759}
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1310849130
+--- !u!1 &1081560409
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -675,10 +401,10 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1310849134}
-  - component: {fileID: 1310849133}
-  - component: {fileID: 1310849132}
-  - component: {fileID: 1310849131}
+  - component: {fileID: 1081560413}
+  - component: {fileID: 1081560412}
+  - component: {fileID: 1081560411}
+  - component: {fileID: 1081560410}
   m_Layer: 0
   m_Name: NavigationHost
   m_TagString: Untagged
@@ -686,40 +412,41 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1310849131
+--- !u!114 &1081560410
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1310849130}
+  m_GameObject: {fileID: 1081560409}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f3cdba403856b014e8b79d936162777c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.UI.Toolkit.CombatHudController
-  _uiDocument: {fileID: 1310849133}
---- !u!114 &1310849132
+  _uiDocument: {fileID: 1081560412}
+  _goldWallet: {fileID: 1201301484}
+--- !u!114 &1081560411
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1310849130}
+  m_GameObject: {fileID: 1081560409}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: bec90ad8386fa4f49a0c567dc36f43ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.UI.Toolkit.NavigationHost
-  _uiDocument: {fileID: 1310849133}
+  _uiDocument: {fileID: 1081560412}
   _cancelAction: {fileID: 7727032971491509709, guid: 2bcd2660ca9b64942af0de543d8d7100, type: 3}
---- !u!114 &1310849133
+--- !u!114 &1081560412
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1310849130}
+  m_GameObject: {fileID: 1081560409}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
@@ -736,64 +463,23 @@ MonoBehaviour:
   m_PivotReferenceSize: 0
   m_Pivot: 0
   m_WorldSpaceCollider: {fileID: 0}
---- !u!4 &1310849134
+--- !u!4 &1081560413
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1310849130}
+  m_GameObject: {fileID: 1081560409}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 262517387}
+  - {fileID: 99438886}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &1436502655
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Universal Render Pipeline/2D/Sprite-Unlit-Default
-  m_Shader: {fileID: 4800000, guid: 13c02b14c4d048fa9653293d54f6e0e1, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _AlphaTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - PixelSnap: 0
-    - _EnableExternalAlpha: 0
-    - _ZWrite: 0
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
-  m_BuildTextureStacks: []
-  m_AllowLocking: 1
---- !u!1 &1492525374
+--- !u!1 &1108550203
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -801,80 +487,30 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1492525375}
+  - component: {fileID: 1108550204}
   m_Layer: 0
-  m_Name: CoinFlyPool
+  m_Name: Enemies
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1492525375
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1492525374}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 262517387}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1805464533
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1805464535}
-  - component: {fileID: 1805464534}
-  m_Layer: 0
-  m_Name: CombatTriggerZone
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1805464534
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1805464533}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
-  m_Name:
-  m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
-  _viewportPosition: {x: 1, y: 0.5}
-  _worldOffset: {x: 0, y: 0}
---- !u!4 &1805464535
+--- !u!4 &1108550204
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1805464533}
+  m_GameObject: {fileID: 1108550203}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 1142825307}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2040358751
+--- !u!1 &1142825299
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -882,14 +518,14 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2040358759}
-  - component: {fileID: 2040358758}
-  - component: {fileID: 2040358757}
-  - component: {fileID: 2040358756}
-  - component: {fileID: 2040358755}
-  - component: {fileID: 2040358754}
-  - component: {fileID: 2040358753}
-  - component: {fileID: 2040358752}
+  - component: {fileID: 1142825307}
+  - component: {fileID: 1142825306}
+  - component: {fileID: 1142825305}
+  - component: {fileID: 1142825304}
+  - component: {fileID: 1142825303}
+  - component: {fileID: 1142825302}
+  - component: {fileID: 1142825301}
+  - component: {fileID: 1142825300}
   m_Layer: 0
   m_Name: CombatWorld
   m_TagString: Untagged
@@ -897,27 +533,27 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &2040358752
+--- !u!114 &1142825300
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2040358751}
+  m_GameObject: {fileID: 1142825299}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e75cd5cde560b1479b2f64aca88c02e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Visuals.DamageNumberBootstrap
   _config: {fileID: 11400000, guid: e24f810158df5a44982e2410682d2481, type: 2}
-  _effectsContainer: {fileID: 2065494051}
---- !u!114 &2040358753
+  _effectsContainer: {fileID: 1972995683}
+--- !u!114 &1142825301
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2040358751}
+  m_GameObject: {fileID: 1142825299}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5c50a4269364eb245bfdb895fa20cc65, type: 3}
@@ -2427,66 +2063,66 @@ MonoBehaviour:
   - {fileID: 8105920918686733900, guid: 63a452c17808953418f593d311c905c0, type: 3}
   _cycleInterval: 5
   _logCycles: 0
---- !u!114 &2040358754
+--- !u!114 &1142825302
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2040358751}
+  m_GameObject: {fileID: 1142825299}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: bbf63cd4a50e64f42ab58e754612196c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Levels.LevelManager
   _levelDatabase: {fileID: 11400000, guid: 702ee8316f0938846af157e000400a13, type: 2}
-  _groundRenderer: {fileID: 1226718479}
+  _groundRenderer: {fileID: 1319216530}
   _currentStageIndex: 0
   _currentLevelIndex: 0
-  _enemiesContainer: {fileID: 1202350667}
-  _teamContainer: {fileID: 567262801}
+  _enemiesContainer: {fileID: 1108550204}
+  _teamContainer: {fileID: 165795981}
   _levelScrollDistance: 4
   _stepScrollDistance: 2
   _enemySpawnOffscreenX: 1
-  _teamHomeAnchor: {fileID: 538497906}
-  _enemiesHomeAnchor: {fileID: 42668107}
-  _combatTriggerZone: {fileID: 1805464535}
+  _teamHomeAnchor: {fileID: 871303883}
+  _enemiesHomeAnchor: {fileID: 1558453259}
+  _combatTriggerZone: {fileID: 1807434157}
   _defeatResetDelay: 1.5
---- !u!114 &2040358755
+--- !u!114 &1142825303
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2040358751}
+  m_GameObject: {fileID: 1142825299}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b118d5ad30663654e8eed4e5afe322c4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Core.CombatSpawnManager
   _teamDatabase: {fileID: 11400000, guid: 64e2b0e27734f43408987455f4ed16e6, type: 2}
-  _teamContainer: {fileID: 567262801}
-  _teamHomeAnchor: {fileID: 538497906}
+  _teamContainer: {fileID: 165795981}
+  _teamHomeAnchor: {fileID: 871303883}
   _characterScale: 1.5
---- !u!114 &2040358756
+--- !u!114 &1142825304
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2040358751}
+  m_GameObject: {fileID: 1142825299}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0795fe3fc3d888e4898d1d1a0b7a58dd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Visuals.CombatWorldVisibility
---- !u!114 &2040358757
+--- !u!114 &1142825305
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2040358751}
+  m_GameObject: {fileID: 1142825299}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c1521c1a81370054bb4593db9113b1aa, type: 3}
@@ -2494,14 +2130,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.WorldConveyor
   _defaultMaxSpeed: 1
   _defaultAcceleration: 0.3
---- !u!50 &2040358758
+--- !u!50 &1142825306
 Rigidbody2D:
   serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2040358751}
+  m_GameObject: {fileID: 1142825299}
   m_BodyType: 1
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
@@ -2521,26 +2157,26 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!4 &2040358759
+--- !u!4 &1142825307
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2040358751}
+  m_GameObject: {fileID: 1142825299}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1226718481}
-  - {fileID: 567262801}
-  - {fileID: 1202350667}
-  - {fileID: 2065494051}
+  - {fileID: 1319216532}
+  - {fileID: 165795981}
+  - {fileID: 1108550204}
+  - {fileID: 1972995683}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2065494050
+--- !u!1 &1201301483
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2548,7 +2184,366 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2065494051}
+  - component: {fileID: 1201301485}
+  - component: {fileID: 1201301484}
+  m_Layer: 0
+  m_Name: GoldWallet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1201301484
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1201301483}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1af37ac3edd8a3e44810cddc3b69ef67, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Economy.GoldWallet
+--- !u!4 &1201301485
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1201301483}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1233334641
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1233334643}
+  - component: {fileID: 1233334642}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!20 &1233334642
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1233334641}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5.4
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1233334643
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1233334641}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1319216529
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1319216532}
+  - component: {fileID: 1319216530}
+  - component: {fileID: 1319216531}
+  m_Layer: 0
+  m_Name: Ground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1319216530
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1319216529}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2008188819}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -10
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 21300000, guid: 9e2df879d43e01849b415d9fd931b7ed, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 2
+  m_Size: {x: 200, y: 6.48}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!114 &1319216531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1319216529}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 619dfd52e55902a418aea05a2822a8f5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.GroundFitter
+  _groundWidth: 200
+--- !u!4 &1319216532
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1319216529}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 95.96, y: 2.16, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1142825307}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1558453257
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1558453259}
+  - component: {fileID: 1558453258}
+  m_Layer: 0
+  m_Name: EnemiesHomeAnchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1558453258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558453257}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
+  _viewportPosition: {x: 0.88, y: 0.676}
+  _worldOffset: {x: 0, y: 0}
+--- !u!4 &1558453259
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558453257}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1807434155
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1807434157}
+  - component: {fileID: 1807434156}
+  m_Layer: 0
+  m_Name: CombatTriggerZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1807434156
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807434155}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa1ce764dccd2624fa6b7de688085f96, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Combat.Environment.ScreenAnchor
+  _viewportPosition: {x: 1, y: 0.5}
+  _worldOffset: {x: 0, y: 0}
+--- !u!4 &1807434157
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807434155}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1844134013
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1844134014}
+  m_Layer: 0
+  m_Name: CoinFlyPool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1844134014
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1844134013}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 99438886}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1972995682
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1972995683}
   m_Layer: 0
   m_Name: Effects
   m_TagString: Untagged
@@ -2556,29 +2551,71 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2065494051
+--- !u!4 &1972995683
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2065494050}
+  m_GameObject: {fileID: 1972995682}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2040358759}
+  m_Father: {fileID: 1142825307}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &2008188819
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Universal Render Pipeline/2D/Sprite-Unlit-Default
+  m_Shader: {fileID: 4800000, guid: 13c02b14c4d048fa9653293d54f6e0e1, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - PixelSnap: 0
+    - _EnableExternalAlpha: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 963787539}
-  - {fileID: 2040358759}
-  - {fileID: 538497906}
-  - {fileID: 42668107}
-  - {fileID: 1805464535}
-  - {fileID: 717122627}
-  - {fileID: 1310849134}
+  - {fileID: 1233334643}
+  - {fileID: 1142825307}
+  - {fileID: 871303883}
+  - {fileID: 1558453259}
+  - {fileID: 1807434157}
+  - {fileID: 299682639}
+  - {fileID: 1081560413}
+  - {fileID: 1201301485}

--- a/Assets/Scripts/Editor/Builders/CombatHudBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/CombatHudBuilder.cs
@@ -1,4 +1,5 @@
 using RogueliteAutoBattler.Combat.Visuals;
+using RogueliteAutoBattler.Economy;
 using RogueliteAutoBattler.UI.Toolkit;
 using UnityEditor;
 using UnityEngine;
@@ -9,30 +10,39 @@ namespace RogueliteAutoBattler.Editor
 {
     internal static class CombatHudBuilder
     {
-        internal static void SetupToolkitCombatHud(GameObject navigationHostGo)
+        private const string CoinFlyOverlayGameObjectName = "CoinFlyOverlay";
+        private const string CoinFlyPoolGameObjectName = "CoinFlyPool";
+        private const string BuiltinKnobSpritePath = "UI/Skin/Knob.psd";
+        private const int CoinFlyCanvasSortingOrder = 100;
+        private const float CoinFlyReferenceResolutionX = 1080f;
+        private const float CoinFlyReferenceResolutionY = 1920f;
+        private const float CoinFlyMatchWidthOrHeight = 0.5f;
+
+        internal static void SetupToolkitCombatHud(GameObject navigationHostGo, GoldWallet goldWallet)
         {
             UIDocument uiDocument = navigationHostGo.GetComponent<UIDocument>();
 
             CombatHudController combatHud = navigationHostGo.AddComponent<CombatHudController>();
             var combatHudSo = new SerializedObject(combatHud);
             EditorUIFactory.SetObj(combatHudSo, "_uiDocument", uiDocument);
+            EditorUIFactory.SetObj(combatHudSo, "_goldWallet", goldWallet);
             combatHudSo.ApplyModifiedProperties();
 
-            var coinFlyOverlayGo = new GameObject("CoinFlyOverlay");
+            var coinFlyOverlayGo = new GameObject(CoinFlyOverlayGameObjectName);
             GameObjectUtility.SetParentAndAlign(coinFlyOverlayGo, navigationHostGo);
 
             Canvas canvas = coinFlyOverlayGo.AddComponent<Canvas>();
             canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-            canvas.sortingOrder = 100;
+            canvas.sortingOrder = CoinFlyCanvasSortingOrder;
 
             CanvasScaler scaler = coinFlyOverlayGo.AddComponent<CanvasScaler>();
             scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
-            scaler.referenceResolution = new Vector2(1080f, 1920f);
-            scaler.matchWidthOrHeight = 0.5f;
+            scaler.referenceResolution = new Vector2(CoinFlyReferenceResolutionX, CoinFlyReferenceResolutionY);
+            scaler.matchWidthOrHeight = CoinFlyMatchWidthOrHeight;
 
             coinFlyOverlayGo.AddComponent<GraphicRaycaster>();
 
-            var coinFlyPoolGo = new GameObject("CoinFlyPool");
+            var coinFlyPoolGo = new GameObject(CoinFlyPoolGameObjectName);
             GameObjectUtility.SetParentAndAlign(coinFlyPoolGo, coinFlyOverlayGo);
             RectTransform coinFlyPoolRect = coinFlyPoolGo.AddComponent<RectTransform>();
             EditorUIFactory.Stretch(coinFlyPoolRect);
@@ -42,7 +52,7 @@ namespace RogueliteAutoBattler.Editor
             EditorUIFactory.SetObj(bootstrapSo, "_coinContainer", coinFlyPoolRect);
             EditorUIFactory.SetObj(bootstrapSo, "_targetBadge", null);
             EditorUIFactory.SetObj(bootstrapSo, "_coinSprite",
-                AssetDatabase.GetBuiltinExtraResource<Sprite>("UI/Skin/Knob.psd"));
+                AssetDatabase.GetBuiltinExtraResource<Sprite>(BuiltinKnobSpritePath));
             bootstrapSo.ApplyModifiedProperties();
         }
     }

--- a/Assets/Scripts/Editor/Builders/NewGameSceneBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/NewGameSceneBuilder.cs
@@ -1,16 +1,26 @@
 using RogueliteAutoBattler.Core;
+using RogueliteAutoBattler.Economy;
 using RogueliteAutoBattler.UI.Toolkit;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem.UI;
+using UnityEngine.SceneManagement;
 
 namespace RogueliteAutoBattler.Editor
 {
     internal static class NewGameSceneBuilder
     {
-        [MenuItem("Roguelite/Setup New Game Scene")]
+        private const string SetupLogTag = "[SetupNewGameScene]";
+        private const string SaveLogTag = "[SaveSceneAfterSetup]";
+        private const string SetupMenuItemPath = "Roguelite/Setup New Game Scene";
+        private const string UndoGroupName = "Setup New Game Scene";
+        private const string EventSystemGameObjectName = "EventSystem";
+        private const string NavigationHostUndoLabel = "NavigationHost";
+        private const string DefaultScenePath = "Assets/Scenes/NewGameScene.unity";
+
+        [MenuItem(SetupMenuItemPath)]
         private static void SetupNewGameScene()
         {
             GameObject existingWorld = GameObject.Find(GameBootstrap.CombatWorldName);
@@ -22,7 +32,7 @@ namespace RogueliteAutoBattler.Editor
 
             Undo.IncrementCurrentGroup();
             int undoGroup = Undo.GetCurrentGroup();
-            Undo.SetCurrentGroupName("Setup New Game Scene");
+            Undo.SetCurrentGroupName(UndoGroupName);
 
             if (existingWorld != null)
                 Undo.DestroyObjectImmediate(existingWorld);
@@ -38,19 +48,31 @@ namespace RogueliteAutoBattler.Editor
             CombatWorldBuilder.ConfigureMainCamera();
             GameObject combatWorld = CombatWorldBuilder.CreateCombatWorld();
 
-            var esGo = new GameObject("EventSystem");
+            var esGo = new GameObject(EventSystemGameObjectName);
             esGo.AddComponent<EventSystem>();
             esGo.AddComponent<InputSystemUIInputModule>();
-            Undo.RegisterCreatedObjectUndo(esGo, "EventSystem");
+            Undo.RegisterCreatedObjectUndo(esGo, EventSystemGameObjectName);
 
             GameObject navHostGo = NavigationHostBuilder.CreateNavigationHost();
-            Undo.RegisterCreatedObjectUndo(navHostGo, "NavigationHost");
-            CombatHudBuilder.SetupToolkitCombatHud(navHostGo);
+            Undo.RegisterCreatedObjectUndo(navHostGo, NavigationHostUndoLabel);
+            GoldWallet goldWallet = WalletsBuilder.FindOrCreateGoldWallet();
+            CombatHudBuilder.SetupToolkitCombatHud(navHostGo, goldWallet);
 
             Undo.CollapseUndoOperations(undoGroup);
             EditorSceneManager.MarkSceneDirty(EditorSceneManager.GetActiveScene());
             Selection.activeGameObject = combatWorld;
-            Debug.Log("[SetupNewGameScene] Done. CombatWorld + EventSystem + NavigationHost created.");
+            Debug.Log($"{SetupLogTag} Done. CombatWorld + EventSystem + NavigationHost created.");
+        }
+
+        public static void SaveSceneAfterSetup()
+        {
+            SetupNewGameScene();
+            Scene activeScene = EditorSceneManager.GetActiveScene();
+            string scenePath = activeScene.path;
+            if (string.IsNullOrEmpty(scenePath))
+                scenePath = DefaultScenePath;
+            EditorSceneManager.SaveScene(activeScene, scenePath);
+            Debug.Log($"{SaveLogTag} Scene saved to: {scenePath}");
         }
     }
 }

--- a/Assets/Scripts/Editor/Builders/SkillTreeBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/SkillTreeBuilder.cs
@@ -10,6 +10,7 @@ namespace RogueliteAutoBattler.Editor
 {
     internal static class SkillTreeBuilder
     {
+        private const string LogTag = "[SkillTreeBuilder]";
         internal const string CircleSpritePath = "Assets/Sprites/UI/circle_white.png";
 
         private static readonly Color32 PanelBg         = new Color32(30,  30,  58,  255);
@@ -106,7 +107,7 @@ namespace RogueliteAutoBattler.Editor
             }
             else
             {
-                Debug.LogError("[SkillTreeBuilder] SkillTreeScreen component not found on skillTreePanel.");
+                Debug.LogError($"{LogTag} SkillTreeScreen component not found on skillTreePanel.");
             }
         }
 
@@ -173,8 +174,8 @@ namespace RogueliteAutoBattler.Editor
             detailPanelSO.ApplyModifiedProperties();
 
             SkillTreeProgress progress = EnsureSkillTreeProgressAsset();
-            GoldWallet goldWallet = FindOrCreateGoldWallet();
-            SkillPointWallet skillPointWallet = FindOrCreateSkillPointWallet();
+            GoldWallet goldWallet = WalletsBuilder.FindOrCreateGoldWallet();
+            SkillPointWallet skillPointWallet = WalletsBuilder.FindOrCreateSkillPointWallet();
 
             SkillTreeScreen screen = skillTreePanel.GetComponent<SkillTreeScreen>();
             if (screen != null)
@@ -193,7 +194,7 @@ namespace RogueliteAutoBattler.Editor
             }
             else
             {
-                Debug.LogError("[SkillTreeBuilder] SkillTreeScreen component not found — cannot wire detail panel references.");
+                Debug.LogError($"{LogTag} SkillTreeScreen component not found — cannot wire detail panel references.");
             }
         }
 
@@ -489,43 +490,28 @@ namespace RogueliteAutoBattler.Editor
             return AssetDatabase.LoadAssetAtPath<SkillTreeProgress>(SkillTreeProgress.DefaultAssetPath);
         }
 
-        private static GoldWallet FindOrCreateGoldWallet()
-        {
-            GoldWallet found = Object.FindFirstObjectByType<GoldWallet>(FindObjectsInactive.Include);
-            if (found != null) return found;
-
-            var walletGo = new GameObject("GoldWallet");
-            return walletGo.AddComponent<GoldWallet>();
-        }
-
-        private static SkillPointWallet FindOrCreateSkillPointWallet()
-        {
-            SkillPointWallet found = Object.FindFirstObjectByType<SkillPointWallet>(FindObjectsInactive.Include);
-            if (found != null) return found;
-
-            var walletGo = new GameObject("SkillPointWallet");
-            return walletGo.AddComponent<SkillPointWallet>();
-        }
-
         internal static Sprite EnsureCircleSprite()
         {
             var existing = AssetDatabase.LoadAssetAtPath<Sprite>(CircleSpritePath);
             if (existing != null) return existing;
 
-            const int size = 128;
-            const float center = size * 0.5f;
-            const float radius = center - 1f;
+            const int textureSizePixels = 128;
+            const float textureCenterPixels = textureSizePixels * 0.5f;
+            const float circleRadiusPixels = textureCenterPixels - 1f;
+            const float pixelCenterOffset = 0.5f;
+            const float antiAliasEdgeOffset = 0.5f;
 
-            var tex = new Texture2D(size, size, TextureFormat.RGBA32, false);
-            var pixels = new Color[size * size];
+            var tex = new Texture2D(textureSizePixels, textureSizePixels, TextureFormat.RGBA32, false);
+            var pixels = new Color[textureSizePixels * textureSizePixels];
+            var circleCenter = new Vector2(textureCenterPixels, textureCenterPixels);
 
-            for (int y = 0; y < size; y++)
+            for (int y = 0; y < textureSizePixels; y++)
             {
-                for (int x = 0; x < size; x++)
+                for (int x = 0; x < textureSizePixels; x++)
                 {
-                    float dist = Vector2.Distance(new Vector2(x + 0.5f, y + 0.5f), new Vector2(center, center));
-                    float alpha = Mathf.Clamp01(radius - dist + 0.5f);
-                    pixels[y * size + x] = new Color(1f, 1f, 1f, alpha);
+                    float distanceFromCenter = Vector2.Distance(new Vector2(x + pixelCenterOffset, y + pixelCenterOffset), circleCenter);
+                    float alpha = Mathf.Clamp01(circleRadiusPixels - distanceFromCenter + antiAliasEdgeOffset);
+                    pixels[y * textureSizePixels + x] = new Color(1f, 1f, 1f, alpha);
                 }
             }
 

--- a/Assets/Scripts/Editor/Builders/WalletsBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/WalletsBuilder.cs
@@ -1,0 +1,27 @@
+using RogueliteAutoBattler.Economy;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Editor
+{
+    internal static class WalletsBuilder
+    {
+        private const string GoldWalletGameObjectName = "GoldWallet";
+        private const string SkillPointWalletGameObjectName = "SkillPointWallet";
+
+        internal static GoldWallet FindOrCreateGoldWallet()
+            => FindOrCreateSceneSingleton<GoldWallet>(GoldWalletGameObjectName);
+
+        internal static SkillPointWallet FindOrCreateSkillPointWallet()
+            => FindOrCreateSceneSingleton<SkillPointWallet>(SkillPointWalletGameObjectName);
+
+        private static TComponent FindOrCreateSceneSingleton<TComponent>(string gameObjectName)
+            where TComponent : Component
+        {
+            TComponent existing = Object.FindFirstObjectByType<TComponent>(FindObjectsInactive.Include);
+            if (existing != null) return existing;
+
+            var hostGo = new GameObject(gameObjectName);
+            return hostGo.AddComponent<TComponent>();
+        }
+    }
+}

--- a/Assets/Scripts/Editor/Builders/WalletsBuilder.cs.meta
+++ b/Assets/Scripts/Editor/Builders/WalletsBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca6440f8b4d346c4c8d4bc6c8af92e5a

--- a/Assets/Scripts/UI/Toolkit/CombatHudController.cs
+++ b/Assets/Scripts/UI/Toolkit/CombatHudController.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using RogueliteAutoBattler.Combat.Visuals;
+using RogueliteAutoBattler.Economy;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -7,7 +8,29 @@ namespace RogueliteAutoBattler.UI.Toolkit
 {
     public class CombatHudController : MonoBehaviour
     {
+        private const string LogTag = "[CombatHudController]";
+        private const string GoldBadgeElementName = "gold-badge";
+        private const string GoldLabelElementName = "gold-label";
+        private const string BattleCompactLabelElementName = "battle-compact-label";
+        private const string AnnouncementOverlayElementName = "announcement-overlay";
+        private const string AnnouncementLabelElementName = "announcement-label";
+        private const string StepProgressContainerElementName = "step-progress-container";
+        private const string InfoPanelRootElementName = "info-panel-root";
+        private const string InfoEmptyLabelElementName = "info-empty-label";
+        private const string InfoContentElementName = "info-content";
+        private const string InfoNameLabelElementName = "info-name-label";
+        private const string InfoTeamPosLabelElementName = "info-team-pos-label";
+        private const string NavPrevButtonElementName = "nav-prev-btn";
+        private const string NavNextButtonElementName = "nav-next-btn";
+        private const string InfoTabStatsButtonElementName = "info-tab-stats";
+        private const string InfoTabTraitsButtonElementName = "info-tab-traits";
+        private const string InfoTabLootButtonElementName = "info-tab-loot";
+        private const string InfoTabStatsContentElementName = "info-tab-content-stats";
+        private const string InfoTabTraitsContentElementName = "info-tab-content-traits";
+        private const string InfoTabLootContentElementName = "info-tab-content-loot";
+
         [SerializeField] private UIDocument _uiDocument;
+        [SerializeField] private GoldWallet _goldWallet;
 
         private GoldBadgeController _goldBadge;
         private BattleIndicatorController _battleIndicator;
@@ -19,23 +42,23 @@ namespace RogueliteAutoBattler.UI.Toolkit
         {
             if (_uiDocument == null)
             {
-                Debug.LogWarning("[CombatHudController] UIDocument is not assigned.");
+                Debug.LogWarning($"{LogTag} UIDocument is not assigned.");
                 return;
             }
 
             VisualElement root = _uiDocument.rootVisualElement;
             if (root == null)
             {
-                Debug.LogWarning("[CombatHudController] rootVisualElement is null.");
+                Debug.LogWarning($"{LogTag} rootVisualElement is null.");
                 return;
             }
 
-            if (!TryQuery<VisualElement>(root, "gold-badge", out VisualElement goldBadgeElement)) return;
-            if (!TryQuery<Label>(root, "gold-label", out Label goldLabel)) return;
-            if (!TryQuery<Label>(root, "battle-compact-label", out Label battleCompactLabel)) return;
-            if (!TryQuery<VisualElement>(root, "announcement-overlay", out VisualElement announcementOverlay)) return;
-            if (!TryQuery<Label>(root, "announcement-label", out Label announcementLabel)) return;
-            if (!TryQuery<VisualElement>(root, "step-progress-container", out VisualElement stepProgressContainer)) return;
+            if (!TryQuery<VisualElement>(root, GoldBadgeElementName, out VisualElement goldBadgeElement)) return;
+            if (!TryQuery<Label>(root, GoldLabelElementName, out Label goldLabel)) return;
+            if (!TryQuery<Label>(root, BattleCompactLabelElementName, out Label battleCompactLabel)) return;
+            if (!TryQuery<VisualElement>(root, AnnouncementOverlayElementName, out VisualElement announcementOverlay)) return;
+            if (!TryQuery<Label>(root, AnnouncementLabelElementName, out Label announcementLabel)) return;
+            if (!TryQuery<VisualElement>(root, StepProgressContainerElementName, out VisualElement stepProgressContainer)) return;
 
             _goldBadgeElement = goldBadgeElement;
 
@@ -43,23 +66,23 @@ namespace RogueliteAutoBattler.UI.Toolkit
             _battleIndicator = new BattleIndicatorController(battleCompactLabel, announcementOverlay, announcementLabel, this);
             _stepProgressBar = new StepProgressBarController(stepProgressContainer);
 
-            _goldBadge.Initialize();
+            _goldBadge.Initialize(_goldWallet);
             _battleIndicator.Initialize();
             _stepProgressBar.Initialize();
 
-            if (!TryQuery<VisualElement>(root, "info-panel-root", out VisualElement panelRoot)) return;
-            if (!TryQuery<Label>(root, "info-empty-label", out Label emptyLabel)) return;
-            if (!TryQuery<VisualElement>(root, "info-content", out VisualElement contentContainer)) return;
-            if (!TryQuery<Label>(root, "info-name-label", out Label nameLabel)) return;
-            if (!TryQuery<Label>(root, "info-team-pos-label", out Label teamPosLabel)) return;
-            if (!TryQuery<Button>(root, "nav-prev-btn", out Button prevButton)) return;
-            if (!TryQuery<Button>(root, "nav-next-btn", out Button nextButton)) return;
-            if (!TryQuery<Button>(root, "info-tab-stats", out Button tabStats)) return;
-            if (!TryQuery<Button>(root, "info-tab-traits", out Button tabTraits)) return;
-            if (!TryQuery<Button>(root, "info-tab-loot", out Button tabLoot)) return;
-            if (!TryQuery<ScrollView>(root, "info-tab-content-stats", out ScrollView statsScrollView)) return;
-            if (!TryQuery<VisualElement>(root, "info-tab-content-traits", out VisualElement traitsContent)) return;
-            if (!TryQuery<VisualElement>(root, "info-tab-content-loot", out VisualElement lootContent)) return;
+            if (!TryQuery<VisualElement>(root, InfoPanelRootElementName, out VisualElement panelRoot)) return;
+            if (!TryQuery<Label>(root, InfoEmptyLabelElementName, out Label emptyLabel)) return;
+            if (!TryQuery<VisualElement>(root, InfoContentElementName, out VisualElement contentContainer)) return;
+            if (!TryQuery<Label>(root, InfoNameLabelElementName, out Label nameLabel)) return;
+            if (!TryQuery<Label>(root, InfoTeamPosLabelElementName, out Label teamPosLabel)) return;
+            if (!TryQuery<Button>(root, NavPrevButtonElementName, out Button prevButton)) return;
+            if (!TryQuery<Button>(root, NavNextButtonElementName, out Button nextButton)) return;
+            if (!TryQuery<Button>(root, InfoTabStatsButtonElementName, out Button tabStats)) return;
+            if (!TryQuery<Button>(root, InfoTabTraitsButtonElementName, out Button tabTraits)) return;
+            if (!TryQuery<Button>(root, InfoTabLootButtonElementName, out Button tabLoot)) return;
+            if (!TryQuery<ScrollView>(root, InfoTabStatsContentElementName, out ScrollView statsScrollView)) return;
+            if (!TryQuery<VisualElement>(root, InfoTabTraitsContentElementName, out VisualElement traitsContent)) return;
+            if (!TryQuery<VisualElement>(root, InfoTabLootContentElementName, out VisualElement lootContent)) return;
 
             var tabButtons = new[] { tabStats, tabTraits, tabLoot };
             var tabContents = new VisualElement[] { statsScrollView, traitsContent, lootContent };
@@ -88,25 +111,25 @@ namespace RogueliteAutoBattler.UI.Toolkit
         private void OnGoldBadgeGeometryChanged(GeometryChangedEvent evt)
         {
             Rect panelBound = _goldBadgeElement.worldBound;
-            if (panelBound.width <= 0 || panelBound.height <= 0)
+            if (panelBound.width <= 0f || panelBound.height <= 0f)
                 return;
 
-            Rect screenBound = PanelToScreenRect(panelBound);
+            Rect screenBound = PanelRectToScreenRect(panelBound);
             CoinFlyService.InitializeToolkitTarget(screenBound, () => _goldBadge.Punch());
             CoinFlyService.UpdateToolkitTargetBound(screenBound);
         }
 
-        private Rect PanelToScreenRect(Rect panelRect)
+        private Rect PanelRectToScreenRect(Rect panelRect)
         {
             VisualElement panelRoot = _goldBadgeElement.panel.visualTree;
             Rect fullPanel = panelRoot.worldBound;
-            float scaleX = Screen.width / fullPanel.width;
-            float scaleY = Screen.height / fullPanel.height;
+            float panelToScreenScaleX = Screen.width / fullPanel.width;
+            float panelToScreenScaleY = Screen.height / fullPanel.height;
             return new Rect(
-                panelRect.x * scaleX,
-                panelRect.y * scaleY,
-                panelRect.width * scaleX,
-                panelRect.height * scaleY);
+                panelRect.x * panelToScreenScaleX,
+                panelRect.y * panelToScreenScaleY,
+                panelRect.width * panelToScreenScaleX,
+                panelRect.height * panelToScreenScaleY);
         }
 
         private void OnDestroy()
@@ -131,7 +154,7 @@ namespace RogueliteAutoBattler.UI.Toolkit
             result = root.Q<T>(elementName);
             if (result != null) return true;
 
-            Debug.LogWarning($"[CombatHudController] Element '{elementName}' not found.");
+            Debug.LogWarning($"{LogTag} Element '{elementName}' not found.");
             return false;
         }
     }

--- a/Assets/Scripts/UI/Toolkit/GoldBadgeController.cs
+++ b/Assets/Scripts/UI/Toolkit/GoldBadgeController.cs
@@ -8,8 +8,10 @@ namespace RogueliteAutoBattler.UI.Toolkit
 {
     public class GoldBadgeController
     {
+        private const string LogTag = "[GoldBadgeController]";
         private const float PeakScale = 1.15f;
         private const float HalfDuration = 0.075f;
+        private const float RestScale = 1f;
 
         private readonly VisualElement _badgeRoot;
         private readonly Label _goldLabel;
@@ -27,21 +29,14 @@ namespace RogueliteAutoBattler.UI.Toolkit
             _coroutineHost = coroutineHost;
         }
 
-        public void Initialize()
+        public void Initialize(GoldWallet wallet)
         {
-            var wallets = UnityEngine.Object.FindObjectsByType<GoldWallet>(FindObjectsSortMode.None);
-            if (wallets.Length == 0)
+            if (wallet == null)
             {
+                Debug.LogWarning($"{LogTag} Initialize called with null wallet; badge will not update.");
                 return;
             }
 
-            _wallet = wallets[0];
-            _wallet.OnGoldChanged += OnGoldChanged;
-            _goldLabel.text = GoldFormatter.Format(_wallet.Gold);
-        }
-
-        internal void InitializeForTest(GoldWallet wallet)
-        {
             _wallet = wallet;
             _wallet.OnGoldChanged += OnGoldChanged;
             _goldLabel.text = GoldFormatter.Format(_wallet.Gold);
@@ -78,10 +73,9 @@ namespace RogueliteAutoBattler.UI.Toolkit
             while (elapsed < HalfDuration)
             {
                 elapsed += Time.deltaTime;
-                float t = Mathf.Clamp01(elapsed / HalfDuration);
-                float easeOut = 1f - (1f - t) * (1f - t);
-                float scale = Mathf.Lerp(1f, PeakScale, easeOut);
-                _badgeRoot.style.scale = new Scale(new Vector3(scale, scale, 1f));
+                float normalizedTime = Mathf.Clamp01(elapsed / HalfDuration);
+                float easeOut = 1f - (1f - normalizedTime) * (1f - normalizedTime);
+                ApplyUniformScale(Mathf.Lerp(RestScale, PeakScale, easeOut));
                 yield return null;
             }
 
@@ -90,16 +84,20 @@ namespace RogueliteAutoBattler.UI.Toolkit
             while (elapsed < HalfDuration)
             {
                 elapsed += Time.deltaTime;
-                float t = Mathf.Clamp01(elapsed / HalfDuration);
-                float easeIn = t * t;
-                float scale = Mathf.Lerp(PeakScale, 1f, easeIn);
-                _badgeRoot.style.scale = new Scale(new Vector3(scale, scale, 1f));
+                float normalizedTime = Mathf.Clamp01(elapsed / HalfDuration);
+                float easeIn = normalizedTime * normalizedTime;
+                ApplyUniformScale(Mathf.Lerp(PeakScale, RestScale, easeIn));
                 yield return null;
             }
 
-            _badgeRoot.style.scale = new Scale(new Vector3(1f, 1f, 1f));
+            ApplyUniformScale(RestScale);
             _punchCoroutine = null;
             onComplete?.Invoke();
+        }
+
+        private void ApplyUniformScale(float scale)
+        {
+            _badgeRoot.style.scale = new Scale(new Vector3(scale, scale, 1f));
         }
     }
 }

--- a/Assets/Tests/EditMode/NewGameSceneBuilderTests.cs
+++ b/Assets/Tests/EditMode/NewGameSceneBuilderTests.cs
@@ -1,12 +1,12 @@
 using NUnit.Framework;
 using RogueliteAutoBattler.Core;
+using RogueliteAutoBattler.Economy;
 using RogueliteAutoBattler.UI.Toolkit;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem.UI;
-using UnityEngine.SceneManagement;
 using UnityEngine.UIElements;
 
 namespace RogueliteAutoBattler.Tests.EditMode
@@ -148,6 +148,44 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             Assert.DoesNotThrow(() => EditorApplication.ExecuteMenuItem(SetupMenuItemPath));
             Assert.IsNotNull(GameObject.Find(GameBootstrap.CombatWorldName), "CombatWorld must still exist after re-running setup.");
+        }
+
+        [Test]
+        public void SetupNewGameScene_CreatesGoldWallet()
+        {
+            EditorApplication.ExecuteMenuItem(SetupMenuItemPath);
+
+            GoldWallet[] goldWallets = Object.FindObjectsByType<GoldWallet>(FindObjectsSortMode.None);
+            Assert.AreEqual(1, goldWallets.Length,
+                "Exactly one GoldWallet must exist in the scene after setup (#215).");
+        }
+
+        [Test]
+        public void SetupNewGameScene_TwiceInSameScene_DoesNotDuplicateGoldWallet()
+        {
+            EditorApplication.ExecuteMenuItem(SetupMenuItemPath);
+            EditorApplication.ExecuteMenuItem(SetupMenuItemPath);
+
+            GoldWallet[] goldWallets = Object.FindObjectsByType<GoldWallet>(FindObjectsSortMode.None);
+            Assert.AreEqual(1, goldWallets.Length,
+                "Running setup twice must not duplicate the GoldWallet (#215 idempotency).");
+        }
+
+        [Test]
+        public void SetupNewGameScene_CombatHudController_HasGoldWalletAssigned()
+        {
+            EditorApplication.ExecuteMenuItem(SetupMenuItemPath);
+
+            CombatHudController combatHud = Object.FindFirstObjectByType<CombatHudController>(FindObjectsInactive.Include);
+            Assert.IsNotNull(combatHud, "CombatHudController must exist in the scene after setup.");
+
+            var serializedHud = new SerializedObject(combatHud);
+            SerializedProperty goldWalletProperty = serializedHud.FindProperty("_goldWallet");
+            Assert.IsNotNull(goldWalletProperty, "CombatHudController must expose a serialized _goldWallet field.");
+            Assert.IsNotNull(goldWalletProperty.objectReferenceValue,
+                "CombatHudController._goldWallet must be wired after setup (#215).");
+            Assert.IsInstanceOf<GoldWallet>(goldWalletProperty.objectReferenceValue,
+                "CombatHudController._goldWallet must reference a GoldWallet component.");
         }
 
         private static UIDocument FindNavigationHostUIDocument()

--- a/Assets/Tests/EditMode/WalletsBuilderTests.cs
+++ b/Assets/Tests/EditMode/WalletsBuilderTests.cs
@@ -1,0 +1,72 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Economy;
+using RogueliteAutoBattler.Editor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    [TestFixture]
+    public class WalletsBuilderTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+        }
+
+        [Test]
+        public void FindOrCreateGoldWallet_CreatesOneWhenAbsent()
+        {
+            GoldWallet wallet = WalletsBuilder.FindOrCreateGoldWallet();
+
+            Assert.IsNotNull(wallet, "FindOrCreateGoldWallet must never return null.");
+            GoldWallet[] walletsInScene = Object.FindObjectsByType<GoldWallet>(FindObjectsSortMode.None);
+            Assert.AreEqual(1, walletsInScene.Length,
+                "Exactly one GoldWallet must exist in the scene after the first call.");
+        }
+
+        [Test]
+        public void FindOrCreateGoldWallet_ReturnsExisting_DoesNotDuplicate()
+        {
+            GoldWallet first = WalletsBuilder.FindOrCreateGoldWallet();
+            GoldWallet second = WalletsBuilder.FindOrCreateGoldWallet();
+
+            GoldWallet[] walletsInScene = Object.FindObjectsByType<GoldWallet>(FindObjectsSortMode.None);
+            Assert.AreEqual(1, walletsInScene.Length,
+                "Calling FindOrCreateGoldWallet twice must not duplicate the wallet.");
+            Assert.AreSame(first, second,
+                "The second call must return the same GoldWallet instance as the first.");
+        }
+
+        [Test]
+        public void FindOrCreateSkillPointWallet_CreatesOneWhenAbsent()
+        {
+            SkillPointWallet wallet = WalletsBuilder.FindOrCreateSkillPointWallet();
+
+            Assert.IsNotNull(wallet, "FindOrCreateSkillPointWallet must never return null.");
+            SkillPointWallet[] walletsInScene = Object.FindObjectsByType<SkillPointWallet>(FindObjectsSortMode.None);
+            Assert.AreEqual(1, walletsInScene.Length,
+                "Exactly one SkillPointWallet must exist in the scene after the first call.");
+        }
+
+        [Test]
+        public void FindOrCreateSkillPointWallet_ReturnsExisting_DoesNotDuplicate()
+        {
+            SkillPointWallet first = WalletsBuilder.FindOrCreateSkillPointWallet();
+            SkillPointWallet second = WalletsBuilder.FindOrCreateSkillPointWallet();
+
+            SkillPointWallet[] walletsInScene = Object.FindObjectsByType<SkillPointWallet>(FindObjectsSortMode.None);
+            Assert.AreEqual(1, walletsInScene.Length,
+                "Calling FindOrCreateSkillPointWallet twice must not duplicate the wallet.");
+            Assert.AreSame(first, second,
+                "The second call must return the same SkillPointWallet instance as the first.");
+        }
+    }
+}

--- a/Assets/Tests/EditMode/WalletsBuilderTests.cs.meta
+++ b/Assets/Tests/EditMode/WalletsBuilderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1fd676d386398264f8e0477a9a9ebd87

--- a/Assets/Tests/PlayMode/CombatHudControllerTests.cs
+++ b/Assets/Tests/PlayMode/CombatHudControllerTests.cs
@@ -1,0 +1,68 @@
+#if UNITY_EDITOR
+using System.Collections;
+using NUnit.Framework;
+using RogueliteAutoBattler.Economy;
+using RogueliteAutoBattler.UI.Toolkit;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace RogueliteAutoBattler.Tests.PlayMode
+{
+    public class CombatHudControllerTests : PlayModeTestBase
+    {
+        private const string PanelSettingsPath = "Assets/UI/MainPanelSettings.asset";
+        private const string MainLayoutPath = "Assets/UI/Layouts/MainLayout.uxml";
+        private const string GoldLabelElementName = "gold-label";
+        private const string UiDocumentFieldName = "_uiDocument";
+        private const string GoldWalletFieldName = "_goldWallet";
+        private const int AddedGoldAmount = 500;
+
+        [UnityTest]
+        public IEnumerator HudGoldLabel_UpdatesWhenWalletAddsGold()
+        {
+            PanelSettings panelSettings = AssetDatabase.LoadAssetAtPath<PanelSettings>(PanelSettingsPath);
+            Assert.IsNotNull(panelSettings, $"MainPanelSettings must exist at {PanelSettingsPath}.");
+
+            VisualTreeAsset visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(MainLayoutPath);
+            Assert.IsNotNull(visualTree, $"MainLayout must exist at {MainLayoutPath}.");
+
+            var walletGo = Track(new GameObject("GoldWallet"));
+            GoldWallet wallet = walletGo.AddComponent<GoldWallet>();
+
+            var hudGo = Track(new GameObject("CombatHud"));
+            hudGo.SetActive(false);
+
+            UIDocument uiDocument = hudGo.AddComponent<UIDocument>();
+            uiDocument.panelSettings = panelSettings;
+            uiDocument.visualTreeAsset = visualTree;
+
+            CombatHudController hudController = hudGo.AddComponent<CombatHudController>();
+            var hudSerialized = new SerializedObject(hudController);
+            SerializedProperty uiDocumentProperty = hudSerialized.FindProperty(UiDocumentFieldName);
+            Assert.IsNotNull(uiDocumentProperty, $"CombatHudController must expose a serialized {UiDocumentFieldName} field.");
+            uiDocumentProperty.objectReferenceValue = uiDocument;
+
+            SerializedProperty goldWalletProperty = hudSerialized.FindProperty(GoldWalletFieldName);
+            Assert.IsNotNull(goldWalletProperty, $"CombatHudController must expose a serialized {GoldWalletFieldName} field.");
+            goldWalletProperty.objectReferenceValue = wallet;
+
+            hudSerialized.ApplyModifiedPropertiesWithoutUndo();
+
+            hudGo.SetActive(true);
+
+            yield return null;
+
+            wallet.Add(AddedGoldAmount);
+
+            yield return null;
+
+            Label goldLabel = uiDocument.rootVisualElement.Q<Label>(GoldLabelElementName);
+            Assert.IsNotNull(goldLabel, $"{GoldLabelElementName} must be present in MainLayout.uxml.");
+            Assert.AreEqual(AddedGoldAmount.ToString(), goldLabel.text,
+                "HUD gold label must reflect wallet total after Add (#215).");
+        }
+    }
+}
+#endif

--- a/Assets/Tests/PlayMode/CombatHudControllerTests.cs.meta
+++ b/Assets/Tests/PlayMode/CombatHudControllerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a5e48de511e14e34cb9c24f0f8a9419f

--- a/Assets/Tests/PlayMode/GoldBadgeControllerTests.cs
+++ b/Assets/Tests/PlayMode/GoldBadgeControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using RogueliteAutoBattler.Economy;
 using RogueliteAutoBattler.UI.Toolkit;
@@ -10,6 +11,12 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 {
     public class GoldBadgeControllerTests : PlayModeTestBase
     {
+        private const int SmallGoldAmount = 500;
+        private const int LargeGoldAmount = 1500;
+        private const string LargeGoldFormatted = "1.5K";
+        private const string ZeroGoldFormatted = "0";
+        private const float PunchWarmupSeconds = 0.05f;
+
         private GoldWallet _wallet;
         private VisualElement _badgeRoot;
         private Label _goldLabel;
@@ -26,29 +33,29 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             _goldLabel = new Label();
 
             _controller = new GoldBadgeController(_badgeRoot, _goldLabel, _wallet);
-            _controller.InitializeForTest(_wallet);
+            _controller.Initialize(_wallet);
         }
 
         [Test]
         public void GoldLabel_ShowsZero_OnInitialize()
         {
-            Assert.AreEqual("0", _controller.DisplayText);
+            Assert.AreEqual(ZeroGoldFormatted, _controller.DisplayText);
         }
 
         [Test]
         public void GoldLabel_Updates_WhenGoldAdded()
         {
-            _wallet.Add(500);
+            _wallet.Add(SmallGoldAmount);
 
-            Assert.AreEqual("500", _controller.DisplayText);
+            Assert.AreEqual(SmallGoldAmount.ToString(), _controller.DisplayText);
         }
 
         [Test]
         public void GoldLabel_FormatsCompact_WhenGoldLarge()
         {
-            _wallet.Add(1500);
+            _wallet.Add(LargeGoldAmount);
 
-            Assert.AreEqual("1.5K", _controller.DisplayText);
+            Assert.AreEqual(LargeGoldFormatted, _controller.DisplayText);
         }
 
         [Test]
@@ -58,7 +65,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             _wallet.Add(999);
 
-            Assert.AreEqual("0", _controller.DisplayText);
+            Assert.AreEqual(ZeroGoldFormatted, _controller.DisplayText);
         }
 
         [UnityTest]
@@ -66,10 +73,50 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         {
             _controller.Punch();
 
-            yield return new WaitForSeconds(0.05f);
+            yield return new WaitForSeconds(PunchWarmupSeconds);
 
             Scale scaleValue = _badgeRoot.style.scale.value;
             Assert.Greater(scaleValue.value.x, 1.0f);
+        }
+
+        [Test]
+        public void Initialize_WithNullWallet_LogsWarning_AndDoesNotSubscribe()
+        {
+            var freshWalletGo = Track(new GameObject("FreshGoldWallet"));
+            var freshWallet = freshWalletGo.AddComponent<GoldWallet>();
+
+            var freshBadgeRoot = new VisualElement();
+            var freshGoldLabel = new Label(ZeroGoldFormatted);
+            var freshController = new GoldBadgeController(freshBadgeRoot, freshGoldLabel, freshWallet);
+
+            LogAssert.Expect(LogType.Warning, new Regex("GoldBadgeController.*null wallet"));
+
+            freshController.Initialize(null);
+
+            freshWallet.Add(200);
+
+            Assert.AreEqual(ZeroGoldFormatted, freshController.DisplayText,
+                "Badge must not update when initialized with a null wallet.");
+        }
+
+        [UnityTest]
+        public IEnumerator Initialize_WithWallet_UpdatesLabelOnSubsequentAdd()
+        {
+            var localWalletGo = Track(new GameObject("LocalGoldWallet"));
+            var localWallet = localWalletGo.AddComponent<GoldWallet>();
+
+            var localBadgeRoot = new VisualElement();
+            var localGoldLabel = new Label();
+            var localController = new GoldBadgeController(localBadgeRoot, localGoldLabel, localWallet);
+
+            localController.Initialize(localWallet);
+
+            localWallet.Add(250);
+
+            yield return null;
+
+            Assert.AreEqual("250", localController.DisplayText,
+                "Badge must subscribe to wallet events when Initialize(wallet) is called and reflect new totals (regression guard for #215).");
         }
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ Assets/
         NewGameSceneBuilder.cs
         RoundedRectSpriteGenerator.cs
         SkillTreeBuilder.cs
+        WalletsBuilder.cs
       Windows/
         GameDesignerWindow.cs
         LevelDesignerTab.cs
@@ -220,6 +221,7 @@ Assets/
       ToolkitIScreenTests.cs
       ToolkitNavigationManagerTests.cs
       ToolkitScreenStackTests.cs
+      WalletsBuilderTests.cs
     PlayMode/
       Tests.PlayMode.asmdef
       TestUtils/
@@ -235,6 +237,7 @@ Assets/
       CoinFlyServiceTests.cs
       CoinFlyTests.cs
       CombatControllerTests.cs
+      CombatHudControllerTests.cs
       CombatSetupHelperTests.cs
       CombatSpawnManagerTests.cs
       CombatStatsRegenTests.cs


### PR DESCRIPTION
## Summary
- Fix: GoldBadgeController now subscribes to GoldWallet via explicit SerializeField injection instead of a race-prone FindObjectsByType at Awake
- NewGameSceneBuilder ensures a GoldWallet exists before building the HUD; CombatHudBuilder wires the reference through SerializedObject and the scene file persists it
- Extract FindOrCreateGoldWallet / FindOrCreateSkillPointWallet into shared WalletsBuilder (DRY between SkillTreeBuilder and NewGameSceneBuilder)
- 9 new automated tests (4 EditMode, 5 PlayMode) lock the regression and wallet-builder idempotency

Closes #215

## Test plan
- [x] EditMode: 160/160 green (incl. 4 new WalletsBuilderTests + 3 new NewGameSceneBuilderTests)
- [x] PlayMode: 9 new tests for #215 all green; pre-existing CanvasFactoryTests.Create_SetsSortingLayer + NavigationHostTests inconclusive are unrelated
- [x] User validated: coin animation → badge chiffre now visually increments, punch effect intact, skill tree gold unaffected, menu-item idempotent