### PR TITLE
feat(skilltree): remove inter-hub paths + expose defaultMaxLevel (#258)

### DIFF
--- a/Assets/Data/SkillTreeData.asset
+++ b/Assets/Data/SkillTreeData.asset
@@ -19,82 +19,83 @@ MonoBehaviour:
   nodeColor: {r: 0.3, g: 0.3, b: 0.3, a: 1}
   borderNormalColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   borderSelectedColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
-  baseCost: 1
-  costMultiplierOdd: 5
-  costMultiplierEven: 1
+  baseCost: 5
+  costMultiplierOdd: 2
+  costMultiplierEven: 5
   costAdditivePerLevel: 0
+  defaultMaxLevel: 5
   edgeColor: {r: 0.6, g: 0.6, b: 0.6, a: 1}
   ringGuideColor: {r: 0.25, g: 0.25, b: 0.25, a: 0.5}
   edgeThickness: 4
   nodes:
   - id: 0
     position: {x: 8, y: 0}
-    connectedNodeIds:
+    connectedNodeIds: 
     costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 2
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 1
-    position: {x: 4, y: 6.9282036}
-    connectedNodeIds:
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 3
-    statModifierMode: 1
-    statModifierValuePerLevel: 5
-  - id: 2
-    position: {x: -4, y: 6.9282036}
-    connectedNodeIds:
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 4
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 3
-    position: {x: -8, y: 0}
-    connectedNodeIds:
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
-    costAdditivePerLevel: 0
-    statModifierType: 5
-    statModifierMode: 1
-    statModifierValuePerLevel: 0
-  - id: 4
-    position: {x: -4, y: -6.9282036}
-    connectedNodeIds:
-    costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
+    maxLevel: 5
+    baseCost: 5
+    costMultiplierOdd: 2
+    costMultiplierEven: 5
     costAdditivePerLevel: 0
     statModifierType: 0
     statModifierMode: 1
     statModifierValuePerLevel: 5
-  - id: 5
-    position: {x: 4, y: -6.9282036}
-    connectedNodeIds:
+  - id: 1
+    position: {x: 3.9999998, y: 6.9282036}
+    connectedNodeIds: 
     costType: 0
-    maxLevel: 0
-    baseCost: 1
-    costMultiplierOdd: 5
-    costMultiplierEven: 2
+    maxLevel: 5
+    baseCost: 5
+    costMultiplierOdd: 2
+    costMultiplierEven: 5
+    costAdditivePerLevel: 0
+    statModifierType: 2
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
+  - id: 2
+    position: {x: -4.0000005, y: 6.928203}
+    connectedNodeIds: 
+    costType: 0
+    maxLevel: 5
+    baseCost: 5
+    costMultiplierOdd: 2
+    costMultiplierEven: 5
+    costAdditivePerLevel: 0
+    statModifierType: 3
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
+  - id: 3
+    position: {x: -8, y: -0.0000006993822}
+    connectedNodeIds: 
+    costType: 0
+    maxLevel: 5
+    baseCost: 5
+    costMultiplierOdd: 2
+    costMultiplierEven: 5
+    costAdditivePerLevel: 0
+    statModifierType: 6
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
+  - id: 4
+    position: {x: -3.9999993, y: -6.9282036}
+    connectedNodeIds: 
+    costType: 0
+    maxLevel: 5
+    baseCost: 5
+    costMultiplierOdd: 2
+    costMultiplierEven: 5
+    costAdditivePerLevel: 0
+    statModifierType: 7
+    statModifierMode: 1
+    statModifierValuePerLevel: 5
+  - id: 5
+    position: {x: 3.9999993, y: -6.9282036}
+    connectedNodeIds: 
+    costType: 0
+    maxLevel: 5
+    baseCost: 5
+    costMultiplierOdd: 2
+    costMultiplierEven: 5
     costAdditivePerLevel: 0
     statModifierType: 1
     statModifierMode: 1

--- a/Assets/Data/SkillTreeData.asset
+++ b/Assets/Data/SkillTreeData.asset
@@ -23,26 +23,14 @@ MonoBehaviour:
   costMultiplierOdd: 2
   costMultiplierEven: 5
   costAdditivePerLevel: 0
-  defaultMaxLevel: 5
+  defaultGeneratedMaxLevel: 5
   edgeColor: {r: 0.6, g: 0.6, b: 0.6, a: 1}
   ringGuideColor: {r: 0.25, g: 0.25, b: 0.25, a: 0.5}
   edgeThickness: 4
   nodes:
   - id: 0
     position: {x: 8, y: 0}
-    connectedNodeIds: 
-    costType: 0
-    maxLevel: 5
-    baseCost: 5
-    costMultiplierOdd: 2
-    costMultiplierEven: 5
-    costAdditivePerLevel: 0
-    statModifierType: 0
-    statModifierMode: 1
-    statModifierValuePerLevel: 5
-  - id: 1
-    position: {x: 3.9999998, y: 6.9282036}
-    connectedNodeIds: 
+    connectedNodeIds:
     costType: 0
     maxLevel: 5
     baseCost: 5
@@ -51,10 +39,10 @@ MonoBehaviour:
     costAdditivePerLevel: 0
     statModifierType: 2
     statModifierMode: 1
-    statModifierValuePerLevel: 5
-  - id: 2
-    position: {x: -4.0000005, y: 6.928203}
-    connectedNodeIds: 
+    statModifierValuePerLevel: 0
+  - id: 1
+    position: {x: 4, y: 6.9282036}
+    connectedNodeIds:
     costType: 0
     maxLevel: 5
     baseCost: 5
@@ -64,33 +52,45 @@ MonoBehaviour:
     statModifierType: 3
     statModifierMode: 1
     statModifierValuePerLevel: 5
-  - id: 3
-    position: {x: -8, y: -0.0000006993822}
-    connectedNodeIds: 
+  - id: 2
+    position: {x: -4, y: 6.9282036}
+    connectedNodeIds:
     costType: 0
     maxLevel: 5
     baseCost: 5
     costMultiplierOdd: 2
     costMultiplierEven: 5
     costAdditivePerLevel: 0
-    statModifierType: 6
+    statModifierType: 4
     statModifierMode: 1
-    statModifierValuePerLevel: 5
-  - id: 4
-    position: {x: -3.9999993, y: -6.9282036}
-    connectedNodeIds: 
+    statModifierValuePerLevel: 0
+  - id: 3
+    position: {x: -8, y: 0}
+    connectedNodeIds:
     costType: 0
     maxLevel: 5
     baseCost: 5
     costMultiplierOdd: 2
     costMultiplierEven: 5
     costAdditivePerLevel: 0
-    statModifierType: 7
+    statModifierType: 5
+    statModifierMode: 1
+    statModifierValuePerLevel: 0
+  - id: 4
+    position: {x: -4, y: -6.9282036}
+    connectedNodeIds:
+    costType: 0
+    maxLevel: 5
+    baseCost: 5
+    costMultiplierOdd: 2
+    costMultiplierEven: 5
+    costAdditivePerLevel: 0
+    statModifierType: 0
     statModifierMode: 1
     statModifierValuePerLevel: 5
   - id: 5
-    position: {x: 3.9999993, y: -6.9282036}
-    connectedNodeIds: 
+    position: {x: 4, y: -6.9282036}
+    connectedNodeIds:
     costType: 0
     maxLevel: 5
     baseCost: 5

--- a/Assets/Data/SkillTreeData.asset
+++ b/Assets/Data/SkillTreeData.asset
@@ -29,7 +29,7 @@ MonoBehaviour:
   nodes:
   - id: 0
     position: {x: 8, y: 0}
-    connectedNodeIds: 01000000
+    connectedNodeIds:
     costType: 0
     maxLevel: 0
     baseCost: 1
@@ -41,7 +41,7 @@ MonoBehaviour:
     statModifierValuePerLevel: 0
   - id: 1
     position: {x: 4, y: 6.9282036}
-    connectedNodeIds: 02000000
+    connectedNodeIds:
     costType: 0
     maxLevel: 0
     baseCost: 1
@@ -53,7 +53,7 @@ MonoBehaviour:
     statModifierValuePerLevel: 5
   - id: 2
     position: {x: -4, y: 6.9282036}
-    connectedNodeIds: 03000000
+    connectedNodeIds:
     costType: 0
     maxLevel: 0
     baseCost: 1
@@ -65,7 +65,7 @@ MonoBehaviour:
     statModifierValuePerLevel: 0
   - id: 3
     position: {x: -8, y: 0}
-    connectedNodeIds: 04000000
+    connectedNodeIds:
     costType: 0
     maxLevel: 0
     baseCost: 1
@@ -77,7 +77,7 @@ MonoBehaviour:
     statModifierValuePerLevel: 0
   - id: 4
     position: {x: -4, y: -6.9282036}
-    connectedNodeIds: 05000000
+    connectedNodeIds:
     costType: 0
     maxLevel: 0
     baseCost: 1
@@ -89,7 +89,7 @@ MonoBehaviour:
     statModifierValuePerLevel: 5
   - id: 5
     position: {x: 4, y: -6.9282036}
-    connectedNodeIds: 00000000
+    connectedNodeIds:
     costType: 0
     maxLevel: 0
     baseCost: 1

--- a/Assets/Scripts/Data/SkillTreeData.cs
+++ b/Assets/Scripts/Data/SkillTreeData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using RogueliteAutoBattler.Combat.Core;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace RogueliteAutoBattler.Data
 {
@@ -77,7 +78,8 @@ namespace RogueliteAutoBattler.Data
         [SerializeField] private float costMultiplierOdd = 1f;
         [SerializeField] private float costMultiplierEven = 1f;
         [SerializeField] private int costAdditivePerLevel = 0;
-        [SerializeField] private int defaultMaxLevel = DefaultMaxLevel;
+        [FormerlySerializedAs("defaultMaxLevel")]
+        [SerializeField] private int defaultGeneratedMaxLevel = DefaultMaxLevel;
 
         [Header("Edge Visual")]
         [SerializeField] private Color edgeColor = DefaultEdgeColor;
@@ -105,7 +107,8 @@ namespace RogueliteAutoBattler.Data
         public float CostMultiplierOdd { get => costMultiplierOdd; internal set => costMultiplierOdd = value; }
         public float CostMultiplierEven { get => costMultiplierEven; internal set => costMultiplierEven = value; }
         public int CostAdditivePerLevel { get => costAdditivePerLevel; internal set => costAdditivePerLevel = value; }
-        public int DefaultGeneratedMaxLevel { get => defaultMaxLevel; internal set => defaultMaxLevel = value; }
+        // Verbose to disambiguate from the public const DefaultMaxLevel (parameter fallback).
+        public int DefaultGeneratedMaxLevel { get => defaultGeneratedMaxLevel; internal set => defaultGeneratedMaxLevel = value; }
         public Color EdgeColor { get => edgeColor; internal set => edgeColor = value; }
         public Color RingGuideColor { get => ringGuideColor; internal set => ringGuideColor = value; }
         public float EdgeThickness { get => edgeThickness; internal set => edgeThickness = value; }
@@ -115,11 +118,11 @@ namespace RogueliteAutoBattler.Data
         {
             nodes.Clear();
             _cachedEdges = null;
-            BuildRingLayout(nodes, ringNodeCount, ringRadius, baseCost, costMultiplierOdd, costMultiplierEven, costAdditivePerLevel, defaultMaxLevel);
+            BuildRingLayout(nodes, ringNodeCount, ringRadius, baseCost, costMultiplierOdd, costMultiplierEven, costAdditivePerLevel, defaultGeneratedMaxLevel);
         }
 
         internal static void BuildRingLayout(List<SkillNodeEntry> output, int nodeCount, float radius,
-            int defaultBaseCost = 1, float defaultMultOdd = 1f, float defaultMultEven = 1f, int defaultAdditive = 0, int defaultMaxLevel = DefaultMaxLevel)
+            int defaultBaseCost = 1, float defaultMultOdd = 1f, float defaultMultEven = 1f, int defaultAdditive = 0, int defaultGeneratedMaxLevel = DefaultMaxLevel)
         {
             Debug.Assert(nodeCount > 0, "Ring node count must be positive");
 
@@ -135,7 +138,7 @@ namespace RogueliteAutoBattler.Data
                     position = pos,
                     connectedNodeIds = new List<int>(),
                     costType = CostType.Gold,
-                    maxLevel = defaultMaxLevel,
+                    maxLevel = defaultGeneratedMaxLevel,
                     baseCost = defaultBaseCost,
                     costMultiplierOdd = defaultMultOdd,
                     costMultiplierEven = defaultMultEven,

--- a/Assets/Scripts/Data/SkillTreeData.cs
+++ b/Assets/Scripts/Data/SkillTreeData.cs
@@ -77,6 +77,7 @@ namespace RogueliteAutoBattler.Data
         [SerializeField] private float costMultiplierOdd = 1f;
         [SerializeField] private float costMultiplierEven = 1f;
         [SerializeField] private int costAdditivePerLevel = 0;
+        [SerializeField] private int defaultMaxLevel = DefaultMaxLevel;
 
         [Header("Edge Visual")]
         [SerializeField] private Color edgeColor = DefaultEdgeColor;
@@ -104,6 +105,7 @@ namespace RogueliteAutoBattler.Data
         public float CostMultiplierOdd { get => costMultiplierOdd; internal set => costMultiplierOdd = value; }
         public float CostMultiplierEven { get => costMultiplierEven; internal set => costMultiplierEven = value; }
         public int CostAdditivePerLevel { get => costAdditivePerLevel; internal set => costAdditivePerLevel = value; }
+        public int DefaultGeneratedMaxLevel { get => defaultMaxLevel; internal set => defaultMaxLevel = value; }
         public Color EdgeColor { get => edgeColor; internal set => edgeColor = value; }
         public Color RingGuideColor { get => ringGuideColor; internal set => ringGuideColor = value; }
         public float EdgeThickness { get => edgeThickness; internal set => edgeThickness = value; }
@@ -113,11 +115,11 @@ namespace RogueliteAutoBattler.Data
         {
             nodes.Clear();
             _cachedEdges = null;
-            BuildRingLayout(nodes, ringNodeCount, ringRadius, baseCost, costMultiplierOdd, costMultiplierEven, costAdditivePerLevel);
+            BuildRingLayout(nodes, ringNodeCount, ringRadius, baseCost, costMultiplierOdd, costMultiplierEven, costAdditivePerLevel, defaultMaxLevel);
         }
 
         internal static void BuildRingLayout(List<SkillNodeEntry> output, int nodeCount, float radius,
-            int defaultBaseCost = 1, float defaultMultOdd = 1f, float defaultMultEven = 1f, int defaultAdditive = 0)
+            int defaultBaseCost = 1, float defaultMultOdd = 1f, float defaultMultEven = 1f, int defaultAdditive = 0, int defaultMaxLevel = DefaultMaxLevel)
         {
             Debug.Assert(nodeCount > 0, "Ring node count must be positive");
 
@@ -133,7 +135,7 @@ namespace RogueliteAutoBattler.Data
                     position = pos,
                     connectedNodeIds = new List<int>(),
                     costType = CostType.Gold,
-                    maxLevel = DefaultMaxLevel,
+                    maxLevel = defaultMaxLevel,
                     baseCost = defaultBaseCost,
                     costMultiplierOdd = defaultMultOdd,
                     costMultiplierEven = defaultMultEven,

--- a/Assets/Scripts/Data/SkillTreeData.cs
+++ b/Assets/Scripts/Data/SkillTreeData.cs
@@ -107,7 +107,6 @@ namespace RogueliteAutoBattler.Data
         public float CostMultiplierOdd { get => costMultiplierOdd; internal set => costMultiplierOdd = value; }
         public float CostMultiplierEven { get => costMultiplierEven; internal set => costMultiplierEven = value; }
         public int CostAdditivePerLevel { get => costAdditivePerLevel; internal set => costAdditivePerLevel = value; }
-        // Verbose to disambiguate from the public const DefaultMaxLevel (parameter fallback).
         public int DefaultGeneratedMaxLevel { get => defaultGeneratedMaxLevel; internal set => defaultGeneratedMaxLevel = value; }
         public Color EdgeColor { get => edgeColor; internal set => edgeColor = value; }
         public Color RingGuideColor { get => ringGuideColor; internal set => ringGuideColor = value; }

--- a/Assets/Scripts/Data/SkillTreeData.cs
+++ b/Assets/Scripts/Data/SkillTreeData.cs
@@ -131,7 +131,7 @@ namespace RogueliteAutoBattler.Data
                 {
                     id = i,
                     position = pos,
-                    connectedNodeIds = new List<int> { (i + 1) % nodeCount },
+                    connectedNodeIds = new List<int>(),
                     costType = CostType.Gold,
                     maxLevel = DefaultMaxLevel,
                     baseCost = defaultBaseCost,

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -31,6 +31,7 @@ namespace RogueliteAutoBattler.Editor.Windows
         private static readonly GUIContent LabelCostMultiplierOdd = new GUIContent("Multiplier (Odd Levels)");
         private static readonly GUIContent LabelCostMultiplierEven = new GUIContent("Multiplier (Even Levels)");
         private static readonly GUIContent LabelCostAdditive = new GUIContent("Additive / Level");
+        private static readonly GUIContent LabelDefaultMaxLevel = new GUIContent("Default Max Level (0 = unlimited)");
         private static readonly GUIContent LabelEdgeColor = new GUIContent("Edge Color");
         private static readonly GUIContent LabelRingGuideColor = new GUIContent("Ring Guide Color");
         private static readonly GUIContent LabelEdgeThickness = new GUIContent("Edge Thickness");
@@ -48,6 +49,7 @@ namespace RogueliteAutoBattler.Editor.Windows
         private SerializedProperty _propCostMultiplierOdd;
         private SerializedProperty _propCostMultiplierEven;
         private SerializedProperty _propCostAdditivePerLevel;
+        private SerializedProperty _propDefaultMaxLevel;
         private SerializedProperty _propEdgeColor;
         private SerializedProperty _propRingGuideColor;
         private SerializedProperty _propEdgeThickness;
@@ -96,6 +98,7 @@ namespace RogueliteAutoBattler.Editor.Windows
             _propCostMultiplierOdd = _serializedData.FindProperty("costMultiplierOdd");
             _propCostMultiplierEven = _serializedData.FindProperty("costMultiplierEven");
             _propCostAdditivePerLevel = _serializedData.FindProperty("costAdditivePerLevel");
+            _propDefaultMaxLevel = _serializedData.FindProperty("defaultMaxLevel");
             _propEdgeColor = _serializedData.FindProperty("edgeColor");
             _propRingGuideColor = _serializedData.FindProperty("ringGuideColor");
             _propEdgeThickness = _serializedData.FindProperty("edgeThickness");
@@ -293,6 +296,7 @@ namespace RogueliteAutoBattler.Editor.Windows
             EditorGUILayout.PropertyField(_propCostMultiplierOdd, LabelCostMultiplierOdd);
             EditorGUILayout.PropertyField(_propCostMultiplierEven, LabelCostMultiplierEven);
             EditorGUILayout.PropertyField(_propCostAdditivePerLevel, LabelCostAdditive);
+            EditorGUILayout.PropertyField(_propDefaultMaxLevel, LabelDefaultMaxLevel);
 
             EditorGUILayout.Space(12);
             EditorGUILayout.LabelField("Edge Settings", EditorStyles.boldLabel);

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -31,7 +31,7 @@ namespace RogueliteAutoBattler.Editor.Windows
         private static readonly GUIContent LabelCostMultiplierOdd = new GUIContent("Multiplier (Odd Levels)");
         private static readonly GUIContent LabelCostMultiplierEven = new GUIContent("Multiplier (Even Levels)");
         private static readonly GUIContent LabelCostAdditive = new GUIContent("Additive / Level");
-        private static readonly GUIContent LabelDefaultMaxLevel = new GUIContent("Default Max Level (0 = unlimited)");
+        private static readonly GUIContent LabelDefaultGeneratedMaxLevel = new GUIContent("Default Max Level (0 = unlimited)");
         private static readonly GUIContent LabelEdgeColor = new GUIContent("Edge Color");
         private static readonly GUIContent LabelRingGuideColor = new GUIContent("Ring Guide Color");
         private static readonly GUIContent LabelEdgeThickness = new GUIContent("Edge Thickness");
@@ -49,7 +49,7 @@ namespace RogueliteAutoBattler.Editor.Windows
         private SerializedProperty _propCostMultiplierOdd;
         private SerializedProperty _propCostMultiplierEven;
         private SerializedProperty _propCostAdditivePerLevel;
-        private SerializedProperty _propDefaultMaxLevel;
+        private SerializedProperty _propDefaultGeneratedMaxLevel;
         private SerializedProperty _propEdgeColor;
         private SerializedProperty _propRingGuideColor;
         private SerializedProperty _propEdgeThickness;
@@ -98,7 +98,7 @@ namespace RogueliteAutoBattler.Editor.Windows
             _propCostMultiplierOdd = _serializedData.FindProperty("costMultiplierOdd");
             _propCostMultiplierEven = _serializedData.FindProperty("costMultiplierEven");
             _propCostAdditivePerLevel = _serializedData.FindProperty("costAdditivePerLevel");
-            _propDefaultMaxLevel = _serializedData.FindProperty("defaultGeneratedMaxLevel");
+            _propDefaultGeneratedMaxLevel = _serializedData.FindProperty("defaultGeneratedMaxLevel");
             _propEdgeColor = _serializedData.FindProperty("edgeColor");
             _propRingGuideColor = _serializedData.FindProperty("ringGuideColor");
             _propEdgeThickness = _serializedData.FindProperty("edgeThickness");
@@ -296,7 +296,7 @@ namespace RogueliteAutoBattler.Editor.Windows
             EditorGUILayout.PropertyField(_propCostMultiplierOdd, LabelCostMultiplierOdd);
             EditorGUILayout.PropertyField(_propCostMultiplierEven, LabelCostMultiplierEven);
             EditorGUILayout.PropertyField(_propCostAdditivePerLevel, LabelCostAdditive);
-            EditorGUILayout.PropertyField(_propDefaultMaxLevel, LabelDefaultMaxLevel);
+            EditorGUILayout.PropertyField(_propDefaultGeneratedMaxLevel, LabelDefaultGeneratedMaxLevel);
 
             EditorGUILayout.Space(12);
             EditorGUILayout.LabelField("Edge Settings", EditorStyles.boldLabel);

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -98,7 +98,7 @@ namespace RogueliteAutoBattler.Editor.Windows
             _propCostMultiplierOdd = _serializedData.FindProperty("costMultiplierOdd");
             _propCostMultiplierEven = _serializedData.FindProperty("costMultiplierEven");
             _propCostAdditivePerLevel = _serializedData.FindProperty("costAdditivePerLevel");
-            _propDefaultMaxLevel = _serializedData.FindProperty("defaultMaxLevel");
+            _propDefaultMaxLevel = _serializedData.FindProperty("defaultGeneratedMaxLevel");
             _propEdgeColor = _serializedData.FindProperty("edgeColor");
             _propRingGuideColor = _serializedData.FindProperty("ringGuideColor");
             _propEdgeThickness = _serializedData.FindProperty("edgeThickness");

--- a/Assets/Tests/EditMode/SkillTreeDataTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeDataTests.cs
@@ -153,7 +153,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
         }
 
         [Test]
-        public void GenerateNodes_EachNodeHasConnectedNodeIds()
+        public void GenerateNodes_EachNodeHasEmptyConnectedNodeIds()
         {
             _skillTreeData.RingNodeCount = 6;
             _skillTreeData.GenerateNodes();
@@ -161,48 +161,20 @@ namespace RogueliteAutoBattler.Tests.EditMode
             for (int i = 0; i < _skillTreeData.Nodes.Count; i++)
             {
                 Assert.IsNotNull(_skillTreeData.Nodes[i].connectedNodeIds,
-                    $"Node {i} should have connectedNodeIds");
-                Assert.AreEqual(1, _skillTreeData.Nodes[i].connectedNodeIds.Count,
-                    $"Node {i} should connect to exactly 1 neighbor");
+                    $"Node {i} should have empty connectedNodeIds (hubs are roots, no chain)");
+                Assert.AreEqual(0, _skillTreeData.Nodes[i].connectedNodeIds.Count,
+                    $"Node {i} should have empty connectedNodeIds (hubs are roots, no chain)");
             }
         }
 
         [Test]
-        public void GenerateNodes_ConnectionsFormClosedRing()
-        {
-            _skillTreeData.RingNodeCount = 6;
-            _skillTreeData.GenerateNodes();
-
-            for (int i = 0; i < 6; i++)
-            {
-                int expectedNext = (i + 1) % 6;
-                Assert.AreEqual(expectedNext, _skillTreeData.Nodes[i].connectedNodeIds[0],
-                    $"Node {i} should connect to node {expectedNext}");
-            }
-        }
-
-        [Test]
-        public void GenerateNodes_MinRingCount_ConnectionsFormClosedRing()
-        {
-            _skillTreeData.RingNodeCount = 3;
-            _skillTreeData.GenerateNodes();
-
-            for (int i = 0; i < 3; i++)
-            {
-                int expectedNext = (i + 1) % 3;
-                Assert.AreEqual(expectedNext, _skillTreeData.Nodes[i].connectedNodeIds[0],
-                    $"Node {i} should connect to node {expectedNext}");
-            }
-        }
-
-        [Test]
-        public void GetEdges_ReturnsCorrectCount()
+        public void GetEdges_ReturnsZeroForHubsWithoutConnections()
         {
             _skillTreeData.RingNodeCount = 6;
             _skillTreeData.GenerateNodes();
 
             var edges = _skillTreeData.GetEdges();
-            Assert.AreEqual(6, edges.Length);
+            Assert.AreEqual(0, edges.Length);
         }
 
         [Test]
@@ -225,10 +197,11 @@ namespace RogueliteAutoBattler.Tests.EditMode
             _skillTreeData.RingNodeCount = 3;
             _skillTreeData.GenerateNodes();
 
-            Assert.AreEqual(3, _skillTreeData.GetEdges().Length);
+            Assert.AreEqual(0, _skillTreeData.GetEdges().Length);
             for (int i = 0; i < 3; i++)
             {
-                Assert.AreEqual(1, _skillTreeData.Nodes[i].connectedNodeIds.Count);
+                Assert.IsNotNull(_skillTreeData.Nodes[i].connectedNodeIds);
+                Assert.AreEqual(0, _skillTreeData.Nodes[i].connectedNodeIds.Count);
             }
         }
 

