### PR TITLE
fix(gold): credit wallet on enemy death even when off combat tab

### DIFF
--- a/Assets/Scripts/Combat/Levels/EnemySpawner.cs
+++ b/Assets/Scripts/Combat/Levels/EnemySpawner.cs
@@ -110,12 +110,10 @@ namespace RogueliteAutoBattler.Combat.Levels
             {
                 components.Stats.OnDied += () =>
                 {
+                    var wallet = _goldWalletProvider();
+                    if (wallet != null) wallet.Add(goldAmount);
                     if (enemyTransform == null) return;
-                    CoinFlyService.Show(enemyTransform.position, () =>
-                    {
-                        var wallet = _goldWalletProvider();
-                        if (wallet != null) wallet.Add(goldAmount);
-                    });
+                    CoinFlyService.Show(enemyTransform.position);
                 };
             }
 

--- a/Assets/UI/Styles/MainStyle.uss
+++ b/Assets/UI/Styles/MainStyle.uss
@@ -197,8 +197,10 @@
 }
 
 .skill-point-icon {
-    width: var(--hud-gold-icon-size);
-    height: var(--hud-gold-icon-size);
+    width: 36px;
+    height: 36px;
+    margin-left: 4px;
+    margin-right: 4px;
     background-color: var(--color-skill-point);
     rotate: 45deg;
 }
@@ -206,7 +208,7 @@
 .skill-point-label {
     font-size: var(--hud-gold-font-size);
     color: var(--color-skill-point);
-    margin-left: 18px;
+    margin-left: 14px;
     -unity-font-style: bold;
     min-width: var(--hud-gold-label-min-width);
     -unity-text-align: middle-right;


### PR DESCRIPTION
## Summary
- Gold was being added inside the `CoinFlyService.Show` completion callback. When the player switched to any non-combat tab, `CombatWorldVisibility` sets `CoinFlyService.Suppressed = true`, so `Show` returns early and the callback never fires — enemies died but gold never accrued.
- Decoupled the credit from the coin animation: wallet is credited immediately on `OnDied`, coin-fly is kept as pure visual feedback (no longer authoritative).
- Shrunk the skill-point diamond icon (56px → 36px) so it no longer overflows the badge.

## Test plan
- [ ] Combat screen: kill enemies, gold badge increments and coin-fly plays.
- [ ] Switch to Arbre tab: enemies keep dying in the background; gold badge **now keeps incrementing** (was previously frozen).
- [ ] Return to combat: total gold matches what was earned while away.
- [ ] Skill-point diamond fits inside its badge with no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)