### PR TITLE
chore(ui): rename nav tab "autre" to "map"

### DIFF
--- a/Assets/Scripts/UI/Toolkit/NavigationHost.cs
+++ b/Assets/Scripts/UI/Toolkit/NavigationHost.cs
@@ -8,12 +8,12 @@ namespace RogueliteAutoBattler.UI.Toolkit
     {
         private static readonly string[] TabButtonNames =
         {
-            "tab-village", "tab-skilltree", "tab-autre", "tab-guilde", "tab-shop"
+            "tab-village", "tab-skilltree", "tab-map", "tab-guilde", "tab-shop"
         };
 
         private static readonly string[] ScreenNames =
         {
-            "screen-village", "screen-skilltree", "screen-autre", "screen-guilde", "screen-shop"
+            "screen-village", "screen-skilltree", "screen-map", "screen-guilde", "screen-shop"
         };
 
         private const string DefaultScreenName = "screen-default";

--- a/Assets/Tests/PlayMode/NavigationHostTests.cs
+++ b/Assets/Tests/PlayMode/NavigationHostTests.cs
@@ -161,7 +161,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             var screenDefault = new VisualElement { name = "screen-default" };
             gameArea.Add(screenDefault);
 
-            string[] screenNames = { "screen-village", "screen-skilltree", "screen-autre", "screen-guilde", "screen-shop" };
+            string[] screenNames = { "screen-village", "screen-skilltree", "screen-map", "screen-guilde", "screen-shop" };
             foreach (string screenName in screenNames)
             {
                 var screen = new VisualElement { name = screenName };
@@ -172,7 +172,7 @@ namespace RogueliteAutoBattler.Tests.PlayMode
             var navBar = new VisualElement { name = "nav-bar" };
             root.Add(navBar);
 
-            string[] tabNames = { "tab-village", "tab-skilltree", "tab-autre", "tab-guilde", "tab-shop" };
+            string[] tabNames = { "tab-village", "tab-skilltree", "tab-map", "tab-guilde", "tab-shop" };
             foreach (string tabName in tabNames)
             {
                 var button = new Button { name = tabName };

--- a/Assets/UI/Layouts/MainLayout.uxml
+++ b/Assets/UI/Layouts/MainLayout.uxml
@@ -40,9 +40,9 @@
                     <ui:Button name="skilltree-detail-close-btn" class="skill-tree-detail-close-btn" text="X" />
                 </ui:VisualElement>
             </ui:VisualElement>
-            <ui:VisualElement name="screen-autre" class="screen-container hidden">
-                <ui:VisualElement class="screen-placeholder screen-autre-bg">
-                    <ui:Label text="AUTRE" class="screen-placeholder-label" />
+            <ui:VisualElement name="screen-map" class="screen-container hidden">
+                <ui:VisualElement class="screen-placeholder screen-map-bg">
+                    <ui:Label text="MAP" class="screen-placeholder-label" />
                 </ui:VisualElement>
             </ui:VisualElement>
             <ui:VisualElement name="screen-guilde" class="screen-container hidden">
@@ -95,7 +95,7 @@
         <ui:VisualElement name="nav-bar" class="nav-bar">
             <ui:Button name="tab-village" text="Village" class="tab-button tab-inactive" />
             <ui:Button name="tab-skilltree" text="Arbre" class="tab-button tab-inactive" />
-            <ui:Button name="tab-autre" text="Autre" class="tab-button tab-inactive" />
+            <ui:Button name="tab-map" text="Map" class="tab-button tab-inactive" />
             <ui:Button name="tab-guilde" text="Guilde" class="tab-button tab-inactive" />
             <ui:Button name="tab-shop" text="Shop" class="tab-button tab-inactive" />
         </ui:VisualElement>

--- a/Assets/UI/Styles/MainStyle.uss
+++ b/Assets/UI/Styles/MainStyle.uss
@@ -131,7 +131,7 @@
     background-color: rgba(123, 45, 142, 220);
 }
 
-.screen-autre-bg {
+.screen-map-bg {
     background-color: rgba(85, 85, 85, 220);
 }
 


### PR DESCRIPTION
## Summary
- Rename navigation tab and screen identifiers from "autre" to "map" (UI Toolkit UXML/USS/C#)
- Pure cosmetic refactor: no logic changes, behavior identical

## Files modified
- `Assets/UI/Layouts/MainLayout.uxml`
- `Assets/UI/Styles/MainStyle.uss`
- `Assets/Scripts/UI/Toolkit/NavigationHost.cs`
- `Assets/Tests/PlayMode/NavigationHostTests.cs`