### PR TITLE
fix(gold): credit on coin-arrival in combat, immediate only when suppressed

### DIFF
--- a/Assets/Scripts/Combat/Levels/EnemySpawner.cs
+++ b/Assets/Scripts/Combat/Levels/EnemySpawner.cs
@@ -110,10 +110,17 @@ namespace RogueliteAutoBattler.Combat.Levels
             {
                 components.Stats.OnDied += () =>
                 {
-                    var wallet = _goldWalletProvider();
-                    if (wallet != null) wallet.Add(goldAmount);
-                    if (enemyTransform == null) return;
-                    CoinFlyService.Show(enemyTransform.position);
+                    if (CoinFlyService.Suppressed || enemyTransform == null)
+                    {
+                        var walletImmediate = _goldWalletProvider();
+                        if (walletImmediate != null) walletImmediate.Add(goldAmount);
+                        return;
+                    }
+                    CoinFlyService.Show(enemyTransform.position, () =>
+                    {
+                        var wallet = _goldWalletProvider();
+                        if (wallet != null) wallet.Add(goldAmount);
+                    });
                 };
             }
 


### PR DESCRIPTION
## Summary
- Restored the \"coin lands on badge, then gold counts up\" feel on the combat tab.
- When `CoinFlyService.Suppressed == true` (off-tab) or the enemy transform is gone, credit the wallet immediately so kills still accrue — no dropped gold.

## Test plan
- [ ] Combat screen: kill enemy → coin-fly animates → gold badge increments at the end of the fly (pre-regression behavior).
- [ ] Switch to Arbre tab mid-fight: gold keeps climbing in real time.
- [ ] Return to combat: next kill still animates coin then credits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)