### PR TITLE
feat(combat): AllyStatBonusService — apply techtree to allies (spawn + live) (#241)

### DIFF
--- a/Assets/Data/SkillTreeData.asset
+++ b/Assets/Data/SkillTreeData.asset
@@ -31,71 +31,71 @@ MonoBehaviour:
     position: {x: 8, y: 0}
     connectedNodeIds: 01000000
     costType: 0
-    maxLevel: 5
+    maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
-    costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 0
-    statModifierValuePerLevel: 5
-  - id: 1
-    position: {x: 3.9999998, y: 6.9282036}
-    connectedNodeIds: 02000000
-    costType: 0
-    maxLevel: 5
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
     statModifierType: 2
-    statModifierMode: 0
-    statModifierValuePerLevel: 1
-  - id: 2
-    position: {x: -4.0000005, y: 6.928203}
-    connectedNodeIds: 03000000
+    statModifierMode: 1
+    statModifierValuePerLevel: 0
+  - id: 1
+    position: {x: 4, y: 6.9282036}
+    connectedNodeIds: 02000000
     costType: 0
-    maxLevel: 5
+    maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
     statModifierType: 3
-    statModifierMode: 0
-    statModifierValuePerLevel: 1
-  - id: 3
-    position: {x: -8, y: -0.0000006993822}
-    connectedNodeIds: 04000000
-    costType: 0
-    maxLevel: 5
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 1
-    costAdditivePerLevel: 0
-    statModifierType: 6
     statModifierMode: 1
     statModifierValuePerLevel: 5
-  - id: 4
-    position: {x: -3.9999993, y: -6.9282036}
-    connectedNodeIds: 05000000
+  - id: 2
+    position: {x: -4, y: 6.9282036}
+    connectedNodeIds: 03000000
     costType: 0
-    maxLevel: 5
+    maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 7
+    statModifierType: 4
+    statModifierMode: 1
+    statModifierValuePerLevel: 0
+  - id: 3
+    position: {x: -8, y: 0}
+    connectedNodeIds: 04000000
+    costType: 0
+    maxLevel: 0
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 2
+    costAdditivePerLevel: 0
+    statModifierType: 5
+    statModifierMode: 1
+    statModifierValuePerLevel: 0
+  - id: 4
+    position: {x: -4, y: -6.9282036}
+    connectedNodeIds: 05000000
+    costType: 0
+    maxLevel: 0
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 2
+    costAdditivePerLevel: 0
+    statModifierType: 0
     statModifierMode: 1
     statModifierValuePerLevel: 5
   - id: 5
-    position: {x: 3.9999993, y: -6.9282036}
+    position: {x: 4, y: -6.9282036}
     connectedNodeIds: 00000000
     costType: 0
-    maxLevel: 5
+    maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
     statModifierType: 1
-    statModifierMode: 0
-    statModifierValuePerLevel: 1
+    statModifierMode: 1
+    statModifierValuePerLevel: 5

--- a/Assets/Data/SkillTreeData.asset
+++ b/Assets/Data/SkillTreeData.asset
@@ -31,70 +31,70 @@ MonoBehaviour:
     position: {x: 8, y: 0}
     connectedNodeIds: 01000000
     costType: 0
-    maxLevel: 5
+    maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
-    costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 1
-    statModifierValuePerLevel: 5
-  - id: 1
-    position: {x: 3.9999998, y: 6.9282036}
-    connectedNodeIds: 02000000
-    costType: 0
-    maxLevel: 5
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
     statModifierType: 2
     statModifierMode: 1
-    statModifierValuePerLevel: 5
-  - id: 2
-    position: {x: -4.0000005, y: 6.928203}
-    connectedNodeIds: 03000000
+    statModifierValuePerLevel: 0
+  - id: 1
+    position: {x: 4, y: 6.9282036}
+    connectedNodeIds: 02000000
     costType: 0
-    maxLevel: 5
+    maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
     statModifierType: 3
     statModifierMode: 1
     statModifierValuePerLevel: 5
+  - id: 2
+    position: {x: -4, y: 6.9282036}
+    connectedNodeIds: 03000000
+    costType: 0
+    maxLevel: 0
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 2
+    costAdditivePerLevel: 0
+    statModifierType: 4
+    statModifierMode: 1
+    statModifierValuePerLevel: 0
   - id: 3
-    position: {x: -8, y: -0.0000006993822}
+    position: {x: -8, y: 0}
     connectedNodeIds: 04000000
     costType: 0
-    maxLevel: 5
+    maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 6
+    statModifierType: 5
     statModifierMode: 1
-    statModifierValuePerLevel: 5
+    statModifierValuePerLevel: 0
   - id: 4
-    position: {x: -3.9999993, y: -6.9282036}
+    position: {x: -4, y: -6.9282036}
     connectedNodeIds: 05000000
     costType: 0
-    maxLevel: 5
+    maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 7
+    statModifierType: 0
     statModifierMode: 1
     statModifierValuePerLevel: 5
   - id: 5
-    position: {x: 3.9999993, y: -6.9282036}
+    position: {x: 4, y: -6.9282036}
     connectedNodeIds: 00000000
     costType: 0
-    maxLevel: 5
+    maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
     statModifierType: 1
     statModifierMode: 1

--- a/Assets/Data/SkillTreeData.asset
+++ b/Assets/Data/SkillTreeData.asset
@@ -31,70 +31,70 @@ MonoBehaviour:
     position: {x: 8, y: 0}
     connectedNodeIds: 01000000
     costType: 0
-    maxLevel: 0
+    maxLevel: 5
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 2
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 1
-    position: {x: 4, y: 6.9282036}
-    connectedNodeIds: 02000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 3
-    statModifierMode: 1
-    statModifierValuePerLevel: 5
-  - id: 2
-    position: {x: -4, y: 6.9282036}
-    connectedNodeIds: 03000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 4
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 3
-    position: {x: -8, y: 0}
-    connectedNodeIds: 04000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 5
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 4
-    position: {x: -4, y: -6.9282036}
-    connectedNodeIds: 05000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
     statModifierType: 0
     statModifierMode: 1
     statModifierValuePerLevel: 5
-  - id: 5
-    position: {x: 4, y: -6.9282036}
-    connectedNodeIds: 00000000
+  - id: 1
+    position: {x: 3.9999998, y: 6.9282036}
+    connectedNodeIds: 02000000
     costType: 0
-    maxLevel: 0
+    maxLevel: 5
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 2
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
+  - id: 2
+    position: {x: -4.0000005, y: 6.928203}
+    connectedNodeIds: 03000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 3
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
+  - id: 3
+    position: {x: -8, y: -0.0000006993822}
+    connectedNodeIds: 04000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 6
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
+  - id: 4
+    position: {x: -3.9999993, y: -6.9282036}
+    connectedNodeIds: 05000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 7
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
+  - id: 5
+    position: {x: 3.9999993, y: -6.9282036}
+    connectedNodeIds: 00000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
     statModifierType: 1
     statModifierMode: 1

--- a/Assets/Data/SkillTreeData.asset
+++ b/Assets/Data/SkillTreeData.asset
@@ -31,71 +31,71 @@ MonoBehaviour:
     position: {x: 8, y: 0}
     connectedNodeIds: 01000000
     costType: 0
-    maxLevel: 0
+    maxLevel: 5
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 2
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 1
-    position: {x: 4, y: 6.9282036}
-    connectedNodeIds: 02000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 3
-    statModifierMode: 1
-    statModifierValuePerLevel: 5
-  - id: 2
-    position: {x: -4, y: 6.9282036}
-    connectedNodeIds: 03000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 4
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 3
-    position: {x: -8, y: 0}
-    connectedNodeIds: 04000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 5
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 4
-    position: {x: -4, y: -6.9282036}
-    connectedNodeIds: 05000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
     statModifierType: 0
+    statModifierMode: 0
+    statModifierValuePerLevel: 5
+  - id: 1
+    position: {x: 3.9999998, y: 6.9282036}
+    connectedNodeIds: 02000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 2
+    statModifierMode: 0
+    statModifierValuePerLevel: 1
+  - id: 2
+    position: {x: -4.0000005, y: 6.928203}
+    connectedNodeIds: 03000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 3
+    statModifierMode: 0
+    statModifierValuePerLevel: 1
+  - id: 3
+    position: {x: -8, y: -0.0000006993822}
+    connectedNodeIds: 04000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 6
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
+  - id: 4
+    position: {x: -3.9999993, y: -6.9282036}
+    connectedNodeIds: 05000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 7
     statModifierMode: 1
     statModifierValuePerLevel: 5
   - id: 5
-    position: {x: 4, y: -6.9282036}
+    position: {x: 3.9999993, y: -6.9282036}
     connectedNodeIds: 00000000
     costType: 0
-    maxLevel: 0
+    maxLevel: 5
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
     statModifierType: 1
-    statModifierMode: 1
-    statModifierValuePerLevel: 5
+    statModifierMode: 0
+    statModifierValuePerLevel: 1

--- a/Assets/Data/SkillTreeData.asset
+++ b/Assets/Data/SkillTreeData.asset
@@ -14,8 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Data.SkillTreeData
   ringRadius: 8
   ringNodeCount: 6
-  unitSize: 200
-  nodeSize: 80
+  unitSize: 40
+  nodeSize: 48
   nodeColor: {r: 0.3, g: 0.3, b: 0.3, a: 1}
   borderNormalColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   borderSelectedColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
@@ -31,71 +31,71 @@ MonoBehaviour:
     position: {x: 8, y: 0}
     connectedNodeIds: 01000000
     costType: 0
-    maxLevel: 0
+    maxLevel: 5
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 2
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 1
-    position: {x: 4, y: 6.9282036}
-    connectedNodeIds: 02000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 3
-    statModifierMode: 1
-    statModifierValuePerLevel: 5
-  - id: 2
-    position: {x: -4, y: 6.9282036}
-    connectedNodeIds: 03000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 4
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 3
-    position: {x: -8, y: 0}
-    connectedNodeIds: 04000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 5
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 4
-    position: {x: -4, y: -6.9282036}
-    connectedNodeIds: 05000000
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
     statModifierType: 0
+    statModifierMode: 0
+    statModifierValuePerLevel: 5
+  - id: 1
+    position: {x: 3.9999998, y: 6.9282036}
+    connectedNodeIds: 02000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 2
+    statModifierMode: 0
+    statModifierValuePerLevel: 1
+  - id: 2
+    position: {x: -4.0000005, y: 6.928203}
+    connectedNodeIds: 03000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 3
+    statModifierMode: 0
+    statModifierValuePerLevel: 1
+  - id: 3
+    position: {x: -8, y: -0.0000006993822}
+    connectedNodeIds: 04000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 6
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
+  - id: 4
+    position: {x: -3.9999993, y: -6.9282036}
+    connectedNodeIds: 05000000
+    costType: 0
+    maxLevel: 5
+    baseCost: 1
+    costMultiplierOdd: 5
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 7
     statModifierMode: 1
     statModifierValuePerLevel: 5
   - id: 5
-    position: {x: 4, y: -6.9282036}
+    position: {x: 3.9999993, y: -6.9282036}
     connectedNodeIds: 00000000
     costType: 0
-    maxLevel: 0
+    maxLevel: 5
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
     statModifierType: 1
-    statModifierMode: 1
-    statModifierValuePerLevel: 5
+    statModifierMode: 0
+    statModifierValuePerLevel: 1

--- a/Assets/Data/SkillTreeData.asset
+++ b/Assets/Data/SkillTreeData.asset
@@ -34,68 +34,68 @@ MonoBehaviour:
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 0
+    statModifierType: 2
+    statModifierMode: 1
     statModifierValuePerLevel: 0
   - id: 1
-    position: {x: 3.9999998, y: 6.9282036}
+    position: {x: 4, y: 6.9282036}
     connectedNodeIds: 02000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 0
-    statModifierValuePerLevel: 0
+    statModifierType: 3
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
   - id: 2
-    position: {x: -4.0000005, y: 6.928203}
+    position: {x: -4, y: 6.9282036}
     connectedNodeIds: 03000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 0
+    statModifierType: 4
+    statModifierMode: 1
     statModifierValuePerLevel: 0
   - id: 3
-    position: {x: -8, y: -0.0000006993822}
+    position: {x: -8, y: 0}
     connectedNodeIds: 04000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 0
+    statModifierType: 5
+    statModifierMode: 1
     statModifierValuePerLevel: 0
   - id: 4
-    position: {x: -3.9999993, y: -6.9282036}
+    position: {x: -4, y: -6.9282036}
     connectedNodeIds: 05000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
     statModifierType: 0
-    statModifierMode: 0
-    statModifierValuePerLevel: 0
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
   - id: 5
-    position: {x: 3.9999993, y: -6.9282036}
+    position: {x: 4, y: -6.9282036}
     connectedNodeIds: 00000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 1
+    costMultiplierEven: 2
     costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 0
-    statModifierValuePerLevel: 0
+    statModifierType: 1
+    statModifierMode: 1
+    statModifierValuePerLevel: 5

--- a/Assets/Data/SkillTreeData.asset
+++ b/Assets/Data/SkillTreeData.asset
@@ -34,68 +34,68 @@ MonoBehaviour:
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
-    statModifierType: 2
-    statModifierMode: 1
+    statModifierType: 0
+    statModifierMode: 0
     statModifierValuePerLevel: 0
   - id: 1
-    position: {x: 4, y: 6.9282036}
+    position: {x: 3.9999998, y: 6.9282036}
     connectedNodeIds: 02000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
-    statModifierType: 3
-    statModifierMode: 1
-    statModifierValuePerLevel: 5
+    statModifierType: 0
+    statModifierMode: 0
+    statModifierValuePerLevel: 0
   - id: 2
-    position: {x: -4, y: 6.9282036}
+    position: {x: -4.0000005, y: 6.928203}
     connectedNodeIds: 03000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
-    statModifierType: 4
-    statModifierMode: 1
+    statModifierType: 0
+    statModifierMode: 0
     statModifierValuePerLevel: 0
   - id: 3
-    position: {x: -8, y: 0}
+    position: {x: -8, y: -0.0000006993822}
     connectedNodeIds: 04000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
-    statModifierType: 5
-    statModifierMode: 1
+    statModifierType: 0
+    statModifierMode: 0
     statModifierValuePerLevel: 0
   - id: 4
-    position: {x: -4, y: -6.9282036}
+    position: {x: -3.9999993, y: -6.9282036}
     connectedNodeIds: 05000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
     statModifierType: 0
-    statModifierMode: 1
-    statModifierValuePerLevel: 5
+    statModifierMode: 0
+    statModifierValuePerLevel: 0
   - id: 5
-    position: {x: 4, y: -6.9282036}
+    position: {x: 3.9999993, y: -6.9282036}
     connectedNodeIds: 00000000
     costType: 0
     maxLevel: 0
     baseCost: 1
     costMultiplierOdd: 5
-    costMultiplierEven: 2
+    costMultiplierEven: 1
     costAdditivePerLevel: 0
-    statModifierType: 1
-    statModifierMode: 1
-    statModifierValuePerLevel: 5
+    statModifierType: 0
+    statModifierMode: 0
+    statModifierValuePerLevel: 0

--- a/Assets/Data/SkillTreeProgress.asset
+++ b/Assets/Data/SkillTreeProgress.asset
@@ -12,4 +12,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 98e4e1bceeef90d46bfe0f67a0864360, type: 3}
   m_Name: SkillTreeProgress
   m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Data.SkillTreeProgress
-  levels: 
+  levels: 0000000000000000000000000000000000000000

--- a/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
+++ b/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
@@ -16,28 +16,16 @@ namespace RogueliteAutoBattler.Combat.Core
             _data = data ?? throw new ArgumentNullException(nameof(data));
             _progress = progress ?? throw new ArgumentNullException(nameof(progress));
 
-            _roster.OnMemberSpawned += HandleMemberSpawned;
-            _roster.OnMemberRevived += HandleMemberRevived;
+            _roster.OnMemberSpawned += ApplyAndHealMember;
+            _roster.OnMemberRevived += ApplyAndHealMember;
             _progress.OnLevelChanged += HandleLevelChanged;
 
             var existing = _roster.Members;
             for (int i = 0; i < existing.Count; i++)
-            {
-                var member = existing[i];
-                ApplyAllToMember(member);
-                if (member?.Stats != null && !member.Stats.IsDead)
-                    member.Stats.HealToFull();
-            }
+                ApplyAndHealMember(existing[i]);
         }
 
-        private void HandleMemberSpawned(TeamMember member)
-        {
-            ApplyAllToMember(member);
-            if (member?.Stats != null && !member.Stats.IsDead)
-                member.Stats.HealToFull();
-        }
-
-        private void HandleMemberRevived(TeamMember member)
+        private void ApplyAndHealMember(TeamMember member)
         {
             ApplyAllToMember(member);
             if (member?.Stats != null && !member.Stats.IsDead)
@@ -50,13 +38,7 @@ namespace RogueliteAutoBattler.Combat.Core
             if (nodeIndex < 0)
             {
                 for (int i = 0; i < members.Count; i++)
-                {
-                    var member = members[i];
-                    if (member?.Stats == null) continue;
-                    RemoveAllFromMember(member);
-                    ApplyAllToMember(member);
-                    if (!member.Stats.IsDead) member.Stats.HealToFull();
-                }
+                    ApplyAndHealMember(members[i]);
                 return;
             }
 
@@ -89,7 +71,7 @@ namespace RogueliteAutoBattler.Combat.Core
             return (node.statModifierType, tier, value);
         }
 
