### PR TITLE
fix(hud): persistent gold + skill-point badges across all screens

### DIFF
--- a/Assets/Scripts/Editor/Builders/CombatHudBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/CombatHudBuilder.cs
@@ -18,7 +18,7 @@ namespace RogueliteAutoBattler.Editor
         private const float CoinFlyReferenceResolutionY = 1920f;
         private const float CoinFlyMatchWidthOrHeight = 0.5f;
 
-        internal static void SetupToolkitCombatHud(GameObject navigationHostGo, GoldWallet goldWallet)
+        internal static void SetupToolkitCombatHud(GameObject navigationHostGo, GoldWallet goldWallet, SkillPointWallet skillPointWallet)
         {
             UIDocument uiDocument = navigationHostGo.GetComponent<UIDocument>();
 
@@ -26,6 +26,7 @@ namespace RogueliteAutoBattler.Editor
             var combatHudSo = new SerializedObject(combatHud);
             EditorUIFactory.SetObj(combatHudSo, "_uiDocument", uiDocument);
             EditorUIFactory.SetObj(combatHudSo, "_goldWallet", goldWallet);
+            EditorUIFactory.SetObj(combatHudSo, "_skillPointWallet", skillPointWallet);
             combatHudSo.ApplyModifiedProperties();
 
             var coinFlyOverlayGo = new GameObject(CoinFlyOverlayGameObjectName);

--- a/Assets/Scripts/Editor/Builders/NewGameSceneBuilder.cs
+++ b/Assets/Scripts/Editor/Builders/NewGameSceneBuilder.cs
@@ -57,7 +57,7 @@ namespace RogueliteAutoBattler.Editor
             Undo.RegisterCreatedObjectUndo(navHostGo, NavigationHostUndoLabel);
             GoldWallet goldWallet = WalletsBuilder.FindOrCreateGoldWallet();
             SkillPointWallet skillPointWallet = WalletsBuilder.FindOrCreateSkillPointWallet();
-            CombatHudBuilder.SetupToolkitCombatHud(navHostGo, goldWallet);
+            CombatHudBuilder.SetupToolkitCombatHud(navHostGo, goldWallet, skillPointWallet);
             SkillTreeScreenBuilder.SetupSkillTreeScreen(navHostGo, goldWallet, skillPointWallet);
 
             Undo.CollapseUndoOperations(undoGroup);

--- a/Assets/Scripts/UI/Toolkit/CombatHudController.cs
+++ b/Assets/Scripts/UI/Toolkit/CombatHudController.cs
@@ -11,6 +11,8 @@ namespace RogueliteAutoBattler.UI.Toolkit
         private const string LogTag = "[CombatHudController]";
         private const string GoldBadgeElementName = "gold-badge";
         private const string GoldLabelElementName = "gold-label";
+        private const string SkillPointBadgeElementName = "skill-point-badge";
+        private const string SkillPointLabelElementName = "skill-point-label";
         private const string BattleCompactLabelElementName = "battle-compact-label";
         private const string AnnouncementOverlayElementName = "announcement-overlay";
         private const string AnnouncementLabelElementName = "announcement-label";
@@ -31,8 +33,10 @@ namespace RogueliteAutoBattler.UI.Toolkit
 
         [SerializeField] private UIDocument _uiDocument;
         [SerializeField] private GoldWallet _goldWallet;
+        [SerializeField] private SkillPointWallet _skillPointWallet;
 
         private GoldBadgeController _goldBadge;
+        private SkillPointBadgeController _skillPointBadge;
         private BattleIndicatorController _battleIndicator;
         private StepProgressBarController _stepProgressBar;
         private VisualElement _goldBadgeElement;
@@ -55,6 +59,8 @@ namespace RogueliteAutoBattler.UI.Toolkit
 
             if (!TryQuery<VisualElement>(root, GoldBadgeElementName, out VisualElement goldBadgeElement)) return;
             if (!TryQuery<Label>(root, GoldLabelElementName, out Label goldLabel)) return;
+            if (!TryQuery<VisualElement>(root, SkillPointBadgeElementName, out VisualElement skillPointBadgeElement)) return;
+            if (!TryQuery<Label>(root, SkillPointLabelElementName, out Label skillPointLabel)) return;
             if (!TryQuery<Label>(root, BattleCompactLabelElementName, out Label battleCompactLabel)) return;
             if (!TryQuery<VisualElement>(root, AnnouncementOverlayElementName, out VisualElement announcementOverlay)) return;
             if (!TryQuery<Label>(root, AnnouncementLabelElementName, out Label announcementLabel)) return;
@@ -63,10 +69,12 @@ namespace RogueliteAutoBattler.UI.Toolkit
             _goldBadgeElement = goldBadgeElement;
 
             _goldBadge = new GoldBadgeController(goldBadgeElement, goldLabel, this);
+            _skillPointBadge = new SkillPointBadgeController(skillPointBadgeElement, skillPointLabel, this);
             _battleIndicator = new BattleIndicatorController(battleCompactLabel, announcementOverlay, announcementLabel, this);
             _stepProgressBar = new StepProgressBarController(stepProgressContainer);
 
             _goldBadge.Initialize(_goldWallet);
+            _skillPointBadge.Initialize(_skillPointWallet);
             _battleIndicator.Initialize();
             _stepProgressBar.Initialize();
 
@@ -139,6 +147,7 @@ namespace RogueliteAutoBattler.UI.Toolkit
 
             _allyStatsPanel?.Dispose();
             _goldBadge?.Dispose();
+            _skillPointBadge?.Dispose();
             _battleIndicator?.Dispose();
             _stepProgressBar?.Dispose();
         }

