### PR TITLE
feat(progression): SkillTreeProgress.OnLevelChanged event (#240)

### DIFF
--- a/Assets/Scripts/Data/SkillTreeProgress.cs
+++ b/Assets/Scripts/Data/SkillTreeProgress.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -7,6 +8,14 @@ namespace RogueliteAutoBattler.Data
     public class SkillTreeProgress : ScriptableObject
     {
         [SerializeField] private List<int> levels = new List<int>();
+
+        /// <summary>
+        /// Raised when a node level changes via <see cref="SetLevel"/> or <see cref="ResetAll"/>.
+        /// Per-node change: (nodeIndex, newLevel).
+        /// Bulk reset: a single sentinel invocation with nodeIndex == -1 and newLevel == 0.
+        /// Never raised on load (OnEnable). Consumers must perform an initial resolve themselves.
+        /// </summary>
+        public event Action<int, int> OnLevelChanged;
 
         public int GetLevel(int nodeIndex)
         {
@@ -18,13 +27,16 @@ namespace RogueliteAutoBattler.Data
         {
             while (levels.Count <= nodeIndex)
                 levels.Add(0);
+            if (levels[nodeIndex] == level) return;
             levels[nodeIndex] = level;
+            OnLevelChanged?.Invoke(nodeIndex, level);
         }
 
         public void ResetAll()
         {
             for (int i = 0; i < levels.Count; i++)
                 levels[i] = 0;
+            OnLevelChanged?.Invoke(-1, 0);
         }
     }
 }

--- a/Assets/Tests/EditMode/SkillTreeProgressTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeProgressTests.cs
@@ -18,7 +18,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(_progress);
+            UnityEngine.Object.DestroyImmediate(_progress);
         }
 
         [Test]
@@ -153,7 +153,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
             }
             finally
             {
-                Object.DestroyImmediate(freshProgress);
+                UnityEngine.Object.DestroyImmediate(freshProgress);
             }
         }
     }

--- a/Assets/Tests/EditMode/SkillTreeProgressTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeProgressTests.cs
@@ -62,22 +62,14 @@ namespace RogueliteAutoBattler.Tests.EditMode
         [Test]
         public void SetLevel_FiresEvent_WithNodeIndexAndNewLevel()
         {
-            int invocationCount = 0;
-            int capturedNodeIndex = int.MinValue;
-            int capturedLevel = int.MinValue;
-            Action<int, int> handler = (nodeIndex, level) =>
-            {
-                invocationCount++;
-                capturedNodeIndex = nodeIndex;
-                capturedLevel = level;
-            };
-            _progress.OnLevelChanged += handler;
+            var recorder = new EventRecorder();
+            _progress.OnLevelChanged += recorder.Handler;
 
             _progress.SetLevel(2, 4);
 
-            Assert.AreEqual(1, invocationCount);
-            Assert.AreEqual(2, capturedNodeIndex);
-            Assert.AreEqual(4, capturedLevel);
+            Assert.AreEqual(1, recorder.Count);
+            Assert.AreEqual(2, recorder.LastNodeIndex);
+            Assert.AreEqual(4, recorder.LastNewLevel);
         }
 
         [Test]
@@ -100,43 +92,27 @@ namespace RogueliteAutoBattler.Tests.EditMode
             _progress.SetLevel(0, 5);
             _progress.SetLevel(2, 3);
 
-            int invocationCount = 0;
-            int capturedNodeIndex = int.MinValue;
-            int capturedLevel = int.MinValue;
-            Action<int, int> handler = (nodeIndex, level) =>
-            {
-                invocationCount++;
-                capturedNodeIndex = nodeIndex;
-                capturedLevel = level;
-            };
-            _progress.OnLevelChanged += handler;
+            var recorder = new EventRecorder();
+            _progress.OnLevelChanged += recorder.Handler;
 
             _progress.ResetAll();
 
-            Assert.AreEqual(1, invocationCount);
-            Assert.AreEqual(-1, capturedNodeIndex);
-            Assert.AreEqual(0, capturedLevel);
+            Assert.AreEqual(1, recorder.Count);
+            Assert.AreEqual(-1, recorder.LastNodeIndex);
+            Assert.AreEqual(0, recorder.LastNewLevel);
         }
 
         [Test]
         public void ResetAll_WhenAlreadyEmpty_StillFires()
         {
-            int invocationCount = 0;
-            int capturedNodeIndex = int.MinValue;
-            int capturedLevel = int.MinValue;
-            Action<int, int> handler = (nodeIndex, level) =>
-            {
-                invocationCount++;
-                capturedNodeIndex = nodeIndex;
-                capturedLevel = level;
-            };
-            _progress.OnLevelChanged += handler;
+            var recorder = new EventRecorder();
+            _progress.OnLevelChanged += recorder.Handler;
 
             _progress.ResetAll();
 
-            Assert.AreEqual(1, invocationCount);
-            Assert.AreEqual(-1, capturedNodeIndex);
-            Assert.AreEqual(0, capturedLevel);
+            Assert.AreEqual(1, recorder.Count);
+            Assert.AreEqual(-1, recorder.LastNodeIndex);
+            Assert.AreEqual(0, recorder.LastNewLevel);
         }
 
         [Test]