-        internal void ApplyAllToMember(TeamMember member)
+        private void ApplyAllToMember(TeamMember member)
         {
             if (member?.Stats == null) return;
             var nodes = _data.Nodes;
@@ -105,20 +87,12 @@ namespace RogueliteAutoBattler.Combat.Core
             }
         }
 
-        internal void RemoveAllFromMember(TeamMember member)
-        {
-            if (member?.Stats == null) return;
-            var nodes = _data.Nodes;
-            for (int i = 0; i < nodes.Count; i++)
-                member.Stats.RemoveModifiersFromSource(ModifierSources.TechTreeNode(nodes[i].id));
-        }
-
         public void Dispose()
         {
             if (_disposed) return;
             _disposed = true;
-            _roster.OnMemberSpawned -= HandleMemberSpawned;
-            _roster.OnMemberRevived -= HandleMemberRevived;
+            _roster.OnMemberSpawned -= ApplyAndHealMember;
+            _roster.OnMemberRevived -= ApplyAndHealMember;
             _progress.OnLevelChanged -= HandleLevelChanged;
         }
     }

--- a/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
+++ b/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
@@ -18,6 +18,7 @@ namespace RogueliteAutoBattler.Combat.Core
 
             _roster.OnMemberSpawned += HandleMemberSpawned;
             _roster.OnMemberRevived += HandleMemberRevived;
+            _progress.OnLevelChanged += HandleLevelChanged;
 
             var existing = _roster.Members;
             for (int i = 0; i < existing.Count; i++)
@@ -41,6 +42,39 @@ namespace RogueliteAutoBattler.Combat.Core
             ApplyAllToMember(member);
             if (member?.Stats != null && !member.Stats.IsDead)
                 member.Stats.HealToFull();
+        }
+
+        private void HandleLevelChanged(int nodeIndex, int newLevel)
+        {
+            var members = _roster.Members;
+            if (nodeIndex < 0)
+            {
+                for (int i = 0; i < members.Count; i++)
+                {
+                    var member = members[i];
+                    if (member?.Stats == null) continue;
+                    RemoveAllFromMember(member);
+                    ApplyAllToMember(member);
+                    if (!member.Stats.IsDead) member.Stats.HealToFull();
+                }
+                return;
+            }
+
+            var nodes = _data.Nodes;
+            if (nodeIndex >= nodes.Count) return;
+            var node = nodes[nodeIndex];
+            string source = ModifierSources.TechTreeNode(node.id);
+            var resolved = ResolveNodeModifier(node, newLevel);
+
+            for (int i = 0; i < members.Count; i++)
+            {
+                var member = members[i];
+                if (member?.Stats == null) continue;
+                member.Stats.RemoveModifiersFromSource(source);
+                if (resolved.HasValue)
+                    member.Stats.AddModifier(resolved.Value.stat, resolved.Value.tier, source, resolved.Value.value);
+                if (!member.Stats.IsDead) member.Stats.HealToFull();
+            }
         }
 
         internal static (StatType stat, ModifierTier tier, float value)? ResolveNodeModifier(
@@ -85,6 +119,7 @@ namespace RogueliteAutoBattler.Combat.Core
             _disposed = true;
             _roster.OnMemberSpawned -= HandleMemberSpawned;
             _roster.OnMemberRevived -= HandleMemberRevived;
+            _progress.OnLevelChanged -= HandleLevelChanged;
         }
     }
 }

--- a/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
+++ b/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
@@ -15,6 +15,32 @@ namespace RogueliteAutoBattler.Combat.Core
             _roster = roster ?? throw new ArgumentNullException(nameof(roster));
             _data = data ?? throw new ArgumentNullException(nameof(data));
             _progress = progress ?? throw new ArgumentNullException(nameof(progress));
+
+            _roster.OnMemberSpawned += HandleMemberSpawned;
+            _roster.OnMemberRevived += HandleMemberRevived;
+
+            var existing = _roster.Members;
+            for (int i = 0; i < existing.Count; i++)
+            {
+                var member = existing[i];
+                ApplyAllToMember(member);
+                if (member?.Stats != null && !member.Stats.IsDead)
+                    member.Stats.HealToFull();
+            }
+        }
+
+        private void HandleMemberSpawned(TeamMember member)
+        {
+            ApplyAllToMember(member);
+            if (member?.Stats != null && !member.Stats.IsDead)
+                member.Stats.HealToFull();
+        }
+
+        private void HandleMemberRevived(TeamMember member)
+        {
+            ApplyAllToMember(member);
+            if (member?.Stats != null && !member.Stats.IsDead)
+                member.Stats.HealToFull();
         }
 
         internal static (StatType stat, ModifierTier tier, float value)? ResolveNodeModifier(
@@ -57,6 +83,8 @@ namespace RogueliteAutoBattler.Combat.Core
         {
             if (_disposed) return;
             _disposed = true;
+            _roster.OnMemberSpawned -= HandleMemberSpawned;
+            _roster.OnMemberRevived -= HandleMemberRevived;
         }
     }
 }

--- a/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
+++ b/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
@@ -5,6 +5,8 @@ namespace RogueliteAutoBattler.Combat.Core
 {
     public sealed class AllyStatBonusService : IDisposable
     {
+        private const float PercentInputToDecimal = 0.01f;
+
         private readonly TeamRoster _roster;
         private readonly SkillTreeData _data;
         private readonly SkillTreeProgress _progress;
@@ -69,10 +71,14 @@ namespace RogueliteAutoBattler.Combat.Core
         {
             if (level <= 0) return null;
             if (node.statModifierValuePerLevel == 0f) return null;
-            float value = node.statModifierValuePerLevel * level;
-            ModifierTier tier = node.statModifierMode == SkillTreeData.StatModifierMode.Percent
-                ? ModifierTier.Percent
-                : ModifierTier.Flat;
+
+            bool isPercentMode = node.statModifierMode == SkillTreeData.StatModifierMode.Percent;
+            float perLevelInPipelineUnits = isPercentMode
+                ? node.statModifierValuePerLevel * PercentInputToDecimal
+                : node.statModifierValuePerLevel;
+            float value = perLevelInPipelineUnits * level;
+
+            ModifierTier tier = isPercentMode ? ModifierTier.Percent : ModifierTier.Flat;
             return (node.statModifierType, tier, value);
         }
 

--- a/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
+++ b/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
@@ -35,7 +35,7 @@ namespace RogueliteAutoBattler.Combat.Core
         private void HandleLevelChanged(int nodeIndex, int newLevel)
         {
             var members = _roster.Members;
-            if (nodeIndex < 0)
+            if (nodeIndex == SkillTreeProgress.BulkResetNodeIndex)
             {
                 for (int i = 0; i < members.Count; i++)
                     ApplyAndHealMember(members[i]);
@@ -52,11 +52,16 @@ namespace RogueliteAutoBattler.Combat.Core
             {
                 var member = members[i];
                 if (member?.Stats == null) continue;
-                member.Stats.RemoveModifiersFromSource(source);
-                if (resolved.HasValue)
-                    member.Stats.AddModifier(resolved.Value.stat, resolved.Value.tier, source, resolved.Value.value);
+                ReapplyNodeModifierToStats(member.Stats, source, resolved);
                 if (!member.Stats.IsDead) member.Stats.HealToFull();
             }
+        }
+
+        private static void ReapplyNodeModifierToStats(CombatStats stats, string source, (StatType stat, ModifierTier tier, float value)? resolved)
+        {
+            stats.RemoveModifiersFromSource(source);
+            if (resolved.HasValue)
+                stats.AddModifier(resolved.Value.stat, resolved.Value.tier, source, resolved.Value.value);
         }
 
         internal static (StatType stat, ModifierTier tier, float value)? ResolveNodeModifier(
@@ -79,11 +84,9 @@ namespace RogueliteAutoBattler.Combat.Core
             {
                 var node = nodes[i];
                 string source = ModifierSources.TechTreeNode(node.id);
-                member.Stats.RemoveModifiersFromSource(source);
                 int level = _progress.GetLevel(i);
                 var resolved = ResolveNodeModifier(node, level);
-                if (resolved.HasValue)
-                    member.Stats.AddModifier(resolved.Value.stat, resolved.Value.tier, source, resolved.Value.value);
+                ReapplyNodeModifierToStats(member.Stats, source, resolved);
             }
         }
 

--- a/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
+++ b/Assets/Scripts/Combat/Core/AllyStatBonusService.cs
@@ -1,0 +1,62 @@
+using System;
+using RogueliteAutoBattler.Data;
+
+namespace RogueliteAutoBattler.Combat.Core
+{
+    public sealed class AllyStatBonusService : IDisposable
+    {
+        private readonly TeamRoster _roster;
+        private readonly SkillTreeData _data;
+        private readonly SkillTreeProgress _progress;
+        private bool _disposed;
+
+        public AllyStatBonusService(TeamRoster roster, SkillTreeData data, SkillTreeProgress progress)
+        {
+            _roster = roster ?? throw new ArgumentNullException(nameof(roster));
+            _data = data ?? throw new ArgumentNullException(nameof(data));
+            _progress = progress ?? throw new ArgumentNullException(nameof(progress));
+        }
+
+        internal static (StatType stat, ModifierTier tier, float value)? ResolveNodeModifier(
+            SkillTreeData.SkillNodeEntry node, int level)
+        {
+            if (level <= 0) return null;
+            if (node.statModifierValuePerLevel == 0f) return null;
+            float value = node.statModifierValuePerLevel * level;
+            ModifierTier tier = node.statModifierMode == SkillTreeData.StatModifierMode.Percent
+                ? ModifierTier.Percent
+                : ModifierTier.Flat;
+            return (node.statModifierType, tier, value);
+        }
+
+        internal void ApplyAllToMember(TeamMember member)
+        {
+            if (member?.Stats == null) return;
+            var nodes = _data.Nodes;
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                var node = nodes[i];
+                string source = ModifierSources.TechTreeNode(node.id);
+                member.Stats.RemoveModifiersFromSource(source);
+                int level = _progress.GetLevel(i);
+                var resolved = ResolveNodeModifier(node, level);
+                if (resolved.HasValue)
+                    member.Stats.AddModifier(resolved.Value.stat, resolved.Value.tier, source, resolved.Value.value);
+            }
+        }
+
+        internal void RemoveAllFromMember(TeamMember member)
+        {
+            if (member?.Stats == null) return;
+            var nodes = _data.Nodes;
+            for (int i = 0; i < nodes.Count; i++)
+                member.Stats.RemoveModifiersFromSource(ModifierSources.TechTreeNode(nodes[i].id));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+        }
+    }
+}

--- a/Assets/Scripts/Combat/Core/AllyStatBonusService.cs.meta
+++ b/Assets/Scripts/Combat/Core/AllyStatBonusService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 902aa9d9033c39d4fa2cd0c82fb301d9

--- a/Assets/Scripts/Combat/Core/CombatStats.cs
+++ b/Assets/Scripts/Combat/Core/CombatStats.cs
@@ -68,9 +68,9 @@ namespace RogueliteAutoBattler.Combat.Core
                 case StatType.Power:
                     return MakeBreakdown(statType, label, "0");
                 case StatType.AttackSpeed:
-                    return MakeBreakdown(statType, label, _attackSpeed.ToString("F1", CultureInfo.InvariantCulture), _baseValues[(int)StatType.AttackSpeed].ToString("F1", CultureInfo.InvariantCulture));
+                    return MakeBreakdown(statType, label, _attackSpeed.ToString("F2", CultureInfo.InvariantCulture), _baseValues[(int)StatType.AttackSpeed].ToString("F2", CultureInfo.InvariantCulture));
                 case StatType.RegenHp:
-                    return MakeBreakdown(statType, label, _regenHpPerSecond.ToString("F1", CultureInfo.InvariantCulture) + "/s", _baseValues[(int)StatType.RegenHp].ToString("F1", CultureInfo.InvariantCulture) + "/s");
+                    return MakeBreakdown(statType, label, _regenHpPerSecond.ToString("F2", CultureInfo.InvariantCulture) + "/s", _baseValues[(int)StatType.RegenHp].ToString("F2", CultureInfo.InvariantCulture) + "/s");
                 case StatType.CritRate:
                     return MakeBreakdown(statType, label, "0%");
                 default:

--- a/Assets/Scripts/Combat/Core/CombatStats.cs
+++ b/Assets/Scripts/Combat/Core/CombatStats.cs
@@ -58,9 +58,9 @@ namespace RogueliteAutoBattler.Combat.Core
             switch (statType)
             {
                 case StatType.Hp:
-                    return MakeBreakdown(statType, label, $"{_currentHp} / {_maxHp}", $"{_maxHp}");
+                    return MakeBreakdown(statType, label, $"{_currentHp} / {_maxHp}", $"{(int)_baseValues[(int)StatType.Hp]}");
                 case StatType.Atk:
-                    return MakeBreakdown(statType, label, $"{_atk}");
+                    return MakeBreakdown(statType, label, $"{_atk}", $"{(int)_baseValues[(int)StatType.Atk]}");
                 case StatType.Def:
                     return MakeBreakdown(statType, label, "0");
                 case StatType.Mana:
@@ -68,9 +68,9 @@ namespace RogueliteAutoBattler.Combat.Core
                 case StatType.Power:
                     return MakeBreakdown(statType, label, "0");
                 case StatType.AttackSpeed:
-                    return MakeBreakdown(statType, label, _attackSpeed.ToString("F1", CultureInfo.InvariantCulture));
+                    return MakeBreakdown(statType, label, _attackSpeed.ToString("F1", CultureInfo.InvariantCulture), _baseValues[(int)StatType.AttackSpeed].ToString("F1", CultureInfo.InvariantCulture));
                 case StatType.RegenHp:
-                    return MakeBreakdown(statType, label, _regenHpPerSecond.ToString("F1", CultureInfo.InvariantCulture) + "/s");
+                    return MakeBreakdown(statType, label, _regenHpPerSecond.ToString("F1", CultureInfo.InvariantCulture) + "/s", _baseValues[(int)StatType.RegenHp].ToString("F1", CultureInfo.InvariantCulture) + "/s");
                 case StatType.CritRate:
                     return MakeBreakdown(statType, label, "0%");
                 default:

--- a/Assets/Scripts/Combat/Core/CombatStats.cs
+++ b/Assets/Scripts/Combat/Core/CombatStats.cs
@@ -112,7 +112,7 @@ namespace RogueliteAutoBattler.Combat.Core
                     float percent = magnitude * PercentToDisplayMultiplier;
                     bool percentIsWhole = Mathf.Approximately(percent, Mathf.Round(percent));
                     string percentStr = percentIsWhole
-                        ? ((int)percent).ToString(CultureInfo.InvariantCulture)
+                        ? Mathf.RoundToInt(percent).ToString(CultureInfo.InvariantCulture)
                         : percent.ToString(FractionalNumberFormat, CultureInfo.InvariantCulture);
                     return sign + percentStr + "%";
                 case ModifierTier.Base:
@@ -120,7 +120,7 @@ namespace RogueliteAutoBattler.Combat.Core
                 default:
                     bool isWhole = Mathf.Approximately(magnitude, Mathf.Round(magnitude));
                     string numberStr = isWhole
-                        ? ((int)magnitude).ToString(CultureInfo.InvariantCulture)
+                        ? Mathf.RoundToInt(magnitude).ToString(CultureInfo.InvariantCulture)
                         : magnitude.ToString(FractionalNumberFormat, CultureInfo.InvariantCulture);
                     return sign + numberStr;
             }

--- a/Assets/Scripts/Combat/Core/CombatStats.cs
+++ b/Assets/Scripts/Combat/Core/CombatStats.cs
@@ -183,6 +183,12 @@ namespace RogueliteAutoBattler.Combat.Core
             return removed;
         }
 
+        public void HealToFull()
+        {
+            Recompute(StatType.Hp);
+            _currentHp = _maxHp;
+        }
+
         internal float GetStatValue(StatType stat) => Recompute(stat);
 
         private float Recompute(StatType stat)

--- a/Assets/Scripts/Combat/Core/ModifierSources.cs
+++ b/Assets/Scripts/Combat/Core/ModifierSources.cs
@@ -11,5 +11,14 @@ namespace RogueliteAutoBattler.Combat.Core
         public static string ItemSource(string instanceId) => "item:" + instanceId;
 
         public static string TechTreeNode(int nodeId) => "techtree:node" + nodeId;
+
+        public static string GetDisplayLabel(string source)
+        {
+            if (string.IsNullOrEmpty(source)) return string.Empty;
+            if (source == Base) return "Base";
+            if (source.StartsWith("techtree:node")) return "Tech Tree";
+            if (source.StartsWith("item:")) return "Item";
+            return source;
+        }
     }
 }

--- a/Assets/Scripts/Combat/Core/ModifierSources.cs
+++ b/Assets/Scripts/Combat/Core/ModifierSources.cs
@@ -9,5 +9,7 @@ namespace RogueliteAutoBattler.Combat.Core
         public const string LevelUp = "levelup";
 
         public static string ItemSource(string instanceId) => "item:" + instanceId;