--- a/Assets/Scripts/UI/Toolkit/SkillPointBadgeController.cs
+++ b/Assets/Scripts/UI/Toolkit/SkillPointBadgeController.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections;
+using RogueliteAutoBattler.Economy;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace RogueliteAutoBattler.UI.Toolkit
+{
+    public class SkillPointBadgeController
+    {
+        private const string LogTag = "[SkillPointBadgeController]";
+        private const float PeakScale = 1.15f;
+        private const float HalfDuration = 0.075f;
+        private const float RestScale = 1f;
+
+        private readonly VisualElement _badgeRoot;
+        private readonly Label _pointsLabel;
+        private readonly MonoBehaviour _coroutineHost;
+
+        private SkillPointWallet _wallet;
+        private Coroutine _punchCoroutine;
+
+        internal string DisplayText => _pointsLabel.text;
+
+        public SkillPointBadgeController(VisualElement badgeRoot, Label pointsLabel, MonoBehaviour coroutineHost)
+        {
+            _badgeRoot = badgeRoot;
+            _pointsLabel = pointsLabel;
+            _coroutineHost = coroutineHost;
+        }
+
+        public void Initialize(SkillPointWallet wallet)
+        {
+            if (wallet == null)
+            {
+                Debug.LogWarning($"{LogTag} Initialize called with null wallet; badge will not update.");
+                return;
+            }
+
+            _wallet = wallet;
+            _wallet.OnPointsChanged += OnPointsChanged;
+            _pointsLabel.text = _wallet.Points.ToString();
+        }
+
+        public void Dispose()
+        {
+            if (_wallet != null)
+            {
+                _wallet.OnPointsChanged -= OnPointsChanged;
+            }
+        }
+
+        public void Punch(Action onComplete = null)
+        {
+            if (_punchCoroutine != null)
+            {
+                _coroutineHost.StopCoroutine(_punchCoroutine);
+            }
+
+            _punchCoroutine = _coroutineHost.StartCoroutine(PunchCoroutine(onComplete));
+        }
+
+        private void OnPointsChanged(int total)
+        {
+            _pointsLabel.text = total.ToString();
+            Punch();
+        }
+
+        private IEnumerator PunchCoroutine(Action onComplete)
+        {
+            float elapsed = 0f;
+
+            while (elapsed < HalfDuration)
+            {
+                elapsed += Time.deltaTime;
+                float normalizedTime = Mathf.Clamp01(elapsed / HalfDuration);
+                float easeOut = 1f - (1f - normalizedTime) * (1f - normalizedTime);
+                ApplyUniformScale(Mathf.Lerp(RestScale, PeakScale, easeOut));
+                yield return null;
+            }
+
+            elapsed = 0f;
+
+            while (elapsed < HalfDuration)
+            {
+                elapsed += Time.deltaTime;
+                float normalizedTime = Mathf.Clamp01(elapsed / HalfDuration);
+                float easeIn = normalizedTime * normalizedTime;
+                ApplyUniformScale(Mathf.Lerp(PeakScale, RestScale, easeIn));
+                yield return null;
+            }
+
+            ApplyUniformScale(RestScale);
+            _punchCoroutine = null;
+            onComplete?.Invoke();
+        }
+
+        private void ApplyUniformScale(float scale)
+        {
+            _badgeRoot.style.scale = new Scale(new Vector3(scale, scale, 1f));
+        }
+    }
+}

--- a/Assets/Scripts/UI/Toolkit/SkillPointBadgeController.cs.meta
+++ b/Assets/Scripts/UI/Toolkit/SkillPointBadgeController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 60d040ca4e833364ba69e173589fe975

--- a/Assets/UI/Layouts/MainLayout.uxml
+++ b/Assets/UI/Layouts/MainLayout.uxml
@@ -4,10 +4,6 @@
         <ui:VisualElement name="game-area" class="game-area" picking-mode="Ignore">
             <ui:VisualElement name="screen-default" class="screen-container screen-default" picking-mode="Ignore">
                 <ui:VisualElement name="hud-overlay" picking-mode="Ignore" class="hud-overlay">
