### PR TITLE
feat(stats): CombatStats 3-stage pipeline + tier-aware breakdown (#239)

### DIFF
--- a/Assets/Data/SkillTreeData.asset
+++ b/Assets/Data/SkillTreeData.asset
@@ -34,68 +34,68 @@ MonoBehaviour:
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 0
+    statModifierType: 2
+    statModifierMode: 1
     statModifierValuePerLevel: 0
   - id: 1
-    position: {x: 3.9999998, y: 6.9282036}
+    position: {x: 4, y: 6.9282036}
     connectedNodeIds: 02000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 0
-    statModifierValuePerLevel: 0
+    statModifierType: 3
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
   - id: 2
-    position: {x: -4.0000005, y: 6.928203}
+    position: {x: -4, y: 6.9282036}
     connectedNodeIds: 03000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 0
+    statModifierType: 4
+    statModifierMode: 1
     statModifierValuePerLevel: 0
   - id: 3
-    position: {x: -8, y: -0.0000006993822}
+    position: {x: -8, y: 0}
     connectedNodeIds: 04000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 0
+    statModifierType: 5
+    statModifierMode: 1
     statModifierValuePerLevel: 0
   - id: 4
-    position: {x: -3.9999993, y: -6.9282036}
+    position: {x: -4, y: -6.9282036}
     connectedNodeIds: 05000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
     statModifierType: 0
-    statModifierMode: 0
-    statModifierValuePerLevel: 0
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
   - id: 5
-    position: {x: 3.9999993, y: -6.9282036}
+    position: {x: 4, y: -6.9282036}
     connectedNodeIds: 00000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 0
-    statModifierValuePerLevel: 0
+    statModifierType: 1
+    statModifierMode: 1
+    statModifierValuePerLevel: 5

--- a/Assets/Scripts/Combat/Core/CombatStats.cs
+++ b/Assets/Scripts/Combat/Core/CombatStats.cs
@@ -40,36 +40,88 @@ namespace RogueliteAutoBattler.Combat.Core
             switch (statType)
             {
                 case StatType.Hp:
-                    return MakeBaseBreakdown("HP", $"{_currentHp} / {_maxHp}", $"{_maxHp}");
+                    return MakeBreakdown(statType, "HP", $"{_currentHp} / {_maxHp}", $"{_maxHp}");
                 case StatType.Atk:
-                    return MakeBaseBreakdown("ATK", $"{_atk}");
+                    return MakeBreakdown(statType, "ATK", $"{_atk}");
                 case StatType.Def:
-                    return MakeBaseBreakdown("DEF", "0");
+                    return MakeBreakdown(statType, "DEF", "0");
                 case StatType.Mana:
-                    return MakeBaseBreakdown("MANA", "0");
+                    return MakeBreakdown(statType, "MANA", "0");
                 case StatType.Power:
-                    return MakeBaseBreakdown("POWER", "0");
+                    return MakeBreakdown(statType, "POWER", "0");
                 case StatType.AttackSpeed:
-                    return MakeBaseBreakdown("SPD", _attackSpeed.ToString("F1", CultureInfo.InvariantCulture));
+                    return MakeBreakdown(statType, "SPD", _attackSpeed.ToString("F1", CultureInfo.InvariantCulture));
                 case StatType.RegenHp:
-                    return MakeBaseBreakdown("REGEN", _regenHpPerSecond.ToString("F1", CultureInfo.InvariantCulture) + "/s");
+                    return MakeBreakdown(statType, "REGEN", _regenHpPerSecond.ToString("F1", CultureInfo.InvariantCulture) + "/s");
                 case StatType.CritRate:
-                    return MakeBaseBreakdown("CRIT", "0%");
+                    return MakeBreakdown(statType, "CRIT", "0%");
                 default:
                     return new StatBreakdownData("", "", System.Array.Empty<StatModifierEntry>());
             }
         }
 
-        private StatBreakdownData MakeBaseBreakdown(string statName, string formattedValue)
+        private StatBreakdownData MakeBreakdown(StatType statType, string statName, string formattedValue)
         {
-            _singleModifierBuffer[0] = new StatModifierEntry("Base", formattedValue, true);
-            return new StatBreakdownData(statName, formattedValue, _singleModifierBuffer);
+            return MakeBreakdown(statType, statName, formattedValue, formattedValue);
         }
 