+
+        public static string TechTreeNode(int nodeId) => "techtree:node" + nodeId;
     }
 }

--- a/Assets/Scripts/Core/GameBootstrap.cs
+++ b/Assets/Scripts/Core/GameBootstrap.cs
@@ -1,6 +1,11 @@
 using RogueliteAutoBattler.Combat.Core;
 using RogueliteAutoBattler.Common;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Economy;
+using RogueliteAutoBattler.Services;
+using RogueliteAutoBattler.Services.Local;
 using RogueliteAutoBattler.UI.Toolkit;
+using RogueliteAutoBattler.UI.Toolkit.SkillTree;
 using UnityEngine;
 
 namespace RogueliteAutoBattler.Core
@@ -13,6 +18,14 @@ namespace RogueliteAutoBattler.Core
         public static TeamRoster TeamRoster { get; private set; }
         public static NavigationHost NavigationHost { get; private set; }
         public static Camera MainCamera { get; private set; }
+        internal static GoldWallet GoldWallet { get; private set; }
+        internal static IPlayerProgressionLoader ProgressionLoader { get; private set; }
+        internal static AllyStatBonusService AllyStatBonusService { get; private set; }
+
+        internal static SkillTreeData SkillTreeDataAssetForTest;
+        internal static SkillTreeProgress SkillTreeProgressAssetForTest;
+        internal static GoldWallet GoldWalletForTest;
+        internal static string ProgressionFilePathForTest;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         internal static void Initialize()
@@ -23,6 +36,33 @@ namespace RogueliteAutoBattler.Core
             var combatWorldGo = GameObject.Find(CombatWorldName);
             CombatWorld = combatWorldGo != null ? combatWorldGo.transform : null;
             TeamRoster = combatWorldGo != null ? combatWorldGo.GetComponent<TeamRoster>() : null;
+
+            GoldWallet = GoldWalletForTest != null
+                ? GoldWalletForTest
+                : Object.FindFirstObjectByType<GoldWallet>(FindObjectsInactive.Include);
+
+            SkillTreeData skillTreeData = SkillTreeDataAssetForTest;
+            SkillTreeProgress skillTreeProgress = SkillTreeProgressAssetForTest;
+            if (skillTreeData == null || skillTreeProgress == null)
+            {
+                var skillTreeController = Object.FindFirstObjectByType<SkillTreeScreenController>(FindObjectsInactive.Include);
+                if (skillTreeController != null)
+                {
+                    if (skillTreeData == null) skillTreeData = skillTreeController.Data;
+                    if (skillTreeProgress == null) skillTreeProgress = skillTreeController.Progress;
+                }
+            }
+
+            if (GoldWallet != null && skillTreeProgress != null)
+            {
+                ProgressionLoader = new LocalPlayerProgressionLoader(skillTreeProgress, GoldWallet, ProgressionFilePathForTest);
+                ProgressionLoader.Load();
+            }
+
+            if (TeamRoster != null && skillTreeData != null && skillTreeProgress != null)
+            {
+                AllyStatBonusService = new AllyStatBonusService(TeamRoster, skillTreeData, skillTreeProgress);
+            }
 
             ConfigurePhysicsLayers();
 
@@ -56,11 +96,27 @@ namespace RogueliteAutoBattler.Core
                 Debug.LogError("[GameBootstrap] No navigation system found in scene (NavigationHost missing).");
             if (MainCamera == null)
                 Debug.LogError("[GameBootstrap] Main Camera not found in scene.");
+            if (GoldWallet == null)
+                Debug.LogError("[GameBootstrap] GoldWallet not found in scene.");
+            if (ProgressionLoader == null)
+                Debug.LogError("[GameBootstrap] ProgressionLoader not initialized (missing GoldWallet or SkillTreeProgress).");
+            if (AllyStatBonusService == null)
+                Debug.LogError("[GameBootstrap] AllyStatBonusService not initialized (missing TeamRoster/SkillTreeData/SkillTreeProgress).");
         }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void ResetOnDomainReload()
         {
+            AllyStatBonusService?.Dispose();
+            AllyStatBonusService = null;
+            if (ProgressionLoader is System.IDisposable disposable) disposable.Dispose();
+            ProgressionLoader = null;
+            GoldWallet = null;
+            SkillTreeDataAssetForTest = null;
+            SkillTreeProgressAssetForTest = null;
+            GoldWalletForTest = null;
+            ProgressionFilePathForTest = null;
+
             CombatWorld = null;
             TeamRoster = null;
             NavigationHost = null;

--- a/Assets/Scripts/Core/GameBootstrap.cs
+++ b/Assets/Scripts/Core/GameBootstrap.cs
@@ -109,7 +109,7 @@ namespace RogueliteAutoBattler.Core
         {
             AllyStatBonusService?.Dispose();
             AllyStatBonusService = null;
-            if (ProgressionLoader is System.IDisposable disposable) disposable.Dispose();
+            ProgressionLoader?.Dispose();
             ProgressionLoader = null;
             GoldWallet = null;
             SkillTreeDataAssetForTest = null;

--- a/Assets/Scripts/Data/SkillTreeData.cs
+++ b/Assets/Scripts/Data/SkillTreeData.cs
@@ -195,6 +195,7 @@ namespace RogueliteAutoBattler.Data
 
         internal void InitializeForTest(List<SkillNodeEntry> testNodes)
         {
+            Debug.Assert(testNodes != null, "InitializeForTest requires non-null node list — pass empty list explicitly.");
             nodes = testNodes ?? new List<SkillNodeEntry>();
             _cachedEdges = null;
         }

--- a/Assets/Scripts/Data/SkillTreeData.cs
+++ b/Assets/Scripts/Data/SkillTreeData.cs
@@ -11,8 +11,8 @@ namespace RogueliteAutoBattler.Data
     {
         public const int DefaultRingNodeCount = 6;
         public const float DefaultRingRadius = 5f;
-        public const float DefaultUnitSize = 200f;
-        public const float DefaultNodeSize = 80f;
+        public const float DefaultUnitSize = 40f;
+        public const float DefaultNodeSize = 48f;
         public const float DefaultEdgeThickness = 4f;
         public const int DefaultMaxLevel = 5;
 

--- a/Assets/Scripts/Data/SkillTreeData.cs
+++ b/Assets/Scripts/Data/SkillTreeData.cs
@@ -192,5 +192,11 @@ namespace RogueliteAutoBattler.Data
             nodes[index] = entry;
             _cachedEdges = null;
         }
+
+        internal void InitializeForTest(List<SkillNodeEntry> testNodes)
+        {
+            nodes = testNodes ?? new List<SkillNodeEntry>();
+            _cachedEdges = null;
+        }
     }
 }

--- a/Assets/Scripts/Data/SkillTreeData.cs
+++ b/Assets/Scripts/Data/SkillTreeData.cs
@@ -14,6 +14,7 @@ namespace RogueliteAutoBattler.Data
         public const float DefaultUnitSize = 200f;
         public const float DefaultNodeSize = 80f;
         public const float DefaultEdgeThickness = 4f;
+        public const int DefaultMaxLevel = 5;
 
         public static readonly Color DefaultNodeColor = new Color(0.3f, 0.3f, 0.3f, 1f);
         public static readonly Color DefaultBorderNormalColor = Color.gray;
@@ -32,6 +33,16 @@ namespace RogueliteAutoBattler.Data
             Flat,
             Percent
         }
+
+        internal static readonly (StatType stat, StatModifierMode mode, float valuePerLevel)[] DefaultNodeStatRotation =
+        {
+            (StatType.Hp, StatModifierMode.Flat, 5f),
+            (StatType.Atk, StatModifierMode.Flat, 1f),
+            (StatType.Def, StatModifierMode.Flat, 1f),
+            (StatType.AttackSpeed, StatModifierMode.Percent, 5f),
+            (StatType.CritRate, StatModifierMode.Percent, 5f),
+            (StatType.RegenHp, StatModifierMode.Flat, 1f)
+        };
 
         [Serializable]
         public struct SkillNodeEntry
@@ -110,23 +121,26 @@ namespace RogueliteAutoBattler.Data
         {
             Debug.Assert(nodeCount > 0, "Ring node count must be positive");
 
+            int rotationLength = DefaultNodeStatRotation.Length;
             for (int i = 0; i < nodeCount; i++)
             {
                 float angle = i * (2f * Mathf.PI / nodeCount);
                 Vector2 pos = new Vector2(radius * Mathf.Cos(angle), radius * Mathf.Sin(angle));
+                var rotationEntry = DefaultNodeStatRotation[i % rotationLength];
                 output.Add(new SkillNodeEntry
                 {
                     id = i,
                     position = pos,
                     connectedNodeIds = new List<int> { (i + 1) % nodeCount },
                     costType = CostType.Gold,
-                    maxLevel = 0,
+                    maxLevel = DefaultMaxLevel,
                     baseCost = defaultBaseCost,
                     costMultiplierOdd = defaultMultOdd,
                     costMultiplierEven = defaultMultEven,
                     costAdditivePerLevel = defaultAdditive,
-                    statModifierType = StatType.Hp,
-                    statModifierValuePerLevel = 0f
+                    statModifierType = rotationEntry.stat,
+                    statModifierMode = rotationEntry.mode,
+                    statModifierValuePerLevel = rotationEntry.valuePerLevel
                 });
             }
         }

--- a/Assets/Scripts/Data/SkillTreeData.cs
+++ b/Assets/Scripts/Data/SkillTreeData.cs
@@ -36,12 +36,12 @@ namespace RogueliteAutoBattler.Data
 
         internal static readonly (StatType stat, StatModifierMode mode, float valuePerLevel)[] DefaultNodeStatRotation =
         {
-            (StatType.Hp, StatModifierMode.Flat, 5f),
-            (StatType.Atk, StatModifierMode.Flat, 1f),
-            (StatType.Def, StatModifierMode.Flat, 1f),
+            (StatType.Hp, StatModifierMode.Percent, 5f),
+            (StatType.Atk, StatModifierMode.Percent, 5f),
+            (StatType.Def, StatModifierMode.Percent, 5f),
             (StatType.AttackSpeed, StatModifierMode.Percent, 5f),
             (StatType.CritRate, StatModifierMode.Percent, 5f),
-            (StatType.RegenHp, StatModifierMode.Flat, 1f)
+            (StatType.RegenHp, StatModifierMode.Percent, 5f)
         };
 
         [Serializable]

--- a/Assets/Scripts/Data/SkillTreeProgress.cs
+++ b/Assets/Scripts/Data/SkillTreeProgress.cs
@@ -9,6 +9,8 @@ namespace RogueliteAutoBattler.Data
     {
         [SerializeField] private List<int> levels = new List<int>();
 
+        internal IReadOnlyList<int> Levels => levels;
+
         /// <summary>
         /// Raised when a node level changes via <see cref="SetLevel"/> or <see cref="ResetAll"/>.
         /// Per-node change: (nodeIndex, newLevel).

--- a/Assets/Scripts/Data/SkillTreeProgress.cs
+++ b/Assets/Scripts/Data/SkillTreeProgress.cs
@@ -11,12 +11,6 @@ namespace RogueliteAutoBattler.Data
 
         internal IReadOnlyList<int> Levels => levels;
 
-        /// <summary>
-        /// Raised when a node level changes via <see cref="SetLevel"/> or <see cref="ResetAll"/>.
-        /// Per-node change: (nodeIndex, newLevel).
-        /// Bulk reset: a single sentinel invocation with nodeIndex == -1 and newLevel == 0.
-        /// Never raised on load (OnEnable). Consumers must perform an initial resolve themselves.
-        /// </summary>
         public event Action<int, int> OnLevelChanged;
 
         public int GetLevel(int nodeIndex)

--- a/Assets/Scripts/Data/SkillTreeProgress.cs
+++ b/Assets/Scripts/Data/SkillTreeProgress.cs
@@ -7,6 +7,8 @@ namespace RogueliteAutoBattler.Data
     [CreateAssetMenu(fileName = "SkillTreeProgress", menuName = "Roguelite/Skill Tree Progress")]
     public class SkillTreeProgress : ScriptableObject
     {
+        public const int BulkResetNodeIndex = -1;
+
         [SerializeField] private List<int> levels = new List<int>();
 
         internal IReadOnlyList<int> Levels => levels;
@@ -32,7 +34,7 @@ namespace RogueliteAutoBattler.Data
         {
             for (int i = 0; i < levels.Count; i++)
                 levels[i] = 0;
-            OnLevelChanged?.Invoke(-1, 0);
+            OnLevelChanged?.Invoke(BulkResetNodeIndex, 0);
         }
     }
 }

--- a/Assets/Scripts/Economy/GoldWallet.cs
+++ b/Assets/Scripts/Economy/GoldWallet.cs
@@ -35,5 +35,11 @@ namespace RogueliteAutoBattler.Economy
             _gold = 0;
             OnGoldChanged?.Invoke(_gold);
         }
+
+        internal void InitializeForPersistence(int gold)
+        {
+            _gold = gold < 0 ? 0 : gold;
+            OnGoldChanged?.Invoke(_gold);
+        }
     }
 }

--- a/Assets/Scripts/Editor/Tools/ResetPlayerProgressMenu.cs
+++ b/Assets/Scripts/Editor/Tools/ResetPlayerProgressMenu.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Services.Local;
 using UnityEditor;
 using UnityEngine;
 