--- a/Assets/Tests/EditMode/SkillTreeDataTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeDataTests.cs
@@ -254,6 +254,40 @@ namespace RogueliteAutoBattler.Tests.EditMode
         }
 
         [Test]
+        public void GenerateNodes_RespectsDefaultMaxLevelField()
+        {
+            _skillTreeData.RingNodeCount = 6;
+            _skillTreeData.DefaultGeneratedMaxLevel = 7;
+
+            _skillTreeData.GenerateNodes();
+
+            Assert.AreEqual(6, _skillTreeData.Nodes.Count);
+            for (int i = 0; i < _skillTreeData.Nodes.Count; i++)
+            {
+                Assert.AreEqual(7, _skillTreeData.Nodes[i].maxLevel,
+                    $"Node {i} maxLevel should match the configured DefaultGeneratedMaxLevel");
+            }
+        }
+
+        [Test]
+        public void GenerateNodes_DefaultMaxLevelZero_AllowsUnlimitedNodes()
+        {
+            _skillTreeData.RingNodeCount = 6;
+            _skillTreeData.DefaultGeneratedMaxLevel = 0;
+
+            _skillTreeData.GenerateNodes();
+
+            for (int i = 0; i < _skillTreeData.Nodes.Count; i++)
+            {
+                var node = _skillTreeData.Nodes[i];
+                Assert.AreEqual(0, node.maxLevel,
+                    $"Node {i} maxLevel should propagate the unlimited (0) default");
+                Assert.IsFalse(SkillTreeData.IsMaxLevel(node, 999),
+                    $"Node {i} with maxLevel=0 should never be considered maxed");
+            }
+        }
+
+        [Test]
         public void HitTestNode_ReturnsCorrectIndex()
         {
             _skillTreeData.RingNodeCount = 4;

--- a/Assets/Tests/EditMode/SkillTreeDataTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeDataTests.cs
@@ -161,9 +161,9 @@ namespace RogueliteAutoBattler.Tests.EditMode
             for (int i = 0; i < _skillTreeData.Nodes.Count; i++)
             {
                 Assert.IsNotNull(_skillTreeData.Nodes[i].connectedNodeIds,
-                    $"Node {i} should have empty connectedNodeIds (hubs are roots, no chain)");
+                    $"Node {i} connectedNodeIds should not be null");
                 Assert.AreEqual(0, _skillTreeData.Nodes[i].connectedNodeIds.Count,
-                    $"Node {i} should have empty connectedNodeIds (hubs are roots, no chain)");
+                    $"Node {i} connectedNodeIds should be empty");
             }
         }
 