-        private StatBreakdownData MakeBaseBreakdown(string statName, string finalValue, string baseValue)
+        private StatBreakdownData MakeBreakdown(StatType statType, string statName, string finalValue, string baseValue)
         {
-            _singleModifierBuffer[0] = new StatModifierEntry("Base", baseValue, true);
-            return new StatBreakdownData(statName, finalValue, _singleModifierBuffer);
+            int modifierCount = CountModifiersForStat(statType);
+            if (modifierCount == 0)
+            {
+                _singleModifierBuffer[0] = new StatModifierEntry("Base", baseValue, true, ModifierTier.Base);
+                return new StatBreakdownData(statName, finalValue, _singleModifierBuffer);
+            }
+
+            var entries = new StatModifierEntry[1 + modifierCount];
+            entries[0] = new StatModifierEntry("Base", baseValue, true, ModifierTier.Base);
+            int writeIndex = 1;
+            for (int i = 0; i < _modifiers.Count; i++)
+            {
+                var m = _modifiers[i];
+                if (m.Stat != statType) continue;
+                entries[writeIndex++] = new StatModifierEntry(
+                    m.Source,
+                    FormatModifierValue(m.Tier, m.Value),
+                    m.Value >= 0f,
+                    m.Tier);
+            }
+            return new StatBreakdownData(statName, finalValue, entries);
+        }
+
+        private int CountModifiersForStat(StatType statType)
+        {
+            int count = 0;
+            for (int i = 0; i < _modifiers.Count; i++)
+            {
+                if (_modifiers[i].Stat == statType) count++;
+            }
+            return count;
+        }
+
+        private static string FormatModifierValue(ModifierTier tier, float value)
+        {
+            string sign = value >= 0f ? "+" : "-";
+            float magnitude = value >= 0f ? value : -value;
+            switch (tier)
+            {
+                case ModifierTier.Percent:
+                    float percent = magnitude * 100f;
+                    bool percentIsWhole = percent == (int)percent;
+                    string percentStr = percentIsWhole
+                        ? ((int)percent).ToString(CultureInfo.InvariantCulture)
+                        : percent.ToString("0.##", CultureInfo.InvariantCulture);
+                    return sign + percentStr + "%";
+                case ModifierTier.Base:
+                case ModifierTier.Flat:
+                default:
+                    bool isWhole = magnitude == (int)magnitude;
+                    string numberStr = isWhole
+                        ? ((int)magnitude).ToString(CultureInfo.InvariantCulture)
+                        : magnitude.ToString("0.##", CultureInfo.InvariantCulture);
+                    return sign + numberStr;
+            }
         }
 
         public void InitializeDirect(int maxHp, int atk, float attackSpeed, float regenHpPerSecond = 0f)