@@ -8,7 +9,6 @@ namespace RogueliteAutoBattler.Editor.Tools
     internal static class ResetPlayerProgressMenu
     {
         private const string MenuPath = "Roguelite/Reset Player Progress";
-        private const string PersistedFileName = "player_progression.json";
         private const string LogTag = "[ResetPlayerProgress]";
         private const string DialogTitle = "Reset Player Progress";
         private const string DialogConfirmButton = "Reset";
@@ -17,7 +17,7 @@ namespace RogueliteAutoBattler.Editor.Tools
         [MenuItem(MenuPath)]
         private static void ResetPlayerProgressMenuItem()
         {
-            string jsonPath = Path.Combine(Application.persistentDataPath, PersistedFileName);
+            string jsonPath = Path.Combine(Application.persistentDataPath, LocalPlayerProgressionLoader.DefaultFileName);
             string message =
                 "Reset all player progression?\n\n" +
                 "- Skill tree levels -> 0\n" +

--- a/Assets/Scripts/Editor/Tools/ResetPlayerProgressMenu.cs
+++ b/Assets/Scripts/Editor/Tools/ResetPlayerProgressMenu.cs
@@ -1,0 +1,59 @@
+using System.IO;
+using RogueliteAutoBattler.Data;
+using UnityEditor;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Editor.Tools
+{
+    internal static class ResetPlayerProgressMenu
+    {
+        private const string MenuPath = "Roguelite/Reset Player Progress";
+        private const string PersistedFileName = "player_progression.json";
+        private const string LogTag = "[ResetPlayerProgress]";
+        private const string DialogTitle = "Reset Player Progress";
+        private const string DialogConfirmButton = "Reset";
+        private const string DialogCancelButton = "Cancel";
+
+        [MenuItem(MenuPath)]
+        private static void ResetPlayerProgressMenuItem()
+        {
+            string jsonPath = Path.Combine(Application.persistentDataPath, PersistedFileName);
+            string message =
+                "Reset all player progression?\n\n" +
+                "- Skill tree levels -> 0\n" +
+                "- Gold -> 0 (on next Play session)\n\n" +
+                $"JSON file: {jsonPath}\n\n" +
+                "This cannot be undone.";
+
+            if (!EditorUtility.DisplayDialog(DialogTitle, message, DialogConfirmButton, DialogCancelButton))
+                return;
+
+            SkillTreeProgress progressAsset =
+                AssetDatabase.LoadAssetAtPath<SkillTreeProgress>(EditorPaths.SkillTreeProgressAsset);
+
+            bool fileExisted = File.Exists(jsonPath);
+            bool assetReset = progressAsset != null;
+
+            PerformReset(jsonPath, progressAsset);
+
+            if (assetReset)
+                AssetDatabase.SaveAssets();
+
+            int deletedFiles = fileExisted ? 1 : 0;
+            int resetAssets = assetReset ? 1 : 0;
+            Debug.Log($"{LogTag} Done. JSON deleted: {deletedFiles}, asset reset: {resetAssets}.");
+        }
+
+        internal static void PerformReset(string jsonPath, SkillTreeProgress progressAsset)
+        {
+            if (File.Exists(jsonPath))
+                File.Delete(jsonPath);
+
+            if (progressAsset != null)
+            {
+                progressAsset.ResetAll();
+                EditorUtility.SetDirty(progressAsset);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Editor/Tools/ResetPlayerProgressMenu.cs
+++ b/Assets/Scripts/Editor/Tools/ResetPlayerProgressMenu.cs
@@ -31,17 +31,15 @@ namespace RogueliteAutoBattler.Editor.Tools
             SkillTreeProgress progressAsset =
                 AssetDatabase.LoadAssetAtPath<SkillTreeProgress>(EditorPaths.SkillTreeProgressAsset);
 
-            bool fileExisted = File.Exists(jsonPath);
-            bool assetReset = progressAsset != null;
+            bool jsonFileDeleted = File.Exists(jsonPath);
+            bool progressAssetReset = progressAsset != null;
 
             PerformReset(jsonPath, progressAsset);
 
-            if (assetReset)
+            if (progressAssetReset)
                 AssetDatabase.SaveAssets();
 
-            int deletedFiles = fileExisted ? 1 : 0;
-            int resetAssets = assetReset ? 1 : 0;
-            Debug.Log($"{LogTag} Done. JSON deleted: {deletedFiles}, asset reset: {resetAssets}.");
+            Debug.Log($"{LogTag} Done. JSON deleted: {(jsonFileDeleted ? 1 : 0)}, asset reset: {(progressAssetReset ? 1 : 0)}.");
         }
 
         internal static void PerformReset(string jsonPath, SkillTreeProgress progressAsset)

--- a/Assets/Scripts/Editor/Tools/ResetPlayerProgressMenu.cs.meta
+++ b/Assets/Scripts/Editor/Tools/ResetPlayerProgressMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5fad2faffc92cd348b3737cb7b35544d

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -305,6 +305,16 @@ namespace RogueliteAutoBattler.Editor.Windows
             if (GUILayout.Button("Generate", GUILayout.Height(30)))
             {
                 _serializedData.ApplyModifiedProperties();
+                if (_data.Nodes.Count > 0)
+                {
+                    bool confirmed = EditorUtility.DisplayDialog(
+                        "Replace Skill Tree?",
+                        "The skill tree already has " + _data.Nodes.Count + " nodes. Regenerating will overwrite all existing nodes (positions, levels, stats, costs).\n\nThis can be undone with Ctrl+Z.",
+                        "Replace",
+                        "Cancel");
+                    if (!confirmed) return;
+                }
+                Undo.RecordObject(_data, "Generate Skill Tree Nodes");
                 _data.GenerateNodes();
                 _selectedNodeIndex = -1;
                 _activeTab = 0;

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -350,7 +350,12 @@ namespace RogueliteAutoBattler.Editor.Windows
             EditorGUILayout.LabelField("Stat Modifier", EditorStyles.boldLabel);
             var newStatModType = (StatType)EditorGUILayout.EnumPopup("Stat", node.statModifierType);
             var newStatModMode = (SkillTreeData.StatModifierMode)EditorGUILayout.EnumPopup("Mode", node.statModifierMode);
-            float newStatModValue = EditorGUILayout.FloatField("Value / Level", node.statModifierValuePerLevel);
+            string statModValueLabel = newStatModMode == SkillTreeData.StatModifierMode.Percent
+                ? "% / Level"
+                : "Value / Level";
+            float newStatModValue = EditorGUILayout.FloatField(statModValueLabel, node.statModifierValuePerLevel);
+            if (newStatModMode == SkillTreeData.StatModifierMode.Percent)
+                EditorGUILayout.HelpBox("Stored as percent (5 = +5%)", MessageType.Info);
 
             if (EditorGUI.EndChangeCheck())
             {

--- a/Assets/Scripts/Services/IPlayerProgressionLoader.cs
+++ b/Assets/Scripts/Services/IPlayerProgressionLoader.cs
@@ -1,0 +1,9 @@
+namespace RogueliteAutoBattler.Services
+{
+    public interface IPlayerProgressionLoader
+    {
+        void Load();
+        void Save();
+        void ResetAll();
+    }
+}

--- a/Assets/Scripts/Services/IPlayerProgressionLoader.cs
+++ b/Assets/Scripts/Services/IPlayerProgressionLoader.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace RogueliteAutoBattler.Services
 {
-    public interface IPlayerProgressionLoader
+    public interface IPlayerProgressionLoader : IDisposable
     {
         void Load();
         void Save();

--- a/Assets/Scripts/Services/IPlayerProgressionLoader.cs.meta
+++ b/Assets/Scripts/Services/IPlayerProgressionLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bf53b128b7692b0429c63bc226f4eaec

--- a/Assets/Scripts/Services/Local/LocalPlayerProgressionLoader.cs
+++ b/Assets/Scripts/Services/Local/LocalPlayerProgressionLoader.cs
@@ -16,6 +16,7 @@ namespace RogueliteAutoBattler.Services.Local
         private readonly Action<int, int> _levelChangedHandler;
         private readonly Action<int> _goldChangedHandler;
         private bool _disposed;
+        private bool _isSuppressingSave;
 
         public LocalPlayerProgressionLoader(SkillTreeProgress progress, GoldWallet wallet, string filePath = null)
         {
@@ -25,8 +26,16 @@ namespace RogueliteAutoBattler.Services.Local
                 ? Path.Combine(Application.persistentDataPath, DEFAULT_FILE_NAME)
                 : filePath;
 
-            _levelChangedHandler = (_, __) => Save();
-            _goldChangedHandler = _ => Save();
+            _levelChangedHandler = (_, __) =>
+            {
+                if (_isSuppressingSave) return;
+                Save();
+            };
+            _goldChangedHandler = _ =>
+            {
+                if (_isSuppressingSave) return;
+                Save();
+            };
 
             _progress.OnLevelChanged += _levelChangedHandler;
             _wallet.OnGoldChanged += _goldChangedHandler;
@@ -76,11 +85,19 @@ namespace RogueliteAutoBattler.Services.Local
 
         public void ResetAll()
         {
+            _isSuppressingSave = true;
+            try
+            {
+                _progress.ResetAll();
+                _wallet.ResetGold();
+            }
+            finally
+            {
+                _isSuppressingSave = false;
+            }
+
             if (File.Exists(_filePath))
                 File.Delete(_filePath);
-
-            _progress.ResetAll();
-            _wallet.ResetGold();
         }
 
         public void Dispose()

--- a/Assets/Scripts/Services/Local/LocalPlayerProgressionLoader.cs
+++ b/Assets/Scripts/Services/Local/LocalPlayerProgressionLoader.cs
@@ -1,0 +1,111 @@
+using System;
+using System.IO;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Economy;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Services.Local
+{
+    public sealed class LocalPlayerProgressionLoader : IPlayerProgressionLoader, IDisposable
+    {
+        private const string DEFAULT_FILE_NAME = "player_progression.json";
+
+        private readonly SkillTreeProgress _progress;
+        private readonly GoldWallet _wallet;
+        private readonly string _filePath;
+        private readonly Action<int, int> _levelChangedHandler;
+        private readonly Action<int> _goldChangedHandler;
+        private bool _disposed;
+
+        public LocalPlayerProgressionLoader(SkillTreeProgress progress, GoldWallet wallet, string filePath = null)
+        {
+            _progress = progress ?? throw new ArgumentNullException(nameof(progress));
+            _wallet = wallet ?? throw new ArgumentNullException(nameof(wallet));
+            _filePath = string.IsNullOrEmpty(filePath)
+                ? Path.Combine(Application.persistentDataPath, DEFAULT_FILE_NAME)
+                : filePath;
+
+            _levelChangedHandler = (_, __) => Save();
+            _goldChangedHandler = _ => Save();
+
+            _progress.OnLevelChanged += _levelChangedHandler;
+            _wallet.OnGoldChanged += _goldChangedHandler;
+        }
+
+        public string FilePath => _filePath;
+
+        public void Load()
+        {
+            if (!File.Exists(_filePath)) return;
+
+            string json = File.ReadAllText(_filePath);
+            if (string.IsNullOrEmpty(json)) return;
+
+            var data = JsonUtility.FromJson<PersistedProgression>(json);
+            if (data == null) return;
+
+            if (data.skillTreeLevels != null)
+            {
+                for (int i = 0; i < data.skillTreeLevels.Length; i++)
+                {
+                    int level = data.skillTreeLevels[i];
+                    if (level > 0)
+                        _progress.SetLevel(i, level);
+                }
+            }
+
+            _wallet.InitializeForPersistence(data.gold);
+        }
+
+        public void Save()
+        {
+            var data = new PersistedProgression
+            {
+                skillTreeLevels = SnapshotLevels(),
+                gold = _wallet.Gold
+            };
+
+            string json = JsonUtility.ToJson(data);
+
+            string directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            File.WriteAllText(_filePath, json);
+        }
+
+        public void ResetAll()
+        {
+            if (File.Exists(_filePath))
+                File.Delete(_filePath);
+
+            _progress.ResetAll();
+            _wallet.ResetGold();
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _progress.OnLevelChanged -= _levelChangedHandler;
+            _wallet.OnGoldChanged -= _goldChangedHandler;
+        }
+
+        private int[] SnapshotLevels()
+        {
+            var levels = _progress.Levels;
+            int count = levels?.Count ?? 0;
+            var array = new int[count];
+            for (int i = 0; i < count; i++)
+                array[i] = levels[i];
+            return array;
+        }
+
+        [Serializable]
+        private class PersistedProgression
+        {
+            public int[] skillTreeLevels;
+            public int gold;
+        }
+    }
+}

--- a/Assets/Scripts/Services/Local/LocalPlayerProgressionLoader.cs
+++ b/Assets/Scripts/Services/Local/LocalPlayerProgressionLoader.cs
@@ -26,19 +26,17 @@ namespace RogueliteAutoBattler.Services.Local
                 ? Path.Combine(Application.persistentDataPath, DefaultFileName)
                 : filePath;
 
-            _levelChangedHandler = (_, __) =>
-            {
-                if (_isSuppressingSave) return;
-                Save();
-            };
-            _goldChangedHandler = _ =>
-            {
-                if (_isSuppressingSave) return;
-                Save();
-            };
+            _levelChangedHandler = (_, __) => HandleProgressChangedSaveIfNotSuppressed();
+            _goldChangedHandler = _ => HandleProgressChangedSaveIfNotSuppressed();
 
             _progress.OnLevelChanged += _levelChangedHandler;
             _wallet.OnGoldChanged += _goldChangedHandler;
+        }
+
+        private void HandleProgressChangedSaveIfNotSuppressed()
+        {
+            if (_isSuppressingSave) return;
+            Save();
         }
 
         public void Load()

--- a/Assets/Scripts/Services/Local/LocalPlayerProgressionLoader.cs
+++ b/Assets/Scripts/Services/Local/LocalPlayerProgressionLoader.cs
@@ -8,7 +8,7 @@ namespace RogueliteAutoBattler.Services.Local
 {
     public sealed class LocalPlayerProgressionLoader : IPlayerProgressionLoader, IDisposable
     {
-        private const string DEFAULT_FILE_NAME = "player_progression.json";
+        internal const string DefaultFileName = "player_progression.json";
 
         private readonly SkillTreeProgress _progress;
         private readonly GoldWallet _wallet;
@@ -23,7 +23,7 @@ namespace RogueliteAutoBattler.Services.Local
             _progress = progress ?? throw new ArgumentNullException(nameof(progress));
             _wallet = wallet ?? throw new ArgumentNullException(nameof(wallet));
             _filePath = string.IsNullOrEmpty(filePath)
-                ? Path.Combine(Application.persistentDataPath, DEFAULT_FILE_NAME)
+                ? Path.Combine(Application.persistentDataPath, DefaultFileName)
                 : filePath;
 
             _levelChangedHandler = (_, __) =>
@@ -40,8 +40,6 @@ namespace RogueliteAutoBattler.Services.Local
             _progress.OnLevelChanged += _levelChangedHandler;
             _wallet.OnGoldChanged += _goldChangedHandler;
         }
-
-        public string FilePath => _filePath;
 
         public void Load()
         {

--- a/Assets/Scripts/Services/Local/LocalPlayerProgressionLoader.cs.meta
+++ b/Assets/Scripts/Services/Local/LocalPlayerProgressionLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c1aed9736cec0c943b8e48ea93291df3

--- a/Assets/Scripts/UI/Toolkit/AllyStatsPanelController.cs
+++ b/Assets/Scripts/UI/Toolkit/AllyStatsPanelController.cs
@@ -14,7 +14,6 @@ namespace RogueliteAutoBattler.UI.Toolkit
     {
         private const float StaggerDelay = 0.025f;
         private const float FadeDuration = 0.075f;
-        private const string BreakdownSectionDividerLine = "\u2500\u2500\u2500\u2500\u2500\u2500";
 
         private static class UssClasses
         {
@@ -60,7 +59,9 @@ namespace RogueliteAutoBattler.UI.Toolkit
             internal Label NameLabel;
             internal Label ValueLabel;
             internal VisualElement BreakdownContainer;
-            internal Label BreakdownText;
+            internal VisualElement BreakdownBaseRow;
+            internal VisualElement BreakdownModifiersList;
+            internal VisualElement BreakdownTotalRow;
         }
 
         public AllyStatsPanelController(
@@ -136,9 +137,21 @@ namespace RogueliteAutoBattler.UI.Toolkit
                 breakdownContainer.AddToClassList("stat-breakdown");
                 breakdownContainer.AddToClassList(UssClasses.BreakdownHidden);
 
-                var breakdownText = new Label();
-                breakdownText.AddToClassList("breakdown-text");
-                breakdownContainer.Add(breakdownText);
+                var baseRow = new VisualElement { name = "breakdown-base-row" };
+                baseRow.AddToClassList("stat-breakdown-base-row");
+                baseRow.Add(new Label());
+                baseRow.Add(new Label());
+                breakdownContainer.Add(baseRow);
+
+                var modifiersList = new VisualElement { name = "breakdown-modifiers-list" };
+                breakdownContainer.Add(modifiersList);
+
+                var totalRow = new VisualElement { name = "breakdown-total-row" };
+                totalRow.AddToClassList("stat-breakdown-total-row");
+                totalRow.Add(new Label { text = "Total" });
+                totalRow.Add(new Label());
+                breakdownContainer.Add(totalRow);
+
                 statRow.Add(breakdownContainer);
 
                 _statsScrollView.Add(statRow);
@@ -149,7 +162,9 @@ namespace RogueliteAutoBattler.UI.Toolkit
                     NameLabel = statName,
                     ValueLabel = statValue,
                     BreakdownContainer = breakdownContainer,
-                    BreakdownText = breakdownText
+                    BreakdownBaseRow = baseRow,
+                    BreakdownModifiersList = modifiersList,
+                    BreakdownTotalRow = totalRow
                 };
             }
         }
@@ -470,21 +485,40 @@ namespace RogueliteAutoBattler.UI.Toolkit
             if (rowIndex >= displayOrder.Count) return;
 
             var breakdown = _trackedStats.GetBreakdown(displayOrder[rowIndex]);
-            _stringBuilder.Clear();
+            ref var row = ref _statRows[rowIndex];
+
+            var baseSourceLabel = row.BreakdownBaseRow[0] as Label;
+            var baseValueLabel = row.BreakdownBaseRow[1] as Label;
+
+            if (breakdown.Modifiers != null && breakdown.Modifiers.Length > 0)
+            {
+                var baseEntry = breakdown.Modifiers[0];
+                if (baseSourceLabel != null)
+                    baseSourceLabel.text = ModifierSources.GetDisplayLabel(baseEntry.Source);
+                if (baseValueLabel != null)
+                    baseValueLabel.text = baseEntry.Value;
+            }
+
+            row.BreakdownModifiersList.Clear();
 
             if (breakdown.Modifiers != null)
             {
-                for (int i = 0; i < breakdown.Modifiers.Length; i++)
+                for (int i = 1; i < breakdown.Modifiers.Length; i++)
                 {
                     var modifier = breakdown.Modifiers[i];
-                    _stringBuilder.Append(modifier.Source).Append(": ").AppendLine(modifier.Value);
+                    var modRow = new VisualElement();
+                    modRow.AddToClassList("stat-breakdown-modifier-row");
+                    var sourceLabel = new Label { text = ModifierSources.GetDisplayLabel(modifier.Source) };
+                    var valueLabel = new Label { text = modifier.Value };
+                    modRow.Add(sourceLabel);
+                    modRow.Add(valueLabel);
+                    row.BreakdownModifiersList.Add(modRow);
                 }
             }
 
-            _stringBuilder.AppendLine(BreakdownSectionDividerLine);
-            _stringBuilder.Append("Total: ").Append(breakdown.FinalValue);
-
-            _statRows[rowIndex].BreakdownText.text = _stringBuilder.ToString();
+            var totalValueLabel = row.BreakdownTotalRow[1] as Label;
+            if (totalValueLabel != null)
+                totalValueLabel.text = breakdown.FinalValue;
         }
 
         internal void NavigateToNextAlly()
@@ -566,9 +600,37 @@ namespace RogueliteAutoBattler.UI.Toolkit
             rowIndex >= 0 && rowIndex < _statRows.Length
             && !_statRows[rowIndex].BreakdownContainer.ClassListContains(UssClasses.BreakdownHidden);
 
-        internal string BreakdownText(int rowIndex) =>
-            rowIndex >= 0 && rowIndex < _statRows.Length
-                ? _statRows[rowIndex].BreakdownText.text : "";
+        internal string BreakdownText(int rowIndex)
+        {
+            if (rowIndex < 0 || rowIndex >= _statRows.Length) return "";
+            ref var row = ref _statRows[rowIndex];
+            _stringBuilder.Clear();
+            if (row.BreakdownBaseRow != null)
+            {
+                foreach (var child in row.BreakdownBaseRow.Children())
+                {
+                    if (child is Label l) _stringBuilder.Append(l.text).Append(' ');
+                }
+            }
+            if (row.BreakdownModifiersList != null)
+            {
+                foreach (var modRow in row.BreakdownModifiersList.Children())
+                {
+                    foreach (var child in modRow.Children())
+                    {
+                        if (child is Label l) _stringBuilder.Append(l.text).Append(' ');
+                    }
+                }
+            }
+            if (row.BreakdownTotalRow != null)
+            {
+                foreach (var child in row.BreakdownTotalRow.Children())
+                {
+                    if (child is Label l) _stringBuilder.Append(l.text).Append(' ');
+                }
+            }
+            return _stringBuilder.ToString().TrimEnd();
+        }
 
         internal string StatValueText(int rowIndex) =>
             rowIndex >= 0 && rowIndex < _statRows.Length
@@ -577,6 +639,15 @@ namespace RogueliteAutoBattler.UI.Toolkit
         internal string StatNameText(int rowIndex) =>
             rowIndex >= 0 && rowIndex < _statRows.Length
                 ? _statRows[rowIndex].NameLabel.text : "";
+
+        internal VisualElement GetBreakdownBaseRow(int rowIndex) =>
+            rowIndex >= 0 && rowIndex < _statRows.Length ? _statRows[rowIndex].BreakdownBaseRow : null;
+
+        internal VisualElement GetBreakdownModifiersList(int rowIndex) =>
+            rowIndex >= 0 && rowIndex < _statRows.Length ? _statRows[rowIndex].BreakdownModifiersList : null;
+
+        internal VisualElement GetBreakdownTotalRow(int rowIndex) =>
+            rowIndex >= 0 && rowIndex < _statRows.Length ? _statRows[rowIndex].BreakdownTotalRow : null;
 
         internal bool IsVisible =>
             _contentContainer.resolvedStyle.display == DisplayStyle.Flex

--- a/Assets/Scripts/UI/Toolkit/SkillTree/SkillTreeScreenController.cs
+++ b/Assets/Scripts/UI/Toolkit/SkillTree/SkillTreeScreenController.cs
@@ -33,6 +33,9 @@ namespace RogueliteAutoBattler.UI.Toolkit.SkillTree
         [SerializeField] private GoldWallet _goldWallet;
         [SerializeField] private SkillPointWallet _skillPointWallet;
 
+        internal SkillTreeData Data => _data;
+        internal SkillTreeProgress Progress => _progress;
+
         private readonly List<SkillTreeNodeElement> _nodeElements = new();
         private readonly List<Vector2> _positionsCache = new();
         private readonly List<SkillTreeNodeVisualState> _statesCache = new();

--- a/Assets/Tests/EditMode/AllyStatBonusServiceResolverTests.cs
+++ b/Assets/Tests/EditMode/AllyStatBonusServiceResolverTests.cs
@@ -1,0 +1,69 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+using RogueliteAutoBattler.Data;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class AllyStatBonusServiceResolverTests
+    {
+        [Test]
+        public void ResolveNodeModifier_LevelZero_ReturnsNull()
+        {
+            var node = new SkillTreeData.SkillNodeEntry
+            {
+                id = 0,
+                statModifierType = StatType.Hp,
+                statModifierMode = SkillTreeData.StatModifierMode.Flat,
+                statModifierValuePerLevel = 5f
+            };
+            Assert.IsNull(AllyStatBonusService.ResolveNodeModifier(node, 0));
+        }
+
+        [Test]
+        public void ResolveNodeModifier_ZeroValuePerLevel_ReturnsNull()
+        {
+            var node = new SkillTreeData.SkillNodeEntry
+            {
+                id = 1,
+                statModifierType = StatType.Hp,
+                statModifierMode = SkillTreeData.StatModifierMode.Flat,
+                statModifierValuePerLevel = 0f
+            };
+            Assert.IsNull(AllyStatBonusService.ResolveNodeModifier(node, 5));
+        }
+
+        [Test]
+        public void ResolveNodeModifier_FlatHpAtLevel3_ReturnsFlatTimesLevel()
+        {
+            var node = new SkillTreeData.SkillNodeEntry
+            {
+                id = 2,
+                statModifierType = StatType.Hp,
+                statModifierMode = SkillTreeData.StatModifierMode.Flat,
+                statModifierValuePerLevel = 5f
+            };
+            var result = AllyStatBonusService.ResolveNodeModifier(node, 3);
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(StatType.Hp, result.Value.stat);
+            Assert.AreEqual(ModifierTier.Flat, result.Value.tier);
+            Assert.AreEqual(15f, result.Value.value, 0.0001f);
+        }
+
+        [Test]
+        public void ResolveNodeModifier_PercentAtkAtLevel2_ReturnsPercentTimesLevel()
+        {
+            var node = new SkillTreeData.SkillNodeEntry
+            {
+                id = 3,
+                statModifierType = StatType.Atk,
+                statModifierMode = SkillTreeData.StatModifierMode.Percent,
+                statModifierValuePerLevel = 0.10f
+            };
+            var result = AllyStatBonusService.ResolveNodeModifier(node, 2);
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(StatType.Atk, result.Value.stat);
+            Assert.AreEqual(ModifierTier.Percent, result.Value.tier);
+            Assert.AreEqual(0.20f, result.Value.value, 0.0001f);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/AllyStatBonusServiceResolverTests.cs
+++ b/Assets/Tests/EditMode/AllyStatBonusServiceResolverTests.cs
@@ -57,13 +57,30 @@ namespace RogueliteAutoBattler.Tests.EditMode
                 id = 3,
                 statModifierType = StatType.Atk,
                 statModifierMode = SkillTreeData.StatModifierMode.Percent,
-                statModifierValuePerLevel = 0.10f
+                statModifierValuePerLevel = 5f
             };
             var result = AllyStatBonusService.ResolveNodeModifier(node, 2);
             Assert.IsTrue(result.HasValue);
             Assert.AreEqual(StatType.Atk, result.Value.stat);
             Assert.AreEqual(ModifierTier.Percent, result.Value.tier);
-            Assert.AreEqual(0.20f, result.Value.value, 0.0001f);
+            Assert.AreEqual(0.10f, result.Value.value, 0.0001f);
+        }
+
+        [Test]
+        public void ResolveNodeModifier_PercentMode_TreatsStoredValueAsHumanPercent()
+        {
+            var node = new SkillTreeData.SkillNodeEntry
+            {
+                id = 4,
+                statModifierType = StatType.Atk,
+                statModifierMode = SkillTreeData.StatModifierMode.Percent,
+                statModifierValuePerLevel = 5f
+            };
+            var result = AllyStatBonusService.ResolveNodeModifier(node, 1);
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(StatType.Atk, result.Value.stat);
+            Assert.AreEqual(ModifierTier.Percent, result.Value.tier);
+            Assert.AreEqual(0.05f, result.Value.value, 0.0001f);
         }
     }
 }

--- a/Assets/Tests/EditMode/AllyStatBonusServiceResolverTests.cs.meta
+++ b/Assets/Tests/EditMode/AllyStatBonusServiceResolverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fe9b9a4238d87d940867ef5657a0c81d

--- a/Assets/Tests/EditMode/CombatStatsBreakdownTests.cs
+++ b/Assets/Tests/EditMode/CombatStatsBreakdownTests.cs
@@ -52,7 +52,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
         {
             var b = _stats.GetBreakdown(StatType.AttackSpeed);
             Assert.AreEqual("AS", b.StatName);
-            Assert.AreEqual("1.2", b.FinalValue);
+            Assert.AreEqual("1.20", b.FinalValue);
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
         {
             var b = _stats.GetBreakdown(StatType.RegenHp);
             Assert.AreEqual("REGEN", b.StatName);
-            Assert.AreEqual("2.0/s", b.FinalValue);
+            Assert.AreEqual("2.00/s", b.FinalValue);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/CombatStatsModifierPipelineTests.cs
+++ b/Assets/Tests/EditMode/CombatStatsModifierPipelineTests.cs
@@ -110,5 +110,19 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             Assert.That(_stats.Atk, Is.EqualTo(116));
         }
+
+        [Test]
+        public void Breakdown_PercentTwoLevelsOfFivePercent_FormatsAsTenNotNine()
+        {
+            float perLevelDecimal = 5f * 0.01f;
+            float twoLevels = perLevelDecimal * 2f;
+            _stats.AddModifier(StatType.Hp, ModifierTier.Percent, "techtree:node0", twoLevels);
+
+            var breakdown = _stats.GetBreakdown(StatType.Hp);
+
+            Assert.AreEqual(2, breakdown.Modifiers.Length);
+            Assert.AreEqual("+10%", breakdown.Modifiers[1].Value,
+                "Float imprecision (5*0.01*2*100 = 9.99999976) must round, not truncate.");
+        }
     }
 }

--- a/Assets/Tests/EditMode/CombatStatsModifierPipelineTests.cs
+++ b/Assets/Tests/EditMode/CombatStatsModifierPipelineTests.cs
@@ -124,5 +124,39 @@ namespace RogueliteAutoBattler.Tests.EditMode
             Assert.AreEqual("+10%", breakdown.Modifiers[1].Value,
                 "Float imprecision (5*0.01*2*100 = 9.99999976) must round, not truncate.");
         }
+
+        [Test]
+        public void Breakdown_ManaWithPercentMod_IncludesModifierLineEvenWhenBaseIsZero()
+        {
+            _stats.AddModifier(StatType.Mana, ModifierTier.Percent, "techtree:node0", 0.05f);
+
+            var breakdown = _stats.GetBreakdown(StatType.Mana);
+
+            Assert.AreEqual(2, breakdown.Modifiers.Length, "Should include base entry + techtree modifier");
+            Assert.AreEqual("+5%", breakdown.Modifiers[1].Value,
+                "Modifier line for Mana (Percent +5%) must be visible even when base Mana is 0.");
+        }
+
+        [Test]
+        public void Breakdown_PowerWithPercentMod_IncludesModifierLineEvenWhenBaseIsZero()
+        {
+            _stats.AddModifier(StatType.Power, ModifierTier.Percent, "techtree:node0", 0.05f);
+
+            var breakdown = _stats.GetBreakdown(StatType.Power);
+
+            Assert.AreEqual(2, breakdown.Modifiers.Length);
+            Assert.AreEqual("+5%", breakdown.Modifiers[1].Value);
+        }
+
+        [Test]
+        public void Breakdown_AtkWithPercentMod_ShowsModifierLine()
+        {
+            _stats.AddModifier(StatType.Atk, ModifierTier.Percent, "techtree:node0", 0.05f);
+
+            var breakdown = _stats.GetBreakdown(StatType.Atk);
+
+            Assert.AreEqual(2, breakdown.Modifiers.Length);
+            Assert.AreEqual("+5%", breakdown.Modifiers[1].Value);
+        }
     }
 }

--- a/Assets/Tests/EditMode/LocalPlayerProgressionLoaderTests.cs
+++ b/Assets/Tests/EditMode/LocalPlayerProgressionLoaderTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Economy;
+using RogueliteAutoBattler.Services.Local;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class LocalPlayerProgressionLoaderTests
+    {
+        private SkillTreeProgress _progress;
+        private GameObject _walletGameObject;
+        private GoldWallet _wallet;
+        private string _tempDirectory;
+        private string _tempFilePath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _progress = ScriptableObject.CreateInstance<SkillTreeProgress>();
+            _walletGameObject = new GameObject("TestWallet");
+            _wallet = _walletGameObject.AddComponent<GoldWallet>();
+
+            _tempDirectory = Path.Combine(Path.GetTempPath(), "roguelite-tests", Guid.NewGuid().ToString());
+            _tempFilePath = Path.Combine(_tempDirectory, "player_progression.json");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_progress != null)
+                UnityEngine.Object.DestroyImmediate(_progress);
+            if (_walletGameObject != null)
+                UnityEngine.Object.DestroyImmediate(_walletGameObject);
+
+            if (Directory.Exists(_tempDirectory))
+                Directory.Delete(_tempDirectory, true);
+        }
+
+        [Test]
+        public void Load_FileMissing_NoOp()
+        {
+            using var loader = new LocalPlayerProgressionLoader(_progress, _wallet, _tempFilePath);
+
+            Assert.IsFalse(File.Exists(_tempFilePath));
+
+            loader.Load();
+
+            Assert.AreEqual(0, _wallet.Gold);
+            Assert.AreEqual(0, _progress.GetLevel(0));
+        }
+
+        [Test]
+        public void Save_ThenLoad_RestoresState()
+        {
+            using (var saver = new LocalPlayerProgressionLoader(_progress, _wallet, _tempFilePath))
+            {
+                _progress.SetLevel(0, 3);
+                _progress.SetLevel(2, 5);
+                _wallet.Add(150);
+            }
+
+            Assert.IsTrue(File.Exists(_tempFilePath));
+
+            var freshProgress = ScriptableObject.CreateInstance<SkillTreeProgress>();
+            var freshWalletGameObject = new GameObject("FreshWallet");
+            var freshWallet = freshWalletGameObject.AddComponent<GoldWallet>();
+            try
+            {
+                using var loader = new LocalPlayerProgressionLoader(freshProgress, freshWallet, _tempFilePath);
+                loader.Load();
+
+                Assert.AreEqual(150, freshWallet.Gold);
+                Assert.AreEqual(3, freshProgress.GetLevel(0));
+                Assert.AreEqual(5, freshProgress.GetLevel(2));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(freshProgress);
+                UnityEngine.Object.DestroyImmediate(freshWalletGameObject);
+            }
+        }
+
+        [Test]
+        public void Save_PersistsImmediatelyOnLevelChange()
+        {
+            using var loader = new LocalPlayerProgressionLoader(_progress, _wallet, _tempFilePath);
+
+            _progress.SetLevel(1, 4);
+
+            Assert.IsTrue(File.Exists(_tempFilePath));
+            string json = File.ReadAllText(_tempFilePath);
+            StringAssert.Contains("\"skillTreeLevels\":[0,4]", json);
+            StringAssert.Contains("\"gold\":0", json);
+        }
+
+        [Test]
+        public void Save_PersistsImmediatelyOnGoldChange()
+        {
+            using var loader = new LocalPlayerProgressionLoader(_progress, _wallet, _tempFilePath);
+
+            _wallet.Add(75);
+
+            Assert.IsTrue(File.Exists(_tempFilePath));
+            string json = File.ReadAllText(_tempFilePath);
+            StringAssert.Contains("\"gold\":75", json);
+        }
+
+        [Test]
+        public void ResetAll_DeletesFileAndZeroesState()
+        {
+            using var loader = new LocalPlayerProgressionLoader(_progress, _wallet, _tempFilePath);
+
+            _progress.SetLevel(0, 3);
+            _wallet.Add(200);
+
+            Assert.IsTrue(File.Exists(_tempFilePath));
+
+            loader.ResetAll();
+
+            Assert.IsFalse(File.Exists(_tempFilePath));
+            Assert.AreEqual(0, _progress.GetLevel(0));
+            Assert.AreEqual(0, _wallet.Gold);
+        }
+
+        [Test]
+        public void Dispose_StopsAutoSave()
+        {
+            var loader = new LocalPlayerProgressionLoader(_progress, _wallet, _tempFilePath);
+
+            _progress.SetLevel(0, 1);
+            Assert.IsTrue(File.Exists(_tempFilePath));
+
+            loader.Dispose();
+
+            File.Delete(_tempFilePath);
+            Assert.IsFalse(File.Exists(_tempFilePath));
+
+            _progress.SetLevel(0, 2);
+
+            Assert.IsFalse(File.Exists(_tempFilePath));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/LocalPlayerProgressionLoaderTests.cs
+++ b/Assets/Tests/EditMode/LocalPlayerProgressionLoaderTests.cs
@@ -24,7 +24,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
             _wallet = _walletGameObject.AddComponent<GoldWallet>();
 
             _tempDirectory = Path.Combine(Path.GetTempPath(), "roguelite-tests", Guid.NewGuid().ToString());
-            _tempFilePath = Path.Combine(_tempDirectory, "player_progression.json");
+            _tempFilePath = Path.Combine(_tempDirectory, LocalPlayerProgressionLoader.DefaultFileName);
         }
 
         [TearDown]

--- a/Assets/Tests/EditMode/LocalPlayerProgressionLoaderTests.cs.meta
+++ b/Assets/Tests/EditMode/LocalPlayerProgressionLoaderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce772d1125bf7114ab62549b0168813d

--- a/Assets/Tests/EditMode/ModifierSourcesTests.cs
+++ b/Assets/Tests/EditMode/ModifierSourcesTests.cs
@@ -21,5 +21,13 @@ namespace RogueliteAutoBattler.Tests.EditMode
         {
             Assert.AreEqual("item:sword42", ModifierSources.ItemSource("sword42"));
         }
+
+        [Test]
+        public void TechTreeNode_FormatsAsTechtreeColonNodeId()
+        {
+            Assert.AreEqual("techtree:node0", ModifierSources.TechTreeNode(0));
+            Assert.AreEqual("techtree:node7", ModifierSources.TechTreeNode(7));
+            Assert.AreEqual("techtree:node42", ModifierSources.TechTreeNode(42));
+        }
     }
 }

