### PR TITLE
chore(agents): apply Lessons from #251 to lead/brainstorm/dev prompts

### DIFF
--- a/.claude/agents/brainstorm-unity.md
+++ b/.claude/agents/brainstorm-unity.md
@@ -124,6 +124,42 @@ Root (Rigidbody2D, movement scripts, combat scripts — NO Animator, NO SpriteRe
 
 **Applies to**: any character prefab that combines physics movement with sprite animations (adventurers, enemies, bosses). Even if there are no position curves, root bindings from sprite-swap animations are sufficient to trigger the conflict.
 
+## Lessons from #251 — Question Budget & YAGNI Discipline
+
+**CRITICAL**: Brainstorm is NOT exhaustive ideation. Over-broad questioning multiplies the planning cost of trivial features. Apply these constraints BEFORE drafting your output.
+
+### Hard cap: 3 open questions max
+
+- If you have more than 3 open questions, **pick the 3 with the highest decisional impact** (those that would change the implementation by > 50 LOC or change the architecture). Flag the rest as `// future` items in a single line, **without developing them**.
+- "Would change the architecture" = different files touched, different ownership, different testing strategy. NOT "different sprite" or "different default value".
+- A question is high-impact ONLY if at least two answers lead to materially different implementations. Otherwise, pick the simpler default and move on.
+
+### YAGNI default for "prepare for later" questions
+
+- Before asking "should we prepare for parallax/tint/animation/streaming later?", check whether the user explicitly referenced that future use case. **If not, default to YAGNI**: recommend the simple version and do NOT raise the question.
+- Adding extension hooks "just in case" is a YAGNI violation. The cost of refactoring later is almost always lower than the cost of premature abstraction now.
+
+### Cosmetic features — skip the architecture-level ceremony
+
+For features that are purely **cosmetic** — sprite assignments, color tweaks, layout placement, UI positioning, drag-drop of static assets — DO NOT raise:
+
+- Client/server split questions (it is obviously client-only and obvious to the user too — flag it in one line, do not develop)
+- Anti-cheat considerations
+- Server validation strategies
+- DTO / API contract questions
+
+The boilerplate "client vs server" section in your output template is **skippable** for cosmetic features. Replace it with a single line: "Client-only feature — no server impact."
+
+### Heuristic: is this feature cosmetic?
+
+A feature is cosmetic if ALL of these hold:
+- No new gameplay rule, stat, formula, or runtime decision
+- No persisted player data being created or modified
+- No effect on combat outcome, loot, progression, or economy
+- The "implementation" is mostly assigning sprites/colors/positions to existing data structures
+
+If yes → output should be < 100 lines and contain at most 2 options. Often 1 option + a recommendation is sufficient.
+
 ## Zero Manual Steps — Automation First
 
 **CRITICAL RULE**: Never classify a task as "manual" or "do it in the Unity Editor" without first evaluating if it can be automated. The user should NEVER have to open Unity Editor to configure something that code can handle.

--- a/.claude/agents/dev-unity.md
+++ b/.claude/agents/dev-unity.md
@@ -248,6 +248,22 @@ When the implementation requires creating Unity assets that can't be produced by
 
 **When NOT to self-destruct:** If the button is meant to be reusable (e.g., "Reload All Prefabs", "Generate Sprite Atlas"), keep it as a permanent utility — do NOT self-destruct. Only self-destruct for true one-time setup operations.
 
+## Lessons from #251 — Using-directive Cleanup Discipline
+
+**CRITICAL**: When the task includes removing or replacing a type, do NOT eagerly remove the corresponding `using` directive. Namespaces typically host multiple types, and removing the `using` because one consumer was replaced will break unrelated consumers in the same file → compile error → wasted commit + re-run cycle.
+
+### Mandatory cleanup checklist BEFORE removing any `using` directive
+
+1. **Grep the whole file** (not just the zone you modified) for any type that lives in that namespace. Use a Grep over the namespace's known types, not just the one you replaced.
+   - Example: removing `using RogueliteAutoBattler.Combat.Visuals;` because you deleted `ProceduralGroundSprite` requires checking that the file does NOT also reference `CombatWorldVisibility`, `DamageNumberBootstrap`, `VisualEquipmentTestLoop`, etc.
+2. **List the namespace's types**: `Glob` the source folder for that namespace (e.g. `Assets/Scripts/Combat/Visuals/*.cs`) and grep each type's name in the current file.
+3. **If the namespace has > 1 type AND any of them is still referenced in the file → KEEP the using.** Even if your initial motivation (the type you removed) is resolved.
+4. **If you are unsure → KEEP the using.** A redundant using is a LOW-severity warning that the next refacto pass will catch. A missing using is a compile error that breaks the build and forces a fix commit.
+
+### Golden rule
+
+> Removing a `using` is a separate cleanup decision from removing a type. Treat them independently. The compiler will flag truly-unused usings later — let it do its job.
+
 ## Rules
 
 - Follow the plan exactly — no unrequested features

--- a/.claude/agents/dev-ux-toolkit.md
+++ b/.claude/agents/dev-ux-toolkit.md
@@ -412,6 +412,22 @@ Rules:
 - Use Edit tool for surgical changes
 - Respect Unity YAML format (2-space indent, `{fileID: <id>}` references)
 
+## Lessons from #251 — Using-directive Cleanup Discipline
+
+**CRITICAL**: When the task includes removing or replacing a type, do NOT eagerly remove the corresponding `using` directive. Namespaces typically host multiple types, and removing the `using` because one consumer was replaced will break unrelated consumers in the same file → compile error → wasted commit + re-run cycle.
+
+### Mandatory cleanup checklist BEFORE removing any `using` directive
+
+1. **Grep the whole file** (not just the zone you modified) for any type that lives in that namespace. Use a Grep over the namespace's known types, not just the one you replaced.
+   - Example: removing `using RogueliteAutoBattler.Combat.Visuals;` because you deleted `ProceduralGroundSprite` requires checking that the file does NOT also reference `CombatWorldVisibility`, `DamageNumberBootstrap`, `VisualEquipmentTestLoop`, etc.
+2. **List the namespace's types**: `Glob` the source folder for that namespace (e.g. `Assets/Scripts/Combat/Visuals/*.cs`) and grep each type's name in the current file.
+3. **If the namespace has > 1 type AND any of them is still referenced in the file → KEEP the using.** Even if your initial motivation (the type you removed) is resolved.
+4. **If you are unsure → KEEP the using.** A redundant using is a LOW-severity warning that the next refacto pass will catch. A missing using is a compile error that breaks the build and forces a fix commit.
+
+### Golden rule
+
+> Removing a `using` is a separate cleanup decision from removing a type. Treat them independently. The compiler will flag truly-unused usings later — let it do its job.
+
 ## Rules
 
 - **NEVER write comments** — use descriptive names. Only `// TODO:` for critical issues.

--- a/.claude/commands/lead-roguelite.md
+++ b/.claude/commands/lead-roguelite.md
@@ -137,6 +137,16 @@ Sous-tache 3: Arret — le personnage s'arrete a portee
 
 ### 4. Boucle implementation par sous-tache
 
+> **Lessons from #251 — Batching obligatoire pour eviter l'explosion de cycles Mode A**
+>
+> Avant de demarrer la boucle, evaluer la **granularite** du plan leaddev :
+>
+> - **Si le plan contient > 6 sous-taches pour une feature client-only sans nouveau systeme de gameplay (cosmetique, UI, drag-drop, fields ScriptableObject, scene wiring)** → REGROUPER en **3 a 5 LOTS** de **2 a 4 sous-taches** chacun. Un lot = un commit + UN SEUL run Mode A.
+> - **Default = batcher** les sous-taches qui touchent des fichiers disjoints ET qui ne dependent que de sous-taches deja landed. Sequencer 1-par-1 SEULEMENT quand la sous-tache N+1 depend du resultat runtime de N (rare pour les additions de fields/UI/SO).
+> - **Cap explicite** : max 1 cycle Mode A par lot ; vise **3 a 5 cycles total** pour une feature de moins de 500 LOC. Si tu prevois > 6 cycles Mode A, c'est un signal de sur-decoupage : reagrege.
+> - **Exemple lot acceptable** : "Lot 1 = ajout du field SO + extension Inspector custom + suppression du namespace deprecated dans 3 fichiers" → 1 commit, 1 Mode A. Pas 3 cycles.
+> - **DAG de dependances obligatoire** : avant de dispatcher la sous-tache N, faire un grep de chaque symbole/champ a supprimer ou retirer (`Grep <symbol> Assets/`). Si > 1 fichier consommateur ET ces fichiers ne sont pas tous deja nettoyes par des sous-taches precedentes → reordonner. Au depart de l'etape 4, lister explicitement le DAG (qui depend de qui). **Tout dispatch hors topo-order est interdit** — il provoque des compile errors et des rounds perdus.
+
 **Pour CHAQUE sous-tache du plan** (dans l'ordre), repeter :
 
 **4a. Implementer la sous-tache**


### PR DESCRIPTION
## Summary
Recovers content from closed PR #252 (branch was deleted pre-merge during #251 finalization). Targeted prompt patches preventing the slowness pattern observed during #251 (12 sub-tasks → 9 Mode A cycles, 7 brainstorm questions, over-aggressive `using` cleanup, sequencing dependencies mal lues).

Each new section in the touched prompts is tagged "Lessons from #251" for future audit.

- lead-roguelite — batching rule + DAG/topo-order check
- brainstorm-unity — 3-question cap + YAGNI default
- dev-unity + dev-ux-toolkit — using-directive cleanup checklist

## Test plan
- [ ] No code change → no Unity tests needed
- [ ] Next cosmetic feature should land in ≤ 5 Mode A cycles

Refs #251.