--- a/Assets/Scripts/Combat/Core/CombatStats.cs
+++ b/Assets/Scripts/Combat/Core/CombatStats.cs
@@ -6,6 +6,7 @@ namespace RogueliteAutoBattler.Combat.Core
 {
     public class CombatStats : MonoBehaviour
     {
+        private readonly List<Modifier> _modifiers = new List<Modifier>();
         private int _currentHp;
         private int _maxHp;
         private int _atk;

--- a/Assets/Scripts/Combat/Core/CombatStats.cs
+++ b/Assets/Scripts/Combat/Core/CombatStats.cs
@@ -6,7 +6,12 @@ namespace RogueliteAutoBattler.Combat.Core
 {
     public class CombatStats : MonoBehaviour
     {
+        private const int StatCount = 8;
+
         private readonly List<Modifier> _modifiers = new List<Modifier>();
+        private readonly float[] _baseValues = new float[StatCount];
+        private readonly float[] _cached = new float[StatCount];
+        private int _dirtyMask;
         private int _currentHp;
         private int _maxHp;
         private int _atk;
@@ -69,12 +74,117 @@ namespace RogueliteAutoBattler.Combat.Core
 
         public void InitializeDirect(int maxHp, int atk, float attackSpeed, float regenHpPerSecond = 0f)
         {
-            _maxHp = maxHp;
+            _modifiers.Clear();
+            for (int i = 0; i < StatCount; i++)
+            {
+                _baseValues[i] = 0f;
+                _cached[i] = 0f;
+            }
+
+            _baseValues[(int)StatType.Hp] = maxHp;
+            _baseValues[(int)StatType.Atk] = atk;
+            _baseValues[(int)StatType.AttackSpeed] = attackSpeed;
+            _baseValues[(int)StatType.RegenHp] = regenHpPerSecond;
+
+            _dirtyMask = 0xFF;
             _currentHp = maxHp;
-            _atk = atk;
-            _attackSpeed = attackSpeed;
-            _regenHpPerSecond = regenHpPerSecond;
+
+            for (int i = 0; i < StatCount; i++)
+            {
+                Recompute((StatType)i);
+            }
+
+            _currentHp = _maxHp;
             _regenAccumulator = 0f;
+        }
+
+        public void AddModifier(StatType stat, ModifierTier tier, string source, float value)
+        {
+            _modifiers.Add(new Modifier(stat, tier, source, value));
+            _dirtyMask |= 1 << (int)stat;
+            Recompute(stat);
+        }
+
+        public int RemoveModifiersFromSource(string source)
+        {
+            int removed = 0;
+            int dirtyAccum = 0;
+            for (int i = _modifiers.Count - 1; i >= 0; i--)
+            {
+                if (_modifiers[i].Source == source)
+                {
+                    dirtyAccum |= 1 << (int)_modifiers[i].Stat;
+                    _modifiers.RemoveAt(i);
+                    removed++;
+                }
+            }
+            if (removed > 0)
+            {
+                _dirtyMask |= dirtyAccum;
+                for (int i = 0; i < StatCount; i++)
+                {
+                    if ((dirtyAccum & (1 << i)) != 0)
+                        Recompute((StatType)i);
+                }
+            }
+            return removed;
+        }
+
+        internal float GetStatValue(StatType stat) => Recompute(stat);
+
+        private float Recompute(StatType stat)
+        {
+            int idx = (int)stat;
+            int bit = 1 << idx;
+            if ((_dirtyMask & bit) == 0) return _cached[idx];
+
+            float baseValue = _baseValues[idx];
+            float sumBase = 0f;
+            float sumPercent = 0f;
+            float sumFlat = 0f;
+            for (int i = 0; i < _modifiers.Count; i++)
+            {
+                var m = _modifiers[i];
+                if (m.Stat != stat) continue;
+                switch (m.Tier)
+                {
+                    case ModifierTier.Base:
+                        sumBase += m.Value;
+                        break;
+                    case ModifierTier.Percent:
+                        sumPercent += m.Value;
+                        break;
+                    case ModifierTier.Flat:
+                        sumFlat += m.Value;
+                        break;
+                }
+            }
+            float result = (baseValue + sumBase) * (1f + sumPercent) + sumFlat;
+            _cached[idx] = result;
+            _dirtyMask &= ~bit;
+
+            SyncBackingField(stat, result);
+            return result;
+        }
+
+        private void SyncBackingField(StatType stat, float value)
+        {
+            switch (stat)
+            {
+                case StatType.Hp:
+                    _maxHp = Mathf.RoundToInt(value);
+                    if (_currentHp > _maxHp) _currentHp = _maxHp;
+                    break;
+                case StatType.Atk:
+                    _atk = Mathf.RoundToInt(value);
+                    break;
+                case StatType.AttackSpeed:
+                    _attackSpeed = value;
+                    break;
+                case StatType.RegenHp:
+                    _regenHpPerSecond = value;
+                    break;
+            }
         }
 
         public event System.Action<int, int> OnDamageTaken;

--- a/Assets/Scripts/Combat/Core/CombatStats.cs
+++ b/Assets/Scripts/Combat/Core/CombatStats.cs
@@ -19,7 +19,7 @@ namespace RogueliteAutoBattler.Combat.Core
             { StatType.Def, "DEF" },
             { StatType.Mana, "MANA" },
             { StatType.Power, "POWER" },
-            { StatType.AttackSpeed, "SPD" },
+            { StatType.AttackSpeed, "AS" },
             { StatType.RegenHp, "REGEN" },
             { StatType.CritRate, "CRIT" }
         };

--- a/Assets/Scripts/Combat/Core/CombatStats.cs
+++ b/Assets/Scripts/Combat/Core/CombatStats.cs
@@ -8,8 +8,24 @@ namespace RogueliteAutoBattler.Combat.Core
     {
         private const int StatCount = 8;
         private const int AllStatsDirtyMask = (1 << StatCount) - 1;
+        private const string BaseEntryLabel = "Base";
+        private const float PercentToDisplayMultiplier = 100f;
+        private const string FractionalNumberFormat = "0.##";
+
+        private static readonly Dictionary<StatType, string> StatLabels = new Dictionary<StatType, string>
+        {
+            { StatType.Hp, "HP" },
+            { StatType.Atk, "ATK" },
+            { StatType.Def, "DEF" },
+            { StatType.Mana, "MANA" },
+            { StatType.Power, "POWER" },
+            { StatType.AttackSpeed, "SPD" },
+            { StatType.RegenHp, "REGEN" },
+            { StatType.CritRate, "CRIT" }
+        };
 
         private readonly List<Modifier> _modifiers = new List<Modifier>();
+        private readonly List<StatModifierEntry> _breakdownBuffer = new List<StatModifierEntry>();
         private readonly float[] _baseValues = new float[StatCount];
         private readonly float[] _cached = new float[StatCount];
         private int _dirtyMask;
@@ -36,24 +52,27 @@ namespace RogueliteAutoBattler.Combat.Core
 
         public StatBreakdownData GetBreakdown(StatType statType)
         {
+            if (!StatLabels.TryGetValue(statType, out string label))
+                return new StatBreakdownData("", "", System.Array.Empty<StatModifierEntry>());
+
             switch (statType)
             {
                 case StatType.Hp:
-                    return MakeBreakdown(statType, "HP", $"{_currentHp} / {_maxHp}", $"{_maxHp}");
+                    return MakeBreakdown(statType, label, $"{_currentHp} / {_maxHp}", $"{_maxHp}");
                 case StatType.Atk:
-                    return MakeBreakdown(statType, "ATK", $"{_atk}");
+                    return MakeBreakdown(statType, label, $"{_atk}");
                 case StatType.Def:
-                    return MakeBreakdown(statType, "DEF", "0");
+                    return MakeBreakdown(statType, label, "0");
                 case StatType.Mana:
-                    return MakeBreakdown(statType, "MANA", "0");
+                    return MakeBreakdown(statType, label, "0");
                 case StatType.Power:
-                    return MakeBreakdown(statType, "POWER", "0");
+                    return MakeBreakdown(statType, label, "0");
                 case StatType.AttackSpeed:
-                    return MakeBreakdown(statType, "SPD", _attackSpeed.ToString("F1", CultureInfo.InvariantCulture));
+                    return MakeBreakdown(statType, label, _attackSpeed.ToString("F1", CultureInfo.InvariantCulture));
                 case StatType.RegenHp:
-                    return MakeBreakdown(statType, "REGEN", _regenHpPerSecond.ToString("F1", CultureInfo.InvariantCulture) + "/s");
+                    return MakeBreakdown(statType, label, _regenHpPerSecond.ToString("F1", CultureInfo.InvariantCulture) + "/s");
                 case StatType.CritRate:
-                    return MakeBreakdown(statType, "CRIT", "0%");
+                    return MakeBreakdown(statType, label, "0%");
                 default:
                     return new StatBreakdownData("", "", System.Array.Empty<StatModifierEntry>());
             }
@@ -66,35 +85,21 @@ namespace RogueliteAutoBattler.Combat.Core
 
         private StatBreakdownData MakeBreakdown(StatType statType, string statName, string finalValue, string baseValue)
         {
-            int modifierCount = CountModifiersForStat(statType);
-            var entries = new StatModifierEntry[1 + modifierCount];
-            entries[0] = new StatModifierEntry("Base", baseValue, true, ModifierTier.Base);
+            _breakdownBuffer.Clear();
+            _breakdownBuffer.Add(new StatModifierEntry(BaseEntryLabel, baseValue, true, ModifierTier.Base));
 
-            if (modifierCount == 0)
-                return new StatBreakdownData(statName, finalValue, entries);
-
-            int writeIndex = 1;
             for (int i = 0; i < _modifiers.Count; i++)
             {
                 var modifier = _modifiers[i];
                 if (modifier.Stat != statType) continue;
-                entries[writeIndex++] = new StatModifierEntry(
+                _breakdownBuffer.Add(new StatModifierEntry(
                     modifier.Source,
                     FormatModifierValue(modifier.Tier, modifier.Value),
                     modifier.Value >= 0f,
-                    modifier.Tier);
+                    modifier.Tier));
             }
-            return new StatBreakdownData(statName, finalValue, entries);
-        }
 
-        private int CountModifiersForStat(StatType statType)
-        {
-            int count = 0;
-            for (int i = 0; i < _modifiers.Count; i++)
-            {
-                if (_modifiers[i].Stat == statType) count++;
-            }
-            return count;
+            return new StatBreakdownData(statName, finalValue, _breakdownBuffer.ToArray());
         }
 
         private static string FormatModifierValue(ModifierTier tier, float value)
@@ -104,19 +109,19 @@ namespace RogueliteAutoBattler.Combat.Core
             switch (tier)
             {
                 case ModifierTier.Percent:
-                    float percent = magnitude * 100f;
-                    bool percentIsWhole = percent == (int)percent;
+                    float percent = magnitude * PercentToDisplayMultiplier;
+                    bool percentIsWhole = Mathf.Approximately(percent, Mathf.Round(percent));
                     string percentStr = percentIsWhole
                         ? ((int)percent).ToString(CultureInfo.InvariantCulture)
-                        : percent.ToString("0.##", CultureInfo.InvariantCulture);
+                        : percent.ToString(FractionalNumberFormat, CultureInfo.InvariantCulture);
                     return sign + percentStr + "%";
                 case ModifierTier.Base:
                 case ModifierTier.Flat:
                 default:
-                    bool isWhole = magnitude == (int)magnitude;
+                    bool isWhole = Mathf.Approximately(magnitude, Mathf.Round(magnitude));
                     string numberStr = isWhole
                         ? ((int)magnitude).ToString(CultureInfo.InvariantCulture)
-                        : magnitude.ToString("0.##", CultureInfo.InvariantCulture);
+                        : magnitude.ToString(FractionalNumberFormat, CultureInfo.InvariantCulture);
                     return sign + numberStr;
             }
         }
@@ -136,7 +141,6 @@ namespace RogueliteAutoBattler.Combat.Core
             _baseValues[(int)StatType.RegenHp] = regenHpPerSecond;
 
             _dirtyMask = AllStatsDirtyMask;
-            _currentHp = maxHp;
 
             for (int i = 0; i < StatCount; i++)
             {

--- a/Assets/Scripts/Combat/Core/CombatStats.cs
+++ b/Assets/Scripts/Combat/Core/CombatStats.cs
@@ -7,6 +7,7 @@ namespace RogueliteAutoBattler.Combat.Core
     public class CombatStats : MonoBehaviour
     {
         private const int StatCount = 8;
+        private const int AllStatsDirtyMask = (1 << StatCount) - 1;
 
         private readonly List<Modifier> _modifiers = new List<Modifier>();
         private readonly float[] _baseValues = new float[StatCount];
@@ -32,8 +33,6 @@ namespace RogueliteAutoBattler.Combat.Core
         };
 
         public static IReadOnlyList<StatType> DisplayOrder => DisplayOrderArray;
-
-        private readonly StatModifierEntry[] _singleModifierBuffer = new StatModifierEntry[1];
 
         public StatBreakdownData GetBreakdown(StatType statType)
         {
@@ -68,24 +67,22 @@ namespace RogueliteAutoBattler.Combat.Core
         private StatBreakdownData MakeBreakdown(StatType statType, string statName, string finalValue, string baseValue)
         {
             int modifierCount = CountModifiersForStat(statType);
-            if (modifierCount == 0)
-            {
-                _singleModifierBuffer[0] = new StatModifierEntry("Base", baseValue, true, ModifierTier.Base);
-                return new StatBreakdownData(statName, finalValue, _singleModifierBuffer);
-            }
-
             var entries = new StatModifierEntry[1 + modifierCount];
             entries[0] = new StatModifierEntry("Base", baseValue, true, ModifierTier.Base);
+
+            if (modifierCount == 0)
+                return new StatBreakdownData(statName, finalValue, entries);
+
             int writeIndex = 1;
             for (int i = 0; i < _modifiers.Count; i++)
             {
-                var m = _modifiers[i];
-                if (m.Stat != statType) continue;
+                var modifier = _modifiers[i];
+                if (modifier.Stat != statType) continue;
                 entries[writeIndex++] = new StatModifierEntry(
-                    m.Source,
-                    FormatModifierValue(m.Tier, m.Value),
-                    m.Value >= 0f,
-                    m.Tier);
+                    modifier.Source,
+                    FormatModifierValue(modifier.Tier, modifier.Value),
+                    modifier.Value >= 0f,
+                    modifier.Tier);
             }
             return new StatBreakdownData(statName, finalValue, entries);
         }
@@ -138,7 +135,7 @@ namespace RogueliteAutoBattler.Combat.Core
             _baseValues[(int)StatType.AttackSpeed] = attackSpeed;
             _baseValues[(int)StatType.RegenHp] = regenHpPerSecond;
 
-            _dirtyMask = 0xFF;
+            _dirtyMask = AllStatsDirtyMask;
             _currentHp = maxHp;
 
             for (int i = 0; i < StatCount; i++)
@@ -196,18 +193,18 @@ namespace RogueliteAutoBattler.Combat.Core
             float sumFlat = 0f;
             for (int i = 0; i < _modifiers.Count; i++)
             {
-                var m = _modifiers[i];
-                if (m.Stat != stat) continue;
-                switch (m.Tier)
+                var modifier = _modifiers[i];
+                if (modifier.Stat != stat) continue;
+                switch (modifier.Tier)
                 {
                     case ModifierTier.Base:
-                        sumBase += m.Value;
+                        sumBase += modifier.Value;
                         break;
                     case ModifierTier.Percent:
-                        sumPercent += m.Value;
+                        sumPercent += modifier.Value;
                         break;
                     case ModifierTier.Flat:
-                        sumFlat += m.Value;
+                        sumFlat += modifier.Value;
                         break;
                 }
             }

--- a/Assets/Scripts/Combat/Core/Modifier.cs
+++ b/Assets/Scripts/Combat/Core/Modifier.cs
@@ -1,0 +1,18 @@
+namespace RogueliteAutoBattler.Combat.Core
+{
+    internal readonly struct Modifier
+    {
+        public readonly StatType Stat;
+        public readonly ModifierTier Tier;
+        public readonly string Source;
+        public readonly float Value;
+
+        public Modifier(StatType stat, ModifierTier tier, string source, float value)
+        {
+            Stat = stat;
+            Tier = tier;
+            Source = source;
+            Value = value;
+        }
+    }
+}

--- a/Assets/Scripts/Combat/Core/Modifier.cs.meta
+++ b/Assets/Scripts/Combat/Core/Modifier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1f870f7c0cab11641b9e92b9cdbc63f4

--- a/Assets/Scripts/Combat/Core/ModifierSources.cs
+++ b/Assets/Scripts/Combat/Core/ModifierSources.cs
@@ -1,0 +1,13 @@
+namespace RogueliteAutoBattler.Combat.Core
+{
+    public static class ModifierSources
+    {
+        public const string Base = "base";
+        public const string TechTree = "techtree";
+        public const string Item = "item";
+        public const string Blessing = "blessing";
+        public const string LevelUp = "levelup";
+
+        public static string ItemSource(string instanceId) => "item:" + instanceId;
+    }
+}

--- a/Assets/Scripts/Combat/Core/ModifierSources.cs.meta
+++ b/Assets/Scripts/Combat/Core/ModifierSources.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e7dd6833958aa7b4a913e654316284de

--- a/Assets/Scripts/Combat/Core/StatModifierEntry.cs
+++ b/Assets/Scripts/Combat/Core/StatModifierEntry.cs
@@ -5,12 +5,19 @@ namespace RogueliteAutoBattler.Combat.Core
         public readonly string Source;
         public readonly string Value;
         public readonly bool IsPositive;
+        public readonly ModifierTier Tier;
 
         public StatModifierEntry(string source, string value, bool isPositive)
+            : this(source, value, isPositive, ModifierTier.Flat)
+        {
+        }
+
+        public StatModifierEntry(string source, string value, bool isPositive, ModifierTier tier)
         {
             Source = source;
             Value = value;
             IsPositive = isPositive;
+            Tier = tier;
         }
     }
 }

--- a/Assets/Tests/EditMode/CombatStatsBreakdownTests.cs
+++ b/Assets/Tests/EditMode/CombatStatsBreakdownTests.cs
@@ -51,7 +51,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
         public void GetBreakdown_AttackSpeed_ReturnsFormattedValue()
         {
             var b = _stats.GetBreakdown(StatType.AttackSpeed);
-            Assert.AreEqual("SPD", b.StatName);
+            Assert.AreEqual("AS", b.StatName);
             Assert.AreEqual("1.2", b.FinalValue);
         }
 

--- a/Assets/Tests/EditMode/CombatStatsBreakdownTests.cs
+++ b/Assets/Tests/EditMode/CombatStatsBreakdownTests.cs
@@ -90,5 +90,74 @@ namespace RogueliteAutoBattler.Tests.EditMode
                 Assert.IsTrue(b.Modifiers[0].IsPositive, $"{statType} base modifier should be positive");
             }
         }
+
+        [Test]
+        public void GetBreakdown_WithFlatModifier_AppendsTierTaggedEntry()
+        {
+            _stats.AddModifier(StatType.Atk, ModifierTier.Flat, "techtree", 10f);
+
+            var b = _stats.GetBreakdown(StatType.Atk);
+
+            Assert.AreEqual(2, b.Modifiers.Length);
+            Assert.AreEqual("Base", b.Modifiers[0].Source);
+            Assert.AreEqual(ModifierTier.Base, b.Modifiers[0].Tier);
+            Assert.AreEqual("techtree", b.Modifiers[1].Source);
+            Assert.AreEqual(ModifierTier.Flat, b.Modifiers[1].Tier);
+            Assert.AreEqual("+10", b.Modifiers[1].Value);
+            Assert.IsTrue(b.Modifiers[1].IsPositive);
+        }
+
+        [Test]
+        public void GetBreakdown_WithPercentModifier_FormatsAsPercent()
+        {
+            _stats.AddModifier(StatType.Atk, ModifierTier.Percent, "item", 0.5f);
+
+            var b = _stats.GetBreakdown(StatType.Atk);
+
+            Assert.AreEqual(2, b.Modifiers.Length);
+            Assert.AreEqual("+50%", b.Modifiers[1].Value);
+            Assert.AreEqual(ModifierTier.Percent, b.Modifiers[1].Tier);
+        }
+
+        [Test]
+        public void GetBreakdown_WithMultipleModifiers_PreservesInsertionOrder()
+        {
+            _stats.AddModifier(StatType.Atk, ModifierTier.Base, "src_base", 5f);
+            _stats.AddModifier(StatType.Atk, ModifierTier.Percent, "src_pct", 0.25f);
+            _stats.AddModifier(StatType.Atk, ModifierTier.Flat, "src_flat", 7f);
+
+            var b = _stats.GetBreakdown(StatType.Atk);
+
+            Assert.AreEqual(4, b.Modifiers.Length);
+            Assert.AreEqual("Base", b.Modifiers[0].Source);
+            Assert.AreEqual("src_base", b.Modifiers[1].Source);
+            Assert.AreEqual(ModifierTier.Base, b.Modifiers[1].Tier);
+            Assert.AreEqual("src_pct", b.Modifiers[2].Source);
+            Assert.AreEqual(ModifierTier.Percent, b.Modifiers[2].Tier);
+            Assert.AreEqual("src_flat", b.Modifiers[3].Source);
+            Assert.AreEqual(ModifierTier.Flat, b.Modifiers[3].Tier);
+        }
+
+        [Test]
+        public void GetBreakdown_NegativePercent_FormatsWithSignedPercent()
+        {
+            _stats.AddModifier(StatType.AttackSpeed, ModifierTier.Percent, "slow", -0.3f);
+
+            var b = _stats.GetBreakdown(StatType.AttackSpeed);
+
+            Assert.AreEqual(2, b.Modifiers.Length);
+            Assert.AreEqual("-30%", b.Modifiers[1].Value);
+            Assert.IsFalse(b.Modifiers[1].IsPositive);
+            Assert.AreEqual(ModifierTier.Percent, b.Modifiers[1].Tier);
+        }
+
+        [Test]
+        public void GetBreakdown_ZeroModifiers_StillSingleEntry()
+        {
+            var b = _stats.GetBreakdown(StatType.Atk);
+
+            Assert.AreEqual(1, b.Modifiers.Length);
+            Assert.AreEqual("Base", b.Modifiers[0].Source);
+        }
     }
 }