--- a/Assets/Tests/EditMode/ResetPlayerProgressMenuTests.cs
+++ b/Assets/Tests/EditMode/ResetPlayerProgressMenuTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Editor.Tools;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    [TestFixture]
+    public class ResetPlayerProgressMenuTests
+    {
+        private string _tempDirectory;
+        private string _tempFilePath;
+        private SkillTreeProgress _progress;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDirectory = Path.Combine(Path.GetTempPath(), "roguelite-tests", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_tempDirectory);
+            _tempFilePath = Path.Combine(_tempDirectory, "progression.json");
+            _progress = ScriptableObject.CreateInstance<SkillTreeProgress>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_progress != null)
+                UnityEngine.Object.DestroyImmediate(_progress);
+
+            if (Directory.Exists(_tempDirectory))
+                Directory.Delete(_tempDirectory, true);
+        }
+
+        [Test]
+        public void PerformReset_FileExists_DeletesFile()
+        {
+            File.WriteAllText(_tempFilePath, "{\"dummy\":true}");
+            Assert.IsTrue(File.Exists(_tempFilePath));
+
+            ResetPlayerProgressMenu.PerformReset(_tempFilePath, null);
+
+            Assert.IsFalse(File.Exists(_tempFilePath));
+        }
+
+        [Test]
+        public void PerformReset_FileMissing_NoOp()
+        {
+            Assert.IsFalse(File.Exists(_tempFilePath));
+
+            Assert.DoesNotThrow(() => ResetPlayerProgressMenu.PerformReset(_tempFilePath, null));
+
+            Assert.IsFalse(File.Exists(_tempFilePath));
+        }
+
+        [Test]
+        public void PerformReset_ResetsProgressAssetLevels()
+        {
+            _progress.SetLevel(0, 5);
+            _progress.SetLevel(2, 3);
+            Assert.AreEqual(5, _progress.GetLevel(0));
+            Assert.AreEqual(3, _progress.GetLevel(2));
+
+            ResetPlayerProgressMenu.PerformReset(_tempFilePath, _progress);
+
+            Assert.AreEqual(0, _progress.GetLevel(0));
+            Assert.AreEqual(0, _progress.GetLevel(2));
+        }
+
+        [Test]
+        public void PerformReset_NullAsset_NoException()
+        {
+            Assert.DoesNotThrow(() => ResetPlayerProgressMenu.PerformReset(_tempFilePath, null));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ResetPlayerProgressMenuTests.cs.meta
+++ b/Assets/Tests/EditMode/ResetPlayerProgressMenuTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 70bb2845a185fb243b85cf3b46483553

--- a/Assets/Tests/EditMode/SkillTreeDataTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeDataTests.cs
@@ -241,14 +241,18 @@ namespace RogueliteAutoBattler.Tests.EditMode
             for (int i = 0; i < _skillTreeData.Nodes.Count; i++)
             {
                 var node = _skillTreeData.Nodes[i];
+                var (expectedStat, expectedMode, expectedValue) = SkillTreeData.DefaultNodeStatRotation[i % SkillTreeData.DefaultNodeStatRotation.Length];
+
                 Assert.AreEqual(SkillTreeData.CostType.Gold, node.costType,
                     $"Node {i} costType should default to Gold");
-                Assert.AreEqual(0, node.maxLevel,
-                    $"Node {i} maxLevel should default to 0 (unlimited)");
-                Assert.AreEqual(StatType.Hp, node.statModifierType,
-                    $"Node {i} statModifierType should default to HP");
-                Assert.AreEqual(0f, node.statModifierValuePerLevel,
-                    $"Node {i} statModifierValuePerLevel should default to 0");
+                Assert.AreEqual(SkillTreeData.DefaultMaxLevel, node.maxLevel,
+                    $"Node {i} maxLevel should default to {SkillTreeData.DefaultMaxLevel}");
+                Assert.AreEqual(expectedStat, node.statModifierType,
+                    $"Node {i} statModifierType should follow rotation");
+                Assert.AreEqual(expectedMode, node.statModifierMode,
+                    $"Node {i} statModifierMode should follow rotation");
+                Assert.AreEqual(expectedValue, node.statModifierValuePerLevel,
+                    $"Node {i} statModifierValuePerLevel should follow rotation");
             }
         }
 