@@ -178,18 +178,28 @@ namespace RogueliteAutoBattler.Tests.EditMode
         }
 
         [Test]
-        public void GetEdges_NoDuplicateEdges()
+        public void GetEdges_FlattensConnectedNodeIdsIntoUniquePairs()
         {
-            _skillTreeData.RingNodeCount = 6;
-            _skillTreeData.GenerateNodes();
+            var nodesWithConnections = new List<SkillTreeData.SkillNodeEntry>
+            {
+                new SkillTreeData.SkillNodeEntry { id = 0, connectedNodeIds = new List<int> { 1, 2 } },
+                new SkillTreeData.SkillNodeEntry { id = 1, connectedNodeIds = new List<int> { 2 } },
+                new SkillTreeData.SkillNodeEntry { id = 2, connectedNodeIds = new List<int>() }
+            };
+            _skillTreeData.InitializeForTest(nodesWithConnections);
 
             var edges = _skillTreeData.GetEdges();
             var uniqueEdges = new HashSet<(int, int)>(edges);
+
+            Assert.AreEqual(3, edges.Length);
             Assert.AreEqual(edges.Length, uniqueEdges.Count, "All edges should be unique");
+            CollectionAssert.Contains(edges, (0, 1));
+            CollectionAssert.Contains(edges, (0, 2));
+            CollectionAssert.Contains(edges, (1, 2));
         }
 
         [Test]
-        public void GenerateNodes_ClearsExistingConnections()
+        public void GenerateNodes_RegeneratedNodesHaveNoEdges()
         {
             _skillTreeData.RingNodeCount = 5;
             _skillTreeData.GenerateNodes();


### PR DESCRIPTION
Closes #258

## Summary
- Removed unlock paths between the 6 main ring hubs to simplify progression
- Exposed `defaultMaxLevel` in skill tree generator for better tuning
- Updated cost defaults and legacy stats alignment
- Strengthened edge-layer tests and renamed symbols for clarity

## Commits
- dd1219d feat(skilltree): remove unlock paths between the 6 ring hubs
- 685e01e refactor(skilltree): strengthen GetEdges test, rename for clarity
- 40b4e4d feat(skilltree): expose defaultMaxLevel + new cost defaults in generator
- 9249145 refactor(skilltree): rename defaultGeneratedMaxLevel + revert legacy stats
- bb08a14 refactor(skilltree): align Editor symbol names + drop redundant comment