@@ -155,6 +131,20 @@ namespace RogueliteAutoBattler.Tests.EditMode
             {
                 UnityEngine.Object.DestroyImmediate(freshProgress);
             }
+        }
+
+        private sealed class EventRecorder
+        {
+            public int Count;
+            public int LastNodeIndex = int.MinValue;
+            public int LastNewLevel = int.MinValue;
+
+            public Action<int, int> Handler => (nodeIndex, level) =>
+            {
+                Count++;
+                LastNodeIndex = nodeIndex;
+                LastNewLevel = level;
+            };
         }
     }
 }

--- a/Assets/Tests/EditMode/SkillTreeProgressTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeProgressTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using RogueliteAutoBattler.Data;
 using UnityEngine;
@@ -56,6 +57,104 @@ namespace RogueliteAutoBattler.Tests.EditMode
             _progress.ResetAll();
             Assert.AreEqual(0, _progress.GetLevel(0));
             Assert.AreEqual(0, _progress.GetLevel(2));
+        }
+
+        [Test]
+        public void SetLevel_FiresEvent_WithNodeIndexAndNewLevel()
+        {
+            int invocationCount = 0;
+            int capturedNodeIndex = int.MinValue;
+            int capturedLevel = int.MinValue;
+            Action<int, int> handler = (nodeIndex, level) =>
+            {
+                invocationCount++;
+                capturedNodeIndex = nodeIndex;
+                capturedLevel = level;
+            };
+            _progress.OnLevelChanged += handler;
+
+            _progress.SetLevel(2, 4);
+
+            Assert.AreEqual(1, invocationCount);
+            Assert.AreEqual(2, capturedNodeIndex);
+            Assert.AreEqual(4, capturedLevel);
+        }
+
+        [Test]
+        public void SetLevel_SameValue_DoesNotFire()
+        {
+            _progress.SetLevel(0, 3);
+
+            int invocationCount = 0;
+            Action<int, int> handler = (nodeIndex, level) => invocationCount++;
+            _progress.OnLevelChanged += handler;
+
+            _progress.SetLevel(0, 3);
+
+            Assert.AreEqual(0, invocationCount);
+        }
+
+        [Test]
+        public void ResetAll_FiresOnce_WithSentinelMinusOne()
+        {
+            _progress.SetLevel(0, 5);
+            _progress.SetLevel(2, 3);
+
+            int invocationCount = 0;
+            int capturedNodeIndex = int.MinValue;
+            int capturedLevel = int.MinValue;
+            Action<int, int> handler = (nodeIndex, level) =>
+            {
+                invocationCount++;
+                capturedNodeIndex = nodeIndex;
+                capturedLevel = level;
+            };
+            _progress.OnLevelChanged += handler;
+
+            _progress.ResetAll();
+
+            Assert.AreEqual(1, invocationCount);
+            Assert.AreEqual(-1, capturedNodeIndex);
+            Assert.AreEqual(0, capturedLevel);
+        }
+
+        [Test]
+        public void ResetAll_WhenAlreadyEmpty_StillFires()
+        {
+            int invocationCount = 0;
+            int capturedNodeIndex = int.MinValue;
+            int capturedLevel = int.MinValue;
+            Action<int, int> handler = (nodeIndex, level) =>
+            {
+                invocationCount++;
+                capturedNodeIndex = nodeIndex;
+                capturedLevel = level;
+            };
+            _progress.OnLevelChanged += handler;
+
+            _progress.ResetAll();
+
+            Assert.AreEqual(1, invocationCount);
+            Assert.AreEqual(-1, capturedNodeIndex);
+            Assert.AreEqual(0, capturedLevel);
+        }
+
+        [Test]
+        public void OnEnable_DoesNotFire()
+        {
+            var freshProgress = ScriptableObject.CreateInstance<SkillTreeProgress>();
+            try
+            {
+                int invocationCount = 0;
+                Action<int, int> handler = (nodeIndex, level) => invocationCount++;
+                freshProgress.OnLevelChanged += handler;
+
+                Assert.AreEqual(0, invocationCount);
+            }
+            finally
+            {
+                Object.DestroyImmediate(freshProgress);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `event Action<int nodeIndex, int newLevel> OnLevelChanged` to `SkillTreeProgress`
- `SetLevel`: silent no-op when same value, fires `(nodeIndex, level)` on change
- `ResetAll`: single sentinel fire `(-1, 0)`, even on already-empty
- 5 new EditMode tests covering fire / no-op / sentinel / load contract
- Selective DRY refactor: nested `EventRecorder` helper for tests capturing 3 fields

Unblocks #241 (`AllyStatBonusService` — apply techtree to allies).

Closes #240.

## Test plan
- [x] EditMode: 220/220 passing (5 new + 215 existing)
- [x] PlayMode: 344/344 passing (no regression on SkillTree/AllyStats controllers)
- [ ] Visual smoke test in Unity (handled by lead before merge)