@@ -262,7 +266,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
             {
                 var node = _skillTreeData.Nodes[i];
                 Assert.AreEqual(SkillTreeData.CostType.Gold, node.costType);
-                Assert.AreEqual(0, node.maxLevel);
+                Assert.AreEqual(SkillTreeData.DefaultMaxLevel, node.maxLevel);
             }
         }
 

--- a/Assets/Tests/EditMode/SkillTreeDataTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeDataTests.cs
@@ -280,7 +280,8 @@ namespace RogueliteAutoBattler.Tests.EditMode
             Vector2 origin = Vector2.zero;
             float zoom = 1f;
 
-            Vector2 clickOnNode0 = new Vector2(1000f, 0f);
+            float node0PixelX = _skillTreeData.RingRadius * SkillTreeData.DefaultUnitSize;
+            Vector2 clickOnNode0 = new Vector2(node0PixelX, 0f);
             int result = SkillTreeDesignerWindow.HitTestNode(clickOnNode0, origin, _skillTreeData.Nodes, SkillTreeData.DefaultUnitSize, SkillTreeData.DefaultNodeSize, zoom);
             Assert.AreEqual(0, result);
         }

--- a/Assets/Tests/EditMode/SkillTreeDesignerViewportFitTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeDesignerViewportFitTests.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Data;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class SkillTreeDesignerViewportFitTests
+    {
+        [Test]
+        public void DefaultRingRadiusAndUnitSize_FitWithinMinimumWindowViewport()
+        {
+            const float MinWindowWidth = 800f;
+            const float ConfigPanelWidthRatio = 0.3f;
+            const float MarginFactor = 0.9f;
+
+            float canvasViewportWidth = MinWindowWidth * (1f - ConfigPanelWidthRatio);
+            float ringDiameterPx = SkillTreeData.DefaultRingRadius * SkillTreeData.DefaultUnitSize * 2f;
+
+            Assert.Less(ringDiameterPx, canvasViewportWidth * MarginFactor,
+                "Default ring diameter must fit inside the minimum designer viewport with 10% margin.");
+        }
+    }
+}

--- a/Assets/Tests/EditMode/SkillTreeDesignerViewportFitTests.cs.meta
+++ b/Assets/Tests/EditMode/SkillTreeDesignerViewportFitTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0d389661bc2de0140937f557ab609f16

--- a/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs
+++ b/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs
@@ -65,8 +65,8 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             _service?.Dispose();
             _service = null;
 
-            if (_data != null) Object.DestroyImmediate(_data);
-            if (_progress != null) Object.DestroyImmediate(_progress);
+            if (_data != null) UnityEngine.Object.DestroyImmediate(_data);
+            if (_progress != null) UnityEngine.Object.DestroyImmediate(_progress);
 
             base.TearDown();
         }
@@ -308,7 +308,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             {
                 GameBootstrap.ResetForTest();
                 if (teamDb != null)
-                    Object.DestroyImmediate(teamDb);
+                    UnityEngine.Object.DestroyImmediate(teamDb);
                 if (Directory.Exists(tempDirectory))
                     Directory.Delete(tempDirectory, true);
             }

--- a/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs
+++ b/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs
@@ -235,6 +235,63 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator OnLevelChanged_PercentNode_ApplyHumanPercentCorrectly()
+        {
+            const int baseAtk = 100;
+            const float percentPerLevel = 5f;
+            const int level = 1;
+            const int expectedAtk = 105;
+            const int allyCount = 1;
+
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry>
+            {
+                new SkillTreeData.SkillNodeEntry
+                {
+                    id = 0,
+                    maxLevel = 5,
+                    statModifierType = StatType.Atk,
+                    statModifierMode = SkillTreeData.StatModifierMode.Percent,
+                    statModifierValuePerLevel = percentPerLevel,
+                    connectedNodeIds = new List<int>()
+                }
+            });
+
+            _service = new AllyStatBonusService(_roster, _data, _progress);
+
+            var teamDb = ScriptableObject.CreateInstance<TeamDatabase>();
+            teamDb.Allies = new List<AllySpawnData>
+            {
+                new AllySpawnData
+                {
+                    AllyName = "Ally_Atk",
+                    Prefab = _allyPrefab,
+                    MaxHp = BaseMaxHp,
+                    Atk = baseAtk,
+                    AttackSpeed = 1f,
+                    MoveSpeed = 2f,
+                    ColliderRadius = 0.3f
+                }
+            };
+
+            ExpectAnimatorWarnings(allyCount);
+            _roster.Spawn(teamDb, _teamContainer, _teamHomeAnchor, TestCharacterScale);
+
+            yield return null;
+
+            TeamMember member = _roster.Members[0];
+            Assert.AreEqual(baseAtk, member.Stats.Atk, "Precondition: Atk should equal base before level up.");
+
+            _progress.SetLevel(0, level);
+
+            yield return null;
+
+            Assert.AreEqual(expectedAtk, member.Stats.Atk,
+                "Atk should equal base * (1 + 0.05) after +5% techtree node at level 1.");
+            Assert.IsTrue(HasTechTreeModifier(member.Stats, StatType.Atk, 0),
+                "Breakdown should contain a techtree:node0 modifier on Atk.");
+        }
+
+        [UnityTest]
         public IEnumerator Integration_GameBootstrapWiresService_LevelUpAffectsSpawnedMembers()
         {
             const int newLevel = 4;

--- a/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs
+++ b/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs
@@ -1,9 +1,13 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using RogueliteAutoBattler.Combat.Core;
+using RogueliteAutoBattler.Core;
 using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Economy;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -228,6 +232,86 @@ namespace RogueliteAutoBattler.Tests.PlayMode
                 "CurrentHp should equal base MaxHp after full heal.");
             Assert.IsFalse(HasTechTreeModifier(member.Stats, StatType.Hp, 0),
                 "Breakdown should NOT contain any techtree:node0 modifier after ResetAll.");
+        }
+
+        [UnityTest]
+        public IEnumerator Integration_GameBootstrapWiresService_LevelUpAffectsSpawnedMembers()
+        {
+            const int newLevel = 4;
+            const int allyCount = 1;
+            int expectedMaxHp = BaseMaxHp + HpPerLevel * newLevel;
+
+            GameBootstrap.ResetForTest();
+
+            var combatWorldGo = Track(new GameObject(GameBootstrap.CombatWorldName));
+            var bootstrappedRoster = combatWorldGo.AddComponent<TeamRoster>();
+            _teamContainer = combatWorldGo.transform;
+            _teamHomeAnchor = combatWorldGo.transform;
+
+            var camGo = Track(new GameObject("MainCamera"));
+            var cam = camGo.AddComponent<Camera>();
+            cam.tag = "MainCamera";
+
+            var walletGo = Track(new GameObject("GoldWallet"));
+            var wallet = walletGo.AddComponent<GoldWallet>();
+
+            string tempDirectory = Path.Combine(Path.GetTempPath(), "roguelite-tests", Guid.NewGuid().ToString());
+            string tempFilePath = Path.Combine(tempDirectory, "progression.json");
+
+            GameBootstrap.SkillTreeDataAssetForTest = _data;
+            GameBootstrap.SkillTreeProgressAssetForTest = _progress;
+            GameBootstrap.GoldWalletForTest = wallet;
+            GameBootstrap.ProgressionFilePathForTest = tempFilePath;
+
+            yield return null;
+
+            LogAssert.Expect(LogType.Error, new Regex("navigation system"));
+
+            TeamDatabase teamDb = null;
+            try
+            {
+                GameBootstrap.Initialize();
+
+                Assert.IsNotNull(GameBootstrap.ProgressionLoader,
+                    "ProgressionLoader should be created by GameBootstrap.");
+                Assert.IsNotNull(GameBootstrap.AllyStatBonusService,
+                    "AllyStatBonusService should be created by GameBootstrap.");
+                Assert.AreSame(bootstrappedRoster, GameBootstrap.TeamRoster,
+                    "GameBootstrap should resolve the TeamRoster on the CombatWorld GameObject.");
+
+                teamDb = TestCharacterFactory.CreateTeamDatabase(allyCount, _allyPrefab);
+                ExpectAnimatorWarnings(allyCount);
+                GameBootstrap.TeamRoster.Spawn(teamDb, _teamContainer, _teamHomeAnchor, TestCharacterScale);
+
+                yield return null;
+
+                TeamMember member = GameBootstrap.TeamRoster.Members[0];
+                Assert.AreEqual(BaseMaxHp, member.Stats.MaxHp,
+                    "Precondition: MaxHp should be base when node level is 0 at spawn time.");
+                Assert.AreEqual(BaseMaxHp, member.Stats.CurrentHp,
+                    "Precondition: CurrentHp should equal base MaxHp at spawn time.");
+                Assert.IsFalse(HasTechTreeModifier(member.Stats, StatType.Hp, 0),
+                    "Precondition: no techtree modifier should be applied at level 0.");
+
+                _progress.SetLevel(0, newLevel);
+
+                yield return null;
+
+                Assert.AreEqual(expectedMaxHp, member.Stats.MaxHp,
+                    "After SetLevel, MaxHp should include techtree bonus through the wired service.");
+                Assert.AreEqual(expectedMaxHp, member.Stats.CurrentHp,
+                    "After SetLevel, CurrentHp should equal MaxHp via HealToFull.");
+                Assert.IsTrue(HasTechTreeModifier(member.Stats, StatType.Hp, 0),
+                    "Breakdown should contain a techtree:node0 modifier after live level up.");
+            }
+            finally
+            {
+                GameBootstrap.ResetForTest();
+                if (teamDb != null)
+                    Object.DestroyImmediate(teamDb);
+                if (Directory.Exists(tempDirectory))
+                    Directory.Delete(tempDirectory, true);
+            }
         }
     }
 }

--- a/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs
+++ b/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs
@@ -1,0 +1,168 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+using RogueliteAutoBattler.Data;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace RogueliteAutoBattler.Tests.PlayMode
+{
+    public class AllyStatBonusServiceTests : PlayModeTestBase
+    {
+        private const float TestCharacterScale = 1.5f;
+        private const float FadeOutWaitSeconds = 0.35f;
+        private const int BaseMaxHp = 100;
+        private const int HpPerLevel = 5;
+
+        private TeamRoster _roster;
+        private Transform _teamContainer;
+        private Transform _teamHomeAnchor;
+        private GameObject _allyPrefab;
+        private SkillTreeData _data;
+        private SkillTreeProgress _progress;
+        private AllyStatBonusService _service;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var rosterGo = Track(new GameObject("TeamRoster"));
+            _roster = rosterGo.AddComponent<TeamRoster>();
+
+            var containerGo = Track(new GameObject("TeamContainer"));
+            _teamContainer = containerGo.transform;
+
+            var anchorGo = Track(new GameObject("TeamHomeAnchor"));
+            _teamHomeAnchor = anchorGo.transform;
+
+            _allyPrefab = Track(TestCharacterFactory.CreateCharacterPrefab());
+
+            _data = ScriptableObject.CreateInstance<SkillTreeData>();
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry>
+            {
+                new SkillTreeData.SkillNodeEntry
+                {
+                    id = 0,
+                    maxLevel = 5,
+                    statModifierType = StatType.Hp,
+                    statModifierMode = SkillTreeData.StatModifierMode.Flat,
+                    statModifierValuePerLevel = HpPerLevel,
+                    connectedNodeIds = new List<int>()
+                }
+            });
+
+            _progress = ScriptableObject.CreateInstance<SkillTreeProgress>();
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            _service?.Dispose();
+            _service = null;
+
+            if (_data != null) Object.DestroyImmediate(_data);
+            if (_progress != null) Object.DestroyImmediate(_progress);
+
+            base.TearDown();
+        }
+
+        private static void ExpectAnimatorWarnings(int allyCount)
+        {
+            for (int i = 0; i < allyCount; i++)
+                LogAssert.Expect(LogType.Warning, new Regex("No Animator found"));
+        }
+
+        private static bool HasTechTreeModifier(CombatStats stats, StatType statType, int nodeId)
+        {
+            string source = ModifierSources.TechTreeNode(nodeId);
+            var breakdown = stats.GetBreakdown(statType);
+            for (int i = 0; i < breakdown.Modifiers.Length; i++)
+            {
+                if (breakdown.Modifiers[i].Source == source)
+                    return true;
+            }
+            return false;
+        }
+
+        [UnityTest]
+        public IEnumerator OnMemberSpawned_AppliesTechtreeModifiers_AndCurrentHpEqualsNewMax()
+        {
+            const int level = 3;
+            const int allyCount = 1;
+            int expectedMaxHp = BaseMaxHp + HpPerLevel * level;
+
+            _progress.SetLevel(0, level);
+            _service = new AllyStatBonusService(_roster, _data, _progress);
+
+            var teamDb = TestCharacterFactory.CreateTeamDatabase(allyCount, _allyPrefab);
+            ExpectAnimatorWarnings(allyCount);
+            _roster.Spawn(teamDb, _teamContainer, _teamHomeAnchor, TestCharacterScale);
+
+            yield return null;
+
+            TeamMember member = _roster.Members[0];
+            Assert.AreEqual(expectedMaxHp, member.Stats.MaxHp, "MaxHp should include +15 HP from techtree level 3.");
+            Assert.AreEqual(expectedMaxHp, member.Stats.CurrentHp, "CurrentHp should equal MaxHp after HealToFull.");
+            Assert.IsTrue(HasTechTreeModifier(member.Stats, StatType.Hp, 0),
+                "Breakdown should contain a techtree:node0 modifier on Hp.");
+        }
+
+        [UnityTest]
+        public IEnumerator OnMemberSpawned_AtLevelZero_DoesNotAddModifier()
+        {
+            const int allyCount = 1;
+
+            _service = new AllyStatBonusService(_roster, _data, _progress);
+
+            var teamDb = TestCharacterFactory.CreateTeamDatabase(allyCount, _allyPrefab);
+            ExpectAnimatorWarnings(allyCount);
+            _roster.Spawn(teamDb, _teamContainer, _teamHomeAnchor, TestCharacterScale);
+
+            yield return null;
+
+            TeamMember member = _roster.Members[0];
+            Assert.AreEqual(BaseMaxHp, member.Stats.MaxHp, "MaxHp should remain at base when node level is 0.");
+            Assert.AreEqual(BaseMaxHp, member.Stats.CurrentHp, "CurrentHp should equal base MaxHp.");
+            Assert.IsFalse(HasTechTreeModifier(member.Stats, StatType.Hp, 0),
+                "Breakdown should NOT contain a techtree:node0 modifier when level is 0.");
+        }
+
+        [UnityTest]
+        public IEnumerator OnMemberRevived_ReappliesTechtreeModifiers_AndFullHeals()
+        {
+            const int level = 3;
+            const int allyCount = 1;
+            int expectedMaxHp = BaseMaxHp + HpPerLevel * level;
+
+            _progress.SetLevel(0, level);
+            _service = new AllyStatBonusService(_roster, _data, _progress);
+
+            var teamDb = TestCharacterFactory.CreateTeamDatabase(allyCount, _allyPrefab);
+            ExpectAnimatorWarnings(allyCount);
+            _roster.Spawn(teamDb, _teamContainer, _teamHomeAnchor, TestCharacterScale);
+
+            yield return null;
+
+            TeamMember member = _roster.Members[0];
+            Assert.AreEqual(expectedMaxHp, member.Stats.MaxHp, "Precondition: MaxHp should be boosted on spawn.");
+
+            member.Stats.TakeDamage(99999);
+
+            yield return new WaitForSeconds(FadeOutWaitSeconds);
+
+            Assert.IsTrue(member.IsDead, "Precondition: member should be dead before revive.");
+
+            _roster.Revive(member);
+
+            yield return null;
+
+            Assert.AreEqual(expectedMaxHp, member.Stats.MaxHp,
+                "After revive, MaxHp should still include techtree bonus (re-applied).");
+            Assert.AreEqual(expectedMaxHp, member.Stats.CurrentHp,
+                "After revive, CurrentHp should equal MaxHp (full heal).");
+            Assert.IsTrue(HasTechTreeModifier(member.Stats, StatType.Hp, 0),
+                "Breakdown should contain a techtree:node0 modifier on Hp after revive.");
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs
+++ b/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs
@@ -164,5 +164,70 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.IsTrue(HasTechTreeModifier(member.Stats, StatType.Hp, 0),
                 "Breakdown should contain a techtree:node0 modifier on Hp after revive.");
         }