-                    <ui:VisualElement name="gold-badge" class="gold-badge">
-                        <ui:VisualElement name="gold-icon" class="gold-icon" />
-                        <ui:Label name="gold-label" text="0" class="gold-label" />
-                    </ui:VisualElement>
                     <ui:Label name="battle-compact-label" text="1-1" class="battle-compact-label" />
                     <ui:VisualElement name="step-progress-container" class="step-progress-container" />
                     <ui:VisualElement name="announcement-overlay" picking-mode="Ignore" class="announcement-overlay">
@@ -57,6 +53,16 @@
             <ui:VisualElement name="screen-shop" class="screen-container hidden">
                 <ui:VisualElement class="screen-placeholder screen-shop-bg">
                     <ui:Label text="SHOP" class="screen-placeholder-label" />
+                </ui:VisualElement>
+            </ui:VisualElement>
+            <ui:VisualElement name="wallets-overlay" picking-mode="Ignore" class="wallets-overlay">
+                <ui:VisualElement name="skill-point-badge" picking-mode="Ignore" class="skill-point-badge">
+                    <ui:VisualElement name="skill-point-icon" picking-mode="Ignore" class="skill-point-icon" />
+                    <ui:Label name="skill-point-label" picking-mode="Ignore" text="0" class="skill-point-label" />
+                </ui:VisualElement>
+                <ui:VisualElement name="gold-badge" picking-mode="Ignore" class="gold-badge">
+                    <ui:VisualElement name="gold-icon" picking-mode="Ignore" class="gold-icon" />
+                    <ui:Label name="gold-label" picking-mode="Ignore" text="0" class="gold-label" />
                 </ui:VisualElement>
             </ui:VisualElement>
         </ui:VisualElement>

--- a/Assets/UI/Styles/MainStyle.uss
+++ b/Assets/UI/Styles/MainStyle.uss
@@ -7,6 +7,7 @@
     --color-tab-text-active: #ffffff;
     --color-text: #e0e0e0;
     --color-gold: rgb(255, 215, 0);
+    --color-skill-point: rgb(120, 210, 255);
     --spacing-xs: 2px;
     --spacing-sm: 4px;
     --spacing-md: 8px;
@@ -149,6 +150,12 @@
     flex-direction: column;
 }
 
+.wallets-overlay {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+}
+
 .gold-badge {
     position: absolute;
     right: 8px;
@@ -172,6 +179,34 @@
     font-size: var(--hud-gold-font-size);
     color: var(--color-gold);
     margin-left: 10px;
+    -unity-font-style: bold;
+    min-width: var(--hud-gold-label-min-width);
+    -unity-text-align: middle-right;
+}
+
+.skill-point-badge {
+    position: absolute;
+    left: 8px;
+    top: 8px;
+    flex-direction: row;
+    align-items: center;
+    background-color: var(--hud-badge-bg);
+    border-radius: var(--hud-badge-radius);
+    padding: 10px 20px;
+    min-width: var(--hud-gold-badge-min-width);
+}
+
+.skill-point-icon {
+    width: var(--hud-gold-icon-size);
+    height: var(--hud-gold-icon-size);
+    background-color: var(--color-skill-point);
+    rotate: 45deg;
+}
+
+.skill-point-label {
+    font-size: var(--hud-gold-font-size);
+    color: var(--color-skill-point);
+    margin-left: 18px;
     -unity-font-style: bold;
     min-width: var(--hud-gold-label-min-width);
     -unity-text-align: middle-right;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,7 @@ Assets/
         NavigationHost.cs
         NavigationManager.cs
         ScreenStack.cs
+        SkillPointBadgeController.cs
         StepProgressBarController.cs
         SkillTree/
           SkillTreeDetailPanelController.cs


### PR DESCRIPTION
## Summary
- Moved `gold-badge` out of `screen-default` into a new `wallets-overlay` sibling so it stays visible on every tab (village, skill-tree, etc.) — previously it was hidden whenever a tab was opened, making it look like gold stopped accruing on the skill-tree screen.
- Added a new `skill-point-badge` (top-left, cyan diamond) mirroring the gold badge (top-right), wired through a new `SkillPointBadgeController` to the existing `SkillPointWallet` scene singleton.
- `hud-overlay` (battle indicator, step progress, announcement) stays inside `screen-default` — still combat-only as intended.

## Test plan
- [ ] Run `Roguelite/Setup New Game Scene` in the Unity editor to re-wire `_skillPointWallet` on `CombatHudController` (new serialized field).
- [ ] Enter Play Mode: on the combat screen, gold badge shows at top-right and skill-point badge shows at top-left.
- [ ] Kill enemies — gold badge increments and punches.
- [ ] Switch to Arbre (skill-tree) tab: both badges remain visible. Let combat run in the background — gold count should keep increasing visibly on the persistent badge.
- [ ] Unlock a skill-tree node — skill-point label decrements and punches.
- [ ] Switch between all other tabs (Village, Autre, Guilde, Shop) — badges always visible, never hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)