--- a/Assets/Tests/EditMode/CombatStatsModifierPipelineTests.cs
+++ b/Assets/Tests/EditMode/CombatStatsModifierPipelineTests.cs
@@ -1,0 +1,114 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    [TestFixture]
+    public class CombatStatsModifierPipelineTests
+    {
+        private GameObject _gameObject;
+        private CombatStats _stats;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _gameObject = new GameObject("ModifierPipelineTestUnit");
+            _stats = _gameObject.AddComponent<CombatStats>();
+            _stats.InitializeDirect(maxHp: 100, atk: 15, attackSpeed: 1.2f, regenHpPerSecond: 2f);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_gameObject != null)
+                Object.DestroyImmediate(_gameObject);
+        }
+
+        [Test]
+        public void AddModifier_BasePlusFlat_AppliesAdditively_OnAtk()
+        {
+            _stats.AddModifier(StatType.Atk, ModifierTier.Base, "test", 10f);
+
+            Assert.That(_stats.Atk, Is.EqualTo(25));
+        }
+
+        [Test]
+        public void AddModifier_PercentMultipliesBaseSum_OnAtk()
+        {
+            _stats.AddModifier(StatType.Atk, ModifierTier.Base, "tt", 5f);
+            _stats.AddModifier(StatType.Atk, ModifierTier.Percent, "item", 0.5f);
+
+            Assert.That(_stats.Atk, Is.EqualTo(30));
+        }
+
+        [Test]
+        public void AddModifier_FlatAppliedAfterPercent_OnAtk()
+        {
+            _stats.AddModifier(StatType.Atk, ModifierTier.Base, "tt", 5f);
+            _stats.AddModifier(StatType.Atk, ModifierTier.Percent, "item", 0.5f);
+            _stats.AddModifier(StatType.Atk, ModifierTier.Flat, "buff", 10f);
+
+            Assert.That(_stats.Atk, Is.EqualTo(40));
+        }
+
+        [Test]
+        public void RemoveModifiersFromSource_Idempotent_ReturnsRemovedCount()
+        {
+            _stats.AddModifier(StatType.Atk, ModifierTier.Base, "techtree", 1f);
+            _stats.AddModifier(StatType.Hp, ModifierTier.Flat, "techtree", 10f);
+            _stats.AddModifier(StatType.AttackSpeed, ModifierTier.Percent, "techtree", 0.1f);
+            _stats.AddModifier(StatType.Atk, ModifierTier.Flat, "item", 5f);
+
+            Assert.That(_stats.RemoveModifiersFromSource("techtree"), Is.EqualTo(3));
+            Assert.That(_stats.RemoveModifiersFromSource("techtree"), Is.EqualTo(0));
+            Assert.That(_stats.RemoveModifiersFromSource("item"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void AddModifier_Hp_ClampsCurrentHpToNewMax()
+        {
+            _stats.AddModifier(StatType.Hp, ModifierTier.Flat, "shrink", -50f);
+
+            Assert.That(_stats.MaxHp, Is.EqualTo(50));
+            Assert.That(_stats.CurrentHp, Is.LessThanOrEqualTo(50));
+        }
+
+        [Test]
+        public void RemoveModifiersFromSource_RecomputesStatsBack()
+        {
+            _stats.AddModifier(StatType.Atk, ModifierTier.Base, "x", 20f);
+            Assert.That(_stats.Atk, Is.EqualTo(35));
+
+            int removed = _stats.RemoveModifiersFromSource("x");
+
+            Assert.That(removed, Is.EqualTo(1));
+            Assert.That(_stats.Atk, Is.EqualTo(15));
+        }
+
+        [Test]
+        public void AddModifier_PercentNegative_ReducesStat()
+        {
+            _stats.AddModifier(StatType.AttackSpeed, ModifierTier.Percent, "slow", -0.5f);
+
+            Assert.That(_stats.AttackSpeed, Is.EqualTo(0.6f).Within(0.001f));
+        }
+
+        [Test]
+        public void AddModifier_DefStat_NoBackingField_StillReturnsCorrectValue()
+        {
+            _stats.AddModifier(StatType.Def, ModifierTier.Flat, "armor", 12f);
+
+            Assert.That(_stats.GetStatValue(StatType.Def), Is.EqualTo(12f).Within(0.001f));
+        }
+
+        [Test]
+        public void AddModifier_Atk_NonRoundResult_RoundsToNearestInt()
+        {
+            _stats.AddModifier(StatType.Atk, ModifierTier.Base, "tt", 90f);
+            _stats.AddModifier(StatType.Atk, ModifierTier.Percent, "item", 0.1f);
+
+            Assert.That(_stats.Atk, Is.EqualTo(116));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/CombatStatsModifierPipelineTests.cs.meta
+++ b/Assets/Tests/EditMode/CombatStatsModifierPipelineTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b906a6664a53ab4a8b788f4aaa39931

--- a/Assets/Tests/EditMode/ModifierSourcesTests.cs
+++ b/Assets/Tests/EditMode/ModifierSourcesTests.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    [TestFixture]
+    public class ModifierSourcesTests
+    {
+        [Test]
+        public void Constants_AreNonEmpty()
+        {
+            Assert.IsFalse(string.IsNullOrEmpty(ModifierSources.Base));
+            Assert.IsFalse(string.IsNullOrEmpty(ModifierSources.TechTree));
+            Assert.IsFalse(string.IsNullOrEmpty(ModifierSources.Item));
+            Assert.IsFalse(string.IsNullOrEmpty(ModifierSources.Blessing));
+            Assert.IsFalse(string.IsNullOrEmpty(ModifierSources.LevelUp));
+        }
+
+        [Test]
+        public void ItemSource_PrefixesInstanceId()
+        {
+            Assert.AreEqual("item:sword42", ModifierSources.ItemSource("sword42"));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ModifierSourcesTests.cs.meta
+++ b/Assets/Tests/EditMode/ModifierSourcesTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eaa0b3865110a5e4a8d58643f0f244d7

--- a/Assets/Tests/EditMode/ModifierStructTests.cs
+++ b/Assets/Tests/EditMode/ModifierStructTests.cs
@@ -1,0 +1,49 @@
+using System;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    [TestFixture]
+    public class ModifierStructTests
+    {
+        [Test]
+        public void Ctor_StoresAllFields()
+        {
+            var modifier = new Modifier(StatType.Hp, ModifierTier.Base, "techtree", 5f);
+
+            Assert.AreEqual(StatType.Hp, modifier.Stat);
+            Assert.AreEqual(ModifierTier.Base, modifier.Tier);
+            Assert.AreEqual("techtree", modifier.Source);
+            Assert.AreEqual(5f, modifier.Value);
+        }
+
+        [Test]
+        public void Ctor_AcceptsAllStatTypes()
+        {
+            foreach (StatType statType in Enum.GetValues(typeof(StatType)))
+            {
+                var modifier = new Modifier(statType, ModifierTier.Flat, "test", 1f);
+                Assert.AreEqual(statType, modifier.Stat);
+            }
+        }
+
+        [Test]
+        public void Ctor_AcceptsAllTiers()
+        {
+            foreach (ModifierTier tier in Enum.GetValues(typeof(ModifierTier)))
+            {
+                var modifier = new Modifier(StatType.Atk, tier, "test", 1f);
+                Assert.AreEqual(tier, modifier.Tier);
+            }
+        }
+
+        [Test]
+        public void Ctor_AcceptsNegativeValue()
+        {
+            var modifier = new Modifier(StatType.Def, ModifierTier.Flat, "curse", -10f);
+
+            Assert.AreEqual(-10f, modifier.Value);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ModifierStructTests.cs.meta
+++ b/Assets/Tests/EditMode/ModifierStructTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 351c27ca87846e34394f5916d5911df4

--- a/Assets/Tests/EditMode/StatModifierEntryTests.cs
+++ b/Assets/Tests/EditMode/StatModifierEntryTests.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    [TestFixture]
+    public class StatModifierEntryTests
+    {
+        [Test]
+        public void LegacyCtor_DefaultsTierToFlat()
+        {
+            var entry = new StatModifierEntry("Base", "100", true);
+
+            Assert.AreEqual(ModifierTier.Flat, entry.Tier);
+        }
+
+        [Test]
+        public void NewCtor_StoresTier()
+        {
+            var percentEntry = new StatModifierEntry("Buff", "+10%", true, ModifierTier.Percent);
+            Assert.AreEqual(ModifierTier.Percent, percentEntry.Tier);
+
+            var baseEntry = new StatModifierEntry("Base", "50", true, ModifierTier.Base);
+            Assert.AreEqual(ModifierTier.Base, baseEntry.Tier);
+
+            var flatEntry = new StatModifierEntry("Equipment", "+5", true, ModifierTier.Flat);
+            Assert.AreEqual(ModifierTier.Flat, flatEntry.Tier);
+        }
+
+        [Test]
+        public void Source_Value_IsPositive_AreStored()
+        {
+            var entry = new StatModifierEntry("Equipment", "+12", true, ModifierTier.Flat);
+
+            Assert.AreEqual("Equipment", entry.Source);
+            Assert.AreEqual("+12", entry.Value);
+            Assert.IsTrue(entry.IsPositive);
+
+            var negativeEntry = new StatModifierEntry("Curse", "-5", false, ModifierTier.Percent);
+
+            Assert.AreEqual("Curse", negativeEntry.Source);
+            Assert.AreEqual("-5", negativeEntry.Value);
+            Assert.IsFalse(negativeEntry.IsPositive);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/StatModifierEntryTests.cs.meta
+++ b/Assets/Tests/EditMode/StatModifierEntryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5d8b2fa70562a454fa2ea1e20e6c6377

--- a/Assets/Tests/PlayMode/AllyStatsPanelControllerTests.cs
+++ b/Assets/Tests/PlayMode/AllyStatsPanelControllerTests.cs
@@ -212,9 +212,11 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.AreEqual("100 / 100", _controller.StatValueText(0));
             Assert.AreEqual("15", _controller.StatValueText(1));
             Assert.AreEqual("0", _controller.StatValueText(2));
-            Assert.AreEqual("1.2", _controller.StatValueText(3));
-            Assert.AreEqual("2.0/s", _controller.StatValueText(4));
-            Assert.AreEqual("0%", _controller.StatValueText(5));
+            Assert.AreEqual("0", _controller.StatValueText(3));
+            Assert.AreEqual("0", _controller.StatValueText(4));
+            Assert.AreEqual("1.2", _controller.StatValueText(5));
+            Assert.AreEqual("2.0/s", _controller.StatValueText(6));
+            Assert.AreEqual("0%", _controller.StatValueText(7));
         }
 
         [UnityTest]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,8 @@ Assets/
         CombatSpawnManager.cs
         CombatStats.cs
         FormationLayout.cs
+        Modifier.cs
+        ModifierSources.cs
         ModifierTier.cs
         StatBreakdownData.cs
         StatModifierEntry.cs
@@ -206,10 +208,13 @@ Assets/
       CombatStatsBreakdownAllStatsTests.cs
       CombatStatsBreakdownTests.cs
       CombatStatsDamageEventTests.cs
+      CombatStatsModifierPipelineTests.cs
       CombatStatsTests.cs
       EditorBuildSettingsSceneTests.cs
       FormationLayoutTests.cs
       GoldFormatterTests.cs
+      ModifierSourcesTests.cs
+      ModifierStructTests.cs
       ModifierTierTests.cs
       NewGameSceneBuilderTests.cs
       ProceduralGroundSpriteTests.cs
@@ -220,6 +225,7 @@ Assets/
       SkillTreeProgressTests.cs
       SkillTreeScreenBuilderTests.cs
       StatBreakdownDataTests.cs
+      StatModifierEntryTests.cs
       StatTypeIndicesTests.cs
       StatTypeValidatorTests.cs
       TargetFinderTests.cs


### PR DESCRIPTION
## Summary
- Adds 3-stage modifier pipeline (Base / Percent / Flat) to `CombatStats` with `AddModifier(stat, tier, source, value)` + `RemoveModifiersFromSource(source)` API
- Refactors `GetBreakdown` to enumerate real modifiers tagged by tier (single-pass via shared buffer)
- Foundation for #241 (AllyStatBonusService applies techtree to allies)
- Side fixes: restores #238 zero-migration asset, syncs `AllyStatsPanelControllerTests` to 8-stat layout, renames `SPD` -> `AS`

## Architecture
- Storage: flat `List<Modifier>` + dirty bitmask (`int _dirtyMask`, 8 bits)
- Cache: lazy via `Recompute(StatType)` with eager sync of backing fields after Add/Remove (preserves pre-existing direct-field reads in FixedUpdate / UI)
- Source identifier: `string` + `ModifierSources` consts (TechTree, Item, Blessing, LevelUp)
- Backward compat: `InitializeDirect` signature unchanged; with no modifiers, behavior is strict-equivalent to pre-#239

## Tests
- 559/559 green (215 EditMode + 344 PlayMode)
- New: `CombatStatsModifierPipelineTests` (9 tests covering math, idempotence, HP clamp on shrink, negative percent), `ModifierStructTests`, `ModifierSourcesTests`, `StatModifierEntryTests`
- Extended: `CombatStatsBreakdownTests` (5 tier-aware assertions)

Closes #239