+
+        [UnityTest]
+        public IEnumerator OnLevelChanged_LiveMember_RecomputesAndFullHeals()
+        {
+            const int newLevel = 3;
+            const int allyCount = 1;
+            int expectedMaxHp = BaseMaxHp + HpPerLevel * newLevel;
+
+            _service = new AllyStatBonusService(_roster, _data, _progress);
+
+            var teamDb = TestCharacterFactory.CreateTeamDatabase(allyCount, _allyPrefab);
+            ExpectAnimatorWarnings(allyCount);
+            _roster.Spawn(teamDb, _teamContainer, _teamHomeAnchor, TestCharacterScale);
+
+            yield return null;
+
+            TeamMember member = _roster.Members[0];
+            Assert.AreEqual(BaseMaxHp, member.Stats.MaxHp, "Precondition: MaxHp should be base before level up.");
+
+            member.Stats.TakeDamage(50);
+            Assert.AreEqual(BaseMaxHp - 50, member.Stats.CurrentHp, "Precondition: CurrentHp should be reduced by 50.");
+
+            _progress.SetLevel(0, newLevel);
+
+            yield return null;
+
+            Assert.AreEqual(expectedMaxHp, member.Stats.MaxHp,
+                "MaxHp should include techtree bonus after OnLevelChanged.");
+            Assert.AreEqual(expectedMaxHp, member.Stats.CurrentHp,
+                "CurrentHp should equal new MaxHp after full heal.");
+            Assert.IsTrue(HasTechTreeModifier(member.Stats, StatType.Hp, 0),
+                "Breakdown should contain a techtree:node0 modifier on Hp.");
+        }
+
+        [UnityTest]
+        public IEnumerator OnLevelChanged_ResetAllSentinel_ClearsAllTechtreeModifiers()
+        {
+            const int initialLevel = 3;
+            const int allyCount = 1;
+            int boostedMaxHp = BaseMaxHp + HpPerLevel * initialLevel;
+
+            _progress.SetLevel(0, initialLevel);
+            _service = new AllyStatBonusService(_roster, _data, _progress);
+
+            var teamDb = TestCharacterFactory.CreateTeamDatabase(allyCount, _allyPrefab);
+            ExpectAnimatorWarnings(allyCount);
+            _roster.Spawn(teamDb, _teamContainer, _teamHomeAnchor, TestCharacterScale);
+
+            yield return null;
+
+            TeamMember member = _roster.Members[0];
+            Assert.AreEqual(boostedMaxHp, member.Stats.MaxHp, "Precondition: MaxHp should include techtree bonus.");
+            Assert.AreEqual(boostedMaxHp, member.Stats.CurrentHp, "Precondition: CurrentHp should equal boosted MaxHp.");
+
+            _progress.ResetAll();
+
+            yield return null;
+
+            Assert.AreEqual(BaseMaxHp, member.Stats.MaxHp,
+                "MaxHp should drop back to base after ResetAll.");
+            Assert.AreEqual(BaseMaxHp, member.Stats.CurrentHp,
+                "CurrentHp should equal base MaxHp after full heal.");
+            Assert.IsFalse(HasTechTreeModifier(member.Stats, StatType.Hp, 0),
+                "Breakdown should NOT contain any techtree:node0 modifier after ResetAll.");
+        }
     }
 }

--- a/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs.meta
+++ b/Assets/Tests/PlayMode/AllyStatBonusServiceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 61f5511decbf22944926425918e78e18

--- a/Assets/Tests/PlayMode/AllyStatsPanelControllerTests.cs
+++ b/Assets/Tests/PlayMode/AllyStatsPanelControllerTests.cs
@@ -214,8 +214,8 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.AreEqual("0", _controller.StatValueText(2));
             Assert.AreEqual("0", _controller.StatValueText(3));
             Assert.AreEqual("0", _controller.StatValueText(4));
-            Assert.AreEqual("1.2", _controller.StatValueText(5));
-            Assert.AreEqual("2.0/s", _controller.StatValueText(6));
+            Assert.AreEqual("1.20", _controller.StatValueText(5));
+            Assert.AreEqual("2.00/s", _controller.StatValueText(6));
             Assert.AreEqual("0%", _controller.StatValueText(7));
         }
 

--- a/Assets/Tests/PlayMode/AllyStatsPanelControllerTests.cs
+++ b/Assets/Tests/PlayMode/AllyStatsPanelControllerTests.cs
@@ -778,6 +778,50 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             Assert.IsFalse(_controller.IsDisplayingDeadUnit);
             Assert.IsFalse(_controller.IsNameLabelDeadMarked);
         }
+
+        [UnityTest]
+        public IEnumerator Breakdown_ForHpStat_RendersBaseRowAndTechTreeModifierRowSeparately()
+        {
+            var ally = TestCharacterFactory.CreateSelectableCharacter("Ally", 200, 15, true, new Vector2(0, 0));
+            Track(ally);
+            ally.GetComponent<CombatStats>().InitializeDirect(maxHp: 200, atk: 15, attackSpeed: 1f);
+            ally.GetComponent<CombatStats>().AddModifier(StatType.Hp, ModifierTier.Flat, ModifierSources.TechTreeNode(0), 15f);
+
+            _selectionManager.ForceSelect(ally);
+            yield return null;
+
+            _controller.ToggleBreakdown(0);
+            yield return null;
+
+            VisualElement baseRow = _controller.GetBreakdownBaseRow(0);
+            Assert.IsNotNull(baseRow, "breakdown-base-row should exist");
+            string baseRowText = ConcatLabels(baseRow);
+            StringAssert.Contains("Base", baseRowText, "Base row source label should contain 'Base'");
+
+            VisualElement modifiersList = _controller.GetBreakdownModifiersList(0);
+            Assert.IsNotNull(modifiersList, "breakdown-modifiers-list should exist");
+            Assert.AreEqual(1, modifiersList.childCount, "Should have exactly one modifier row for the TechTree bonus");
+            string modRowText = ConcatLabels(modifiersList[0]);
+            StringAssert.Contains("Tech Tree", modRowText, "Modifier source should display 'Tech Tree', not the raw key");
+            StringAssert.Contains("15", modRowText, "Modifier row should contain the value 15");
+            StringAssert.DoesNotContain("techtree:node0", modRowText, "Raw source key must not appear in the UI");
+
+            VisualElement totalRow = _controller.GetBreakdownTotalRow(0);
+            Assert.IsNotNull(totalRow, "breakdown-total-row should exist");
+            string totalRowText = ConcatLabels(totalRow);
+            StringAssert.Contains("Total", totalRowText, "Total row label should contain 'Total'");
+            StringAssert.Contains("215", totalRowText, "Total row should contain the computed total (200 + 15)");
+        }
+
+        private static string ConcatLabels(VisualElement element)
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (var child in element.Children())
+            {
+                if (child is Label l) sb.Append(l.text).Append(' ');
+            }
+            return sb.ToString();
+        }
     }
 
     public class CoroutineHostStub : MonoBehaviour { }

--- a/Assets/Tests/PlayMode/CombatStatsHealToFullTests.cs
+++ b/Assets/Tests/PlayMode/CombatStatsHealToFullTests.cs
@@ -1,0 +1,83 @@
+using System.Collections;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+using UnityEngine.TestTools;
+
+namespace RogueliteAutoBattler.Tests.PlayMode
+{
+    public class CombatStatsHealToFullTests : PlayModeTestBase
+    {
+        [UnityTest]
+        public IEnumerator HealToFull_AfterMaxHpModifierAdded_LiftsCurrentHpToNewMax()
+        {
+            var charGo = Track(TestCharacterFactory.CreateCombatCharacter(
+                name: "HealToFullModifierChar",
+                maxHp: 100,
+                atk: 10,
+                attackSpeed: 1f));
+
+            var stats = charGo.GetComponent<CombatStats>();
+
+            yield return null;
+
+            Assert.AreEqual(100, stats.CurrentHp, "CurrentHp should start at 100.");
+            Assert.AreEqual(100, stats.MaxHp, "MaxHp should start at 100.");
+
+            stats.AddModifier(StatType.Hp, ModifierTier.Flat, "test", 50f);
+
+            Assert.AreEqual(150, stats.MaxHp, "MaxHp should rise to 150 after +50 Flat modifier.");
+            Assert.AreEqual(100, stats.CurrentHp, "CurrentHp should remain at 100 until HealToFull is called.");
+
+            stats.HealToFull();
+
+            Assert.AreEqual(150, stats.MaxHp, "MaxHp should still be 150 after HealToFull.");
+            Assert.AreEqual(150, stats.CurrentHp, "CurrentHp should be lifted to 150 after HealToFull.");
+            Assert.AreEqual(stats.MaxHp, stats.CurrentHp, "CurrentHp should equal MaxHp after HealToFull.");
+        }
+
+        [UnityTest]
+        public IEnumerator HealToFull_AtFullHealth_NoOp()
+        {
+            var charGo = Track(TestCharacterFactory.CreateCombatCharacter(
+                name: "HealToFullNoOpChar",
+                maxHp: 100,
+                atk: 10,
+                attackSpeed: 1f));
+
+            var stats = charGo.GetComponent<CombatStats>();
+
+            yield return null;
+
+            stats.HealToFull();
+
+            Assert.AreEqual(100, stats.CurrentHp, "CurrentHp should remain at 100.");
+            Assert.AreEqual(100, stats.MaxHp, "MaxHp should remain at 100.");
+            Assert.AreEqual(stats.MaxHp, stats.CurrentHp, "CurrentHp should equal MaxHp.");
+        }
+
+        [UnityTest]
+        public IEnumerator HealToFull_DoesNotRaiseOnHealed()
+        {
+            var charGo = Track(TestCharacterFactory.CreateCombatCharacter(
+                name: "HealToFullSilentChar",
+                maxHp: 100,
+                atk: 10,
+                attackSpeed: 1f));
+
+            var stats = charGo.GetComponent<CombatStats>();
+
+            yield return null;
+
+            stats.TakeDamage(50);
+            Assert.AreEqual(50, stats.CurrentHp, "CurrentHp should be 50 after taking 50 damage.");
+
+            int onHealedFireCount = 0;
+            stats.OnHealed += (heal, currentHp) => onHealedFireCount++;
+
+            stats.HealToFull();
+
+            Assert.AreEqual(100, stats.CurrentHp, "CurrentHp should be lifted to 100 after HealToFull.");
+            Assert.AreEqual(0, onHealedFireCount, "HealToFull should not raise OnHealed.");
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/CombatStatsHealToFullTests.cs.meta
+++ b/Assets/Tests/PlayMode/CombatStatsHealToFullTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b4cf487677701144bbde8d1aac24d126

--- a/Assets/Tests/PlayMode/GameBootstrapTests.cs
+++ b/Assets/Tests/PlayMode/GameBootstrapTests.cs
@@ -321,8 +321,8 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             finally
             {
                 GameBootstrap.ResetForTest();
-                Object.DestroyImmediate(data);
-                Object.DestroyImmediate(progress);
+                UnityEngine.Object.DestroyImmediate(data);
+                UnityEngine.Object.DestroyImmediate(progress);
                 if (Directory.Exists(tempDirectory))
                     Directory.Delete(tempDirectory, true);
             }

--- a/Assets/Tests/PlayMode/GameBootstrapTests.cs
+++ b/Assets/Tests/PlayMode/GameBootstrapTests.cs
@@ -230,8 +230,8 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             finally
             {
                 GameBootstrap.ResetForTest();
-                Object.DestroyImmediate(data);
-                Object.DestroyImmediate(progress);
+                UnityEngine.Object.DestroyImmediate(data);
+                UnityEngine.Object.DestroyImmediate(progress);
                 if (Directory.Exists(tempDirectory))
                     Directory.Delete(tempDirectory, true);
             }

--- a/Assets/Tests/PlayMode/GameBootstrapTests.cs
+++ b/Assets/Tests/PlayMode/GameBootstrapTests.cs
@@ -42,7 +42,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator Initialize_FindsAllSceneRefs()
         {
-            var combatWorldGo = Track(new GameObject("CombatWorld"));
+            var combatWorldGo = Track(new GameObject(GameBootstrap.CombatWorldName));
 
             var camGo = Track(new GameObject("MainCamera"));
             var cam = camGo.AddComponent<Camera>();
@@ -96,7 +96,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator ResetForTest_ClearsAllRefs()
         {
-            Track(new GameObject("CombatWorld"));
+            Track(new GameObject(GameBootstrap.CombatWorldName));
 
             var camGo = Track(new GameObject("MainCamera"));
             var cam = camGo.AddComponent<Camera>();
@@ -120,7 +120,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator Initialize_SetsTeamRoster_WhenCombatWorldHasComponent()
         {
-            var combatWorldGo = Track(new GameObject("CombatWorld"));
+            var combatWorldGo = Track(new GameObject(GameBootstrap.CombatWorldName));
             var expectedRoster = combatWorldGo.AddComponent<TeamRoster>();
 
             var camGo = Track(new GameObject("MainCamera"));
@@ -140,7 +140,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator Initialize_LogsError_WhenCombatWorldLacksTeamRoster()
         {
-            Track(new GameObject("CombatWorld"));
+            Track(new GameObject(GameBootstrap.CombatWorldName));
 
             var camGo = Track(new GameObject("MainCamera"));
             var cam = camGo.AddComponent<Camera>();
@@ -159,7 +159,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator ResetForTest_ClearsTeamRoster()
         {
-            var combatWorldGo = Track(new GameObject("CombatWorld"));
+            var combatWorldGo = Track(new GameObject(GameBootstrap.CombatWorldName));
             combatWorldGo.AddComponent<TeamRoster>();
 
             var camGo = Track(new GameObject("MainCamera"));
@@ -181,7 +181,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator Initialize_WithSkillTreeAssetsInjected_CreatesAllyStatBonusServiceAndLoader()
         {
-            var combatWorldGo = Track(new GameObject("CombatWorld"));
+            var combatWorldGo = Track(new GameObject(GameBootstrap.CombatWorldName));
             combatWorldGo.AddComponent<TeamRoster>();
 
             var camGo = Track(new GameObject("MainCamera"));
@@ -240,7 +240,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator Initialize_MissingSkillTreeAssets_LogsErrorAndServiceNull()
         {
-            var combatWorldGo = Track(new GameObject("CombatWorld"));
+            var combatWorldGo = Track(new GameObject(GameBootstrap.CombatWorldName));
             combatWorldGo.AddComponent<TeamRoster>();
 
             var camGo = Track(new GameObject("MainCamera"));
@@ -261,7 +261,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         [UnityTest]
         public IEnumerator ResetForTest_DisposesProgressionLoaderAndService()
         {
-            var combatWorldGo = Track(new GameObject("CombatWorld"));
+            var combatWorldGo = Track(new GameObject(GameBootstrap.CombatWorldName));
             combatWorldGo.AddComponent<TeamRoster>();
 
             var camGo = Track(new GameObject("MainCamera"));

--- a/Assets/Tests/PlayMode/GameBootstrapTests.cs
+++ b/Assets/Tests/PlayMode/GameBootstrapTests.cs
@@ -1,8 +1,13 @@
+using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.IO;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using RogueliteAutoBattler.Combat.Core;
 using RogueliteAutoBattler.Core;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Economy;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -10,6 +15,10 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 {
     public class GameBootstrapTests : PlayModeTestBase
     {
+        private static readonly Regex GoldWalletErrorRegex = new Regex("GoldWallet not found");
+        private static readonly Regex ProgressionLoaderErrorRegex = new Regex("ProgressionLoader not initialized");
+        private static readonly Regex AllyStatBonusServiceErrorRegex = new Regex("AllyStatBonusService not initialized");
+
         [SetUp]
         public void SetUp()
         {
@@ -21,6 +30,13 @@ namespace RogueliteAutoBattler.Tests.PlayMode
         {
             GameBootstrap.ResetForTest();
             base.TearDown();
+        }
+
+        private static void ExpectMissingProgressionRefsErrors()
+        {
+            LogAssert.Expect(LogType.Error, GoldWalletErrorRegex);
+            LogAssert.Expect(LogType.Error, ProgressionLoaderErrorRegex);
+            LogAssert.Expect(LogType.Error, AllyStatBonusServiceErrorRegex);
         }
 
         [UnityTest]
@@ -35,6 +51,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             LogAssert.Expect(LogType.Error, new Regex("TeamRoster"));
             LogAssert.Expect(LogType.Error, new Regex("navigation system"));
+            ExpectMissingProgressionRefsErrors();
 
             GameBootstrap.Initialize();
 
@@ -54,6 +71,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             LogAssert.Expect(LogType.Error, new Regex("CombatWorld"));
             LogAssert.Expect(LogType.Error, new Regex("TeamRoster"));
             LogAssert.Expect(LogType.Error, new Regex("navigation system"));
+            ExpectMissingProgressionRefsErrors();
 
             GameBootstrap.Initialize();
         }
@@ -67,6 +85,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             LogAssert.Expect(LogType.Error, new Regex("TeamRoster"));
             LogAssert.Expect(LogType.Error, new Regex("navigation system"));
             LogAssert.Expect(LogType.Error, new Regex("Main Camera"));
+            ExpectMissingProgressionRefsErrors();
 
             GameBootstrap.Initialize();
 
@@ -86,6 +105,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             LogAssert.Expect(LogType.Error, new Regex("TeamRoster"));
             LogAssert.Expect(LogType.Error, new Regex("navigation system"));
+            ExpectMissingProgressionRefsErrors();
 
             GameBootstrap.Initialize();
             Assert.IsNotNull(GameBootstrap.CombatWorld);
@@ -109,6 +129,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             yield return null;
 
             LogAssert.Expect(LogType.Error, new Regex("navigation system"));
+            ExpectMissingProgressionRefsErrors();
 
             GameBootstrap.Initialize();
 
@@ -128,6 +149,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
 
             LogAssert.Expect(LogType.Error, "[GameBootstrap] TeamRoster not found on CombatWorld root.");
             LogAssert.Expect(LogType.Error, new Regex("navigation system"));
+            ExpectMissingProgressionRefsErrors();
 
             GameBootstrap.Initialize();
 
@@ -146,6 +168,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             yield return null;
 
             LogAssert.Expect(LogType.Error, new Regex("navigation system"));
+            ExpectMissingProgressionRefsErrors();
 
             GameBootstrap.Initialize();
             Assert.IsNotNull(GameBootstrap.TeamRoster);
@@ -153,6 +176,156 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             GameBootstrap.ResetForTest();
 
             Assert.IsNull(GameBootstrap.TeamRoster);
+        }
+
+        [UnityTest]
+        public IEnumerator Initialize_WithSkillTreeAssetsInjected_CreatesAllyStatBonusServiceAndLoader()
+        {
+            var combatWorldGo = Track(new GameObject("CombatWorld"));
+            combatWorldGo.AddComponent<TeamRoster>();
+
+            var camGo = Track(new GameObject("MainCamera"));
+            var cam = camGo.AddComponent<Camera>();
+            cam.tag = "MainCamera";
+
+            var walletGo = Track(new GameObject("GoldWallet"));
+            var wallet = walletGo.AddComponent<GoldWallet>();
+
+            var data = ScriptableObject.CreateInstance<SkillTreeData>();
+            data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry>
+            {
+                new SkillTreeData.SkillNodeEntry
+                {
+                    id = 0,
+                    maxLevel = 5,
+                    statModifierType = StatType.Hp,
+                    statModifierMode = SkillTreeData.StatModifierMode.Flat,
+                    statModifierValuePerLevel = 5f,
+                    connectedNodeIds = new List<int>()
+                }
+            });
+            var progress = ScriptableObject.CreateInstance<SkillTreeProgress>();
+
+            string tempDirectory = Path.Combine(Path.GetTempPath(), "roguelite-tests", Guid.NewGuid().ToString());
+            string tempFilePath = Path.Combine(tempDirectory, "progression.json");
+
+            GameBootstrap.SkillTreeDataAssetForTest = data;
+            GameBootstrap.SkillTreeProgressAssetForTest = progress;
+            GameBootstrap.GoldWalletForTest = wallet;
+            GameBootstrap.ProgressionFilePathForTest = tempFilePath;
+
+            yield return null;
+
+            LogAssert.Expect(LogType.Error, new Regex("navigation system"));
+
+            try
+            {
+                GameBootstrap.Initialize();
+
+                Assert.IsNotNull(GameBootstrap.GoldWallet, "GoldWallet should be resolved from injection.");
+                Assert.AreSame(wallet, GameBootstrap.GoldWallet);
+                Assert.IsNotNull(GameBootstrap.ProgressionLoader, "ProgressionLoader should be created.");
+                Assert.IsNotNull(GameBootstrap.AllyStatBonusService, "AllyStatBonusService should be created.");
+            }
+            finally
+            {
+                GameBootstrap.ResetForTest();
+                Object.DestroyImmediate(data);
+                Object.DestroyImmediate(progress);
+                if (Directory.Exists(tempDirectory))
+                    Directory.Delete(tempDirectory, true);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Initialize_MissingSkillTreeAssets_LogsErrorAndServiceNull()
+        {
+            var combatWorldGo = Track(new GameObject("CombatWorld"));
+            combatWorldGo.AddComponent<TeamRoster>();
+
+            var camGo = Track(new GameObject("MainCamera"));
+            var cam = camGo.AddComponent<Camera>();
+            cam.tag = "MainCamera";
+
+            yield return null;
+
+            LogAssert.Expect(LogType.Error, new Regex("navigation system"));
+            ExpectMissingProgressionRefsErrors();
+
+            GameBootstrap.Initialize();
+
+            Assert.IsNull(GameBootstrap.AllyStatBonusService);
+            Assert.IsNull(GameBootstrap.ProgressionLoader);
+        }
+
+        [UnityTest]
+        public IEnumerator ResetForTest_DisposesProgressionLoaderAndService()
+        {
+            var combatWorldGo = Track(new GameObject("CombatWorld"));
+            combatWorldGo.AddComponent<TeamRoster>();
+
+            var camGo = Track(new GameObject("MainCamera"));
+            var cam = camGo.AddComponent<Camera>();
+            cam.tag = "MainCamera";
+
+            var walletGo = Track(new GameObject("GoldWallet"));
+            var wallet = walletGo.AddComponent<GoldWallet>();
+
+            var data = ScriptableObject.CreateInstance<SkillTreeData>();
+            data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry>
+            {
+                new SkillTreeData.SkillNodeEntry
+                {
+                    id = 0,
+                    maxLevel = 5,
+                    statModifierType = StatType.Hp,
+                    statModifierMode = SkillTreeData.StatModifierMode.Flat,
+                    statModifierValuePerLevel = 5f,
+                    connectedNodeIds = new List<int>()
+                }
+            });
+            var progress = ScriptableObject.CreateInstance<SkillTreeProgress>();
+
+            string tempDirectory = Path.Combine(Path.GetTempPath(), "roguelite-tests", Guid.NewGuid().ToString());
+            string tempFilePath = Path.Combine(tempDirectory, "progression.json");
+
+            GameBootstrap.SkillTreeDataAssetForTest = data;
+            GameBootstrap.SkillTreeProgressAssetForTest = progress;
+            GameBootstrap.GoldWalletForTest = wallet;
+            GameBootstrap.ProgressionFilePathForTest = tempFilePath;
+
+            yield return null;
+
+            LogAssert.Expect(LogType.Error, new Regex("navigation system"));
+
+            try
+            {
+                GameBootstrap.Initialize();
+
+                Assert.IsNotNull(GameBootstrap.ProgressionLoader);
+                Assert.IsNotNull(GameBootstrap.AllyStatBonusService);
+
+                GameBootstrap.ResetForTest();
+
+                Assert.IsNull(GameBootstrap.ProgressionLoader);
+                Assert.IsNull(GameBootstrap.AllyStatBonusService);
+
+                if (File.Exists(tempFilePath))
+                    File.Delete(tempFilePath);
+
+                progress.SetLevel(0, 7);
+
+                Assert.IsFalse(File.Exists(tempFilePath),
+                    "Save handler should have been unsubscribed by Dispose; no file should be written.");
+            }
+            finally
+            {
+                GameBootstrap.ResetForTest();
+                Object.DestroyImmediate(data);
+                Object.DestroyImmediate(progress);
+                if (Directory.Exists(tempDirectory))
+                    Directory.Delete(tempDirectory, true);
+            }
         }
     }
 }

--- a/Assets/Tests/PlayMode/NewGameSceneSmokeTests.cs
+++ b/Assets/Tests/PlayMode/NewGameSceneSmokeTests.cs
@@ -112,6 +112,10 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             {
                 if (err.Contains("[GameBootstrap] No navigation system"))
                     continue;
+                if (err.Contains("[GameBootstrap] ProgressionLoader not initialized"))
+                    continue;
+                if (err.Contains("[GameBootstrap] AllyStatBonusService not initialized"))
+                    continue;
                 unexpectedErrors.Add(err);
             }
 

--- a/Assets/UI/Styles/MainStyle.uss
+++ b/Assets/UI/Styles/MainStyle.uss
@@ -452,6 +452,29 @@
     white-space: normal;
 }
 
+.stat-breakdown-base-row {
+    flex-direction: row;
+    justify-content: space-between;
+    -unity-font-style: bold;
+}
+
+.stat-breakdown-modifier-row {
+    flex-direction: row;
+    justify-content: space-between;
+    padding-left: 16px;
+    opacity: 0.85;
+}
+
+.stat-breakdown-total-row {
+    flex-direction: row;
+    justify-content: space-between;
+    border-top-width: 1px;
+    border-top-color: rgba(255, 255, 255, 0.3);
+    margin-top: 4px;
+    padding-top: 2px;
+    -unity-font-style: bold;
+}
+
 #screen-skilltree {
     background-color: rgb(20, 20, 28);
     flex-grow: 1;

--- a/Assets/UI/Styles/MainStyle.uss
+++ b/Assets/UI/Styles/MainStyle.uss
@@ -455,14 +455,24 @@
 .stat-breakdown-base-row {
     flex-direction: row;
     justify-content: space-between;
-    -unity-font-style: bold;
+}
+
+.stat-breakdown-base-row > Label {
+    font-size: var(--info-breakdown-font-size);
+    color: rgb(140, 210, 255);
+    white-space: normal;
 }
 
 .stat-breakdown-modifier-row {
     flex-direction: row;
     justify-content: space-between;
     padding-left: 16px;
-    opacity: 0.85;
+}
+
+.stat-breakdown-modifier-row > Label {
+    font-size: var(--info-breakdown-font-size);
+    color: rgb(140, 210, 255);
+    white-space: normal;
 }
 
 .stat-breakdown-total-row {
@@ -472,7 +482,12 @@
     border-top-color: rgba(255, 255, 255, 0.3);
     margin-top: 4px;
     padding-top: 2px;
-    -unity-font-style: bold;
+}
+
+.stat-breakdown-total-row > Label {
+    font-size: var(--info-breakdown-font-size);
+    color: rgb(140, 210, 255);
+    white-space: normal;
 }
 
 #screen-skilltree {

--- a/Assets/_Recovery.meta
+++ b/Assets/_Recovery.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a35a0df139ee0d449b2f71d727f44782
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 Doc detaille : `Assets/doc/premier-jet-roguelite.html`
 
 # Project Structure
-Generated: 2026-04-25
+Generated: 2026-04-26
 
 .github/
   workflows/
@@ -78,6 +78,7 @@ Assets/
     Adventurers/  (empty)
     Combat/
       Core/
+        AllyStatBonusService.cs
         AnimHashes.cs
         AnimationEventRelay.cs
         AttackSlotRegistry.cs
@@ -143,6 +144,7 @@ Assets/
         SkillTreeScreenBuilder.cs
         WalletsBuilder.cs
       Tools/
+        ResetPlayerProgressMenu.cs
         StatTypeValidator.cs
       Windows/
         GameDesignerWindow.cs
@@ -160,7 +162,9 @@ Assets/
       TeamDatabase.cs
     ScriptableObjects/  (empty)
     Services/
-      Local/  (empty)
+      IPlayerProgressionLoader.cs
+      Local/
+        LocalPlayerProgressionLoader.cs
     UI/
       Toolkit/
         AllyStatsPanelController.cs
@@ -204,6 +208,7 @@ Assets/
       Tests.EditMode.asmdef
       TestUtils/
         StubScreen.cs
+      AllyStatBonusServiceResolverTests.cs
       AttackSlotRegistryTests.cs
       CombatStatsBreakdownAllStatsTests.cs
       CombatStatsBreakdownTests.cs
@@ -213,12 +218,14 @@ Assets/
       EditorBuildSettingsSceneTests.cs
       FormationLayoutTests.cs
       GoldFormatterTests.cs
+      LocalPlayerProgressionLoaderTests.cs
       ModifierSourcesTests.cs
       ModifierStructTests.cs
       ModifierTierTests.cs
       NewGameSceneBuilderTests.cs
       ProceduralGroundSpriteTests.cs
       RecalculateFormationTests.cs
+      ResetPlayerProgressMenuTests.cs
       SkillTreeAssetIntegrityTests.cs
       SkillTreeDataAssetSpacingTests.cs
       SkillTreeDataTests.cs
@@ -239,6 +246,7 @@ Assets/
       TestUtils/
         PlayModeTestBase.cs
         TestCharacterFactory.cs
+      AllyStatBonusServiceTests.cs
       AllyStatsPanelControllerTests.cs
       AllyStatsPanelScalingTests.cs
       AnimationEventRelayTests.cs
@@ -251,6 +259,7 @@ Assets/
       CombatHudControllerTests.cs
       CombatSetupHelperTests.cs
       CombatSpawnManagerTests.cs
+      CombatStatsHealToFullTests.cs
       CombatStatsRegenTests.cs
       CombatWorldVisibilityNavTests.cs
       DamageNumberServiceTests.cs


### PR DESCRIPTION
Closes #241

## Summary
- Pure C# service applies all unlocked tech-tree node modifiers to every ally CombatStats reactively (spawn / revive / live level-up), with full-heal on living members
- Unlocked nodes persist locally in `Application.persistentDataPath` (JSON) with gold/wallet state
- Designer UX: Percent label + helpbox, default 6 nodes Percent 5% rotation, confirm-on-regenerate, Ctrl+Z support
- Stat breakdown panel: structured layout (base / modifiers / total), "Tech Tree" friendly label, F2 decimal precision for AttackSpeed/RegenHp

## Key Components
- `AllyStatBonusService` — pure C# service, owned by GameBootstrap
- `IPlayerProgressionLoader` + `LocalPlayerProgressionLoader` — JSON persist for skill tree levels + gold in `Application.persistentDataPath`
- Editor menu `Roguelite/Reset Player Progress` with confirmation dialog
- `CombatStats.HealToFull()` (silent helper)
- `ModifierSources.TechTreeNode(int)` source key + `GetDisplayLabel()` friendly mapping

## Bug Fixes During Manual Test
- Percent unit conversion (5% no longer applied as 500%)
- Float trunc → RoundToInt for "+10%" display (was "+9%")
- Base row shows actual character base, not recomputed value

## Test Results
599 green (241 EditMode + 358 PlayMode) — full coverage of resolver, persistence roundtrip, spawn/revive/live propagation, integration through GameBootstrap.