### PR TITLE
feat(skilltree-editor): mirror construction mode (#281)

### DIFF
--- a/Assets/Data/SkillTrees/Default.asset
+++ b/Assets/Data/SkillTrees/Default.asset
@@ -28,13 +28,74 @@ MonoBehaviour:
   nodes:
   - id: 0
     position: {x: 0, y: 0}
-    connectedNodeIds: []
+    connectedNodeIds: 0100000002000000
     costType: 0
     maxLevel: 1
     baseCost: 100
     costMultiplierOdd: 1
     costMultiplierEven: 1
     costAdditivePerLevel: 0
-    statModifierType: 0
+    statModifierType: 8
     statModifierMode: 0
     statModifierValuePerLevel: 0
+  - id: 1
+    position: {x: 1.5000002, y: -2.598076}
+    connectedNodeIds: 05000000
+    costType: 1
+    maxLevel: 1
+    baseCost: 1
+    costMultiplierOdd: 1
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 0
+    statModifierMode: 0
+    statModifierValuePerLevel: 5
+  - id: 2
+    position: {x: -1.4999999, y: -2.598076}
+    connectedNodeIds: 0300000004000000
+    costType: 1
+    maxLevel: 1
+    baseCost: 1
+    costMultiplierOdd: 1
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 0
+    statModifierMode: 0
+    statModifierValuePerLevel: 5
+  - id: 3
+    position: {x: -2.9999998, y: -5.196152}
+    connectedNodeIds: 
+    costType: 1
+    maxLevel: 1
+    baseCost: 1
+    costMultiplierOdd: 1
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 0
+    statModifierMode: 0
+    statModifierValuePerLevel: 5
+  - id: 4
+    position: {x: 0.00000035762787, y: -5.196152}
+    connectedNodeIds: 
+    costType: 1
+    maxLevel: 1
+    baseCost: 1
+    costMultiplierOdd: 1
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 0
+    statModifierMode: 0
+    statModifierValuePerLevel: 5
+  - id: 5
+    position: {x: 3.0000005, y: -5.196152}
+    connectedNodeIds: 
+    costType: 1
+    maxLevel: 1
+    baseCost: 1
+    costMultiplierOdd: 1
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 0
+    statModifierMode: 0
+    statModifierValuePerLevel: 5
+  assetGuid: 63a2645100f4ff4428d968c9feeb46f4

--- a/Assets/Data/SkillTrees/NewSkillTree.asset
+++ b/Assets/Data/SkillTrees/NewSkillTree.asset
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9568085fa8c1a7f43962fb27b9ab0163, type: 3}
+  m_Name: NewSkillTree
+  m_EditorClassIdentifier: RogueliteAutoBattler.Runtime::RogueliteAutoBattler.Data.SkillTreeData
+  unitSize: 40
+  nodeSize: 48
+  nodeColor: {r: 0.3, g: 0.3, b: 0.3, a: 1}
+  borderNormalColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  borderSelectedColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  baseCost: 1
+  costMultiplierOdd: 1
+  costMultiplierEven: 1
+  costAdditivePerLevel: 0
+  defaultGeneratedMaxLevel: 5
+  edgeColor: {r: 0.6, g: 0.6, b: 0.6, a: 1}
+  edgeThickness: 4
+  centralUnlockCost: 100
+  nodes:
+  - id: 0
+    position: {x: 0, y: 0}
+    connectedNodeIds: 
+    costType: 0
+    maxLevel: 1
+    baseCost: 100
+    costMultiplierOdd: 1
+    costMultiplierEven: 1
+    costAdditivePerLevel: 0
+    statModifierType: 8
+    statModifierMode: 0
+    statModifierValuePerLevel: 0
+  assetGuid: 

--- a/Assets/Data/SkillTrees/NewSkillTree.asset.meta
+++ b/Assets/Data/SkillTrees/NewSkillTree.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 981c5e607a63a2647acc400c7b7f34cd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/Tools/BranchPlacement.cs
+++ b/Assets/Scripts/Editor/Tools/BranchPlacement.cs
@@ -8,6 +8,8 @@ namespace RogueliteAutoBattler.Editor.Tools
         private const float FullCircleDegrees = 360f;
         private const float DefaultAngleForOriginParent = 0f;
 
+        public const float PositionTolerance = 1f;
+
         public static Vector2 ComputeBranchPosition(Vector2 parentPosition, float distance)
         {
             Vector2 direction = parentPosition.sqrMagnitude < DegenerateMagnitudeThreshold
@@ -22,9 +24,14 @@ namespace RogueliteAutoBattler.Editor.Tools
         /// </summary>
         public static Vector2 ComputeBranchPosition(Vector2 parentPosition, float distance, float clockwiseFromNorthDegrees)
         {
-            float radians = clockwiseFromNorthDegrees * Mathf.Deg2Rad;
-            Vector2 direction = new Vector2(Mathf.Sin(radians), Mathf.Cos(radians));
+            Vector2 direction = DirectionFromClockwiseNorthDegrees(clockwiseFromNorthDegrees);
             return parentPosition + direction * distance;
+        }
+
+        internal static Vector2 DirectionFromClockwiseNorthDegrees(float clockwiseFromNorthDegrees)
+        {
+            float radians = clockwiseFromNorthDegrees * Mathf.Deg2Rad;
+            return new Vector2(Mathf.Sin(radians), Mathf.Cos(radians));
         }
 
         /// <summary>
@@ -38,7 +45,23 @@ namespace RogueliteAutoBattler.Editor.Tools
                 return DefaultAngleForOriginParent;
 
             float clockwiseFromNorthDegrees = Mathf.Atan2(parentPosition.x, parentPosition.y) * Mathf.Rad2Deg;
-            return (clockwiseFromNorthDegrees % FullCircleDegrees + FullCircleDegrees) % FullCircleDegrees;
+            return NormalizeDegrees(clockwiseFromNorthDegrees);
+        }
+
+        /// <summary>
+        /// Reflect <paramref name="angleDegrees"/> across the axis line defined by
+        /// <paramref name="axisAngleDegrees"/>. Angles use the clockwise-from-north convention
+        /// (0 = north, 90 = east, 180 = south, 270 = west). Formula:
+        /// normalize(2 * normalize(axis) - normalize(angle)). Result is normalized to [0, 360).
+        /// </summary>
+        public static float MirrorAngle(float angleDegrees, float axisAngleDegrees)
+        {
+            return NormalizeDegrees(2f * NormalizeDegrees(axisAngleDegrees) - NormalizeDegrees(angleDegrees));
+        }
+
+        private static float NormalizeDegrees(float angleDegrees)
+        {
+            return (angleDegrees % FullCircleDegrees + FullCircleDegrees) % FullCircleDegrees;
         }
     }
 }

--- a/Assets/Scripts/Editor/Tools/BranchPreviewSettings.cs
+++ b/Assets/Scripts/Editor/Tools/BranchPreviewSettings.cs
@@ -4,14 +4,20 @@ namespace RogueliteAutoBattler.Editor.Tools
     {
         private const float DefaultDistanceUnits = 3f;
         private const float DefaultAngleDegrees = 0f;
+        private const bool DefaultMirrorEnabled = false;
+        private const float DefaultMirrorAxisDegrees = 0f;
 
         public float distance;
         public float angleDegrees;
+        public bool mirrorEnabled;
+        public float mirrorAxisDegrees;
 
         internal static readonly BranchPreviewSettings Defaults = new BranchPreviewSettings
         {
             distance = DefaultDistanceUnits,
-            angleDegrees = DefaultAngleDegrees
+            angleDegrees = DefaultAngleDegrees,
+            mirrorEnabled = DefaultMirrorEnabled,
+            mirrorAxisDegrees = DefaultMirrorAxisDegrees
         };
     }
 }

--- a/Assets/Scripts/Editor/Tools/MirrorAxisGeometry.cs
+++ b/Assets/Scripts/Editor/Tools/MirrorAxisGeometry.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Editor.Tools
+{
+    internal static class MirrorAxisGeometry
+    {
+        public static void ComputeAxisEndpoints(
+            Vector2 origin,
+            float axisAngleDegrees,
+            float halfSpan,
+            out Vector2 start,
+            out Vector2 end)
+        {
+            Vector2 axisDir = BranchPlacement.DirectionFromClockwiseNorthDegrees(axisAngleDegrees);
+            start = origin - axisDir * halfSpan;
+            end = origin + axisDir * halfSpan;
+        }
+    }
+}

--- a/Assets/Scripts/Editor/Tools/MirrorAxisGeometry.cs.meta
+++ b/Assets/Scripts/Editor/Tools/MirrorAxisGeometry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f3415f821668bd64b8f1a4abca3c3921

--- a/Assets/Scripts/Editor/Tools/MirrorAxisPersistence.cs
+++ b/Assets/Scripts/Editor/Tools/MirrorAxisPersistence.cs
@@ -1,0 +1,25 @@
+using UnityEditor;
+
+namespace RogueliteAutoBattler.Editor.Tools
+{
+    internal static class MirrorAxisPersistence
+    {
+        internal const string EditorPrefKey = "SkillTreeDesigner.MirrorAxisDegrees";
+        private const float MirrorAxisDegreesDefault = 0f;
+
+        public static float Load()
+        {
+            return EditorPrefs.GetFloat(EditorPrefKey, MirrorAxisDegreesDefault);
+        }
+
+        public static void Save(float value)
+        {
+            EditorPrefs.SetFloat(EditorPrefKey, value);
+        }
+
+        public static void ApplyTo(ref BranchPreviewSettings settings)
+        {
+            settings.mirrorAxisDegrees = Load();
+        }
+    }
+}

--- a/Assets/Scripts/Editor/Tools/MirrorAxisPersistence.cs.meta
+++ b/Assets/Scripts/Editor/Tools/MirrorAxisPersistence.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f97e45cddc142dd4fa62429bc2d21448

--- a/Assets/Scripts/Editor/Tools/MirrorPairGenerator.cs
+++ b/Assets/Scripts/Editor/Tools/MirrorPairGenerator.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Globalization;
+using RogueliteAutoBattler.Data;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Editor.Tools
+{
+    internal static class MirrorPairGenerator
+    {
+        internal const string UndoLabelSingleNode = "Create Branch Node";
+        internal const string UndoLabelMirroredPair = "Create Branch Node Pair (Mirrored)";
+        internal const string MirrorSkippedWarningFormat = "Mirror skipped: a node already exists within {0} units of the reflected position.";
+
+        private const string ErrorDataNull = "Skill tree data is null.";
+        private const string ErrorInvalidParentIndex = "Invalid parent index.";
+
+        internal readonly struct MirrorPairResult
+        {
+            public readonly bool OriginalCreated;
+            public readonly bool MirrorCreated;
+            public readonly string WarningMessage;
+            public readonly int OriginalNewId;
+            public readonly int MirrorNewId;
+
+            private MirrorPairResult(bool original, bool mirror, string warning, int originalId, int mirrorId)
+            {
+                OriginalCreated = original;
+                MirrorCreated = mirror;
+                WarningMessage = warning;
+                OriginalNewId = originalId;
+                MirrorNewId = mirrorId;
+            }
+
+            internal static MirrorPairResult Invalid(string errorReason) => new MirrorPairResult(false, false, errorReason, -1, -1);
+            internal static MirrorPairResult OriginalOnly(int originalId) => new MirrorPairResult(true, false, null, originalId, -1);
+            internal static MirrorPairResult OriginalOnlyWithWarning(int originalId, string warning) => new MirrorPairResult(true, false, warning, originalId, -1);
+            internal static MirrorPairResult Pair(int originalNodeId, int mirrorNodeId) => new MirrorPairResult(true, true, null, originalNodeId, mirrorNodeId);
+        }
+
+        public static MirrorPairResult TryGenerate(SkillTreeData data, int parentIndex, BranchPreviewSettings settings)
+        {
+            if (data == null)
+                return MirrorPairResult.Invalid(ErrorDataNull);
+
+            if (parentIndex < 0 || parentIndex >= data.Nodes.Count)
+                return MirrorPairResult.Invalid(ErrorInvalidParentIndex);
+
+            var parentEntry = data.Nodes[parentIndex];
+            Vector2 parentPosition = parentEntry.position;
+            int parentId = parentEntry.id;
+
+            Vector2 originalPos = BranchPlacement.ComputeBranchPosition(parentPosition, settings.distance, settings.angleDegrees);
+            int originalNewId = SkillTreeNodeIdAllocator.ComputeNextNodeId(data.Nodes);
+            var originalEntry = SkillTreeNodeFactory.CreateBranchNode(originalNewId, originalPos);
+            data.AddBranchNode(originalEntry, parentId);
+
+            if (!settings.mirrorEnabled)
+                return MirrorPairResult.OriginalOnly(originalNewId);
+
+            float mirrorAngle = BranchPlacement.MirrorAngle(settings.angleDegrees, settings.mirrorAxisDegrees);
+            Vector2 mirrorPos = BranchPlacement.ComputeBranchPosition(parentPosition, settings.distance, mirrorAngle);
+
+            if (HasCollisionAt(data.Nodes, mirrorPos, BranchPlacement.PositionTolerance))
+            {
+                string warning = string.Format(CultureInfo.InvariantCulture, MirrorSkippedWarningFormat, BranchPlacement.PositionTolerance);
+                return MirrorPairResult.OriginalOnlyWithWarning(originalNewId, warning);
+            }
+
+            int mirrorNewId = SkillTreeNodeIdAllocator.ComputeNextNodeId(data.Nodes);
+            var mirrorEntry = SkillTreeNodeFactory.CreateBranchNode(mirrorNewId, mirrorPos);
+            data.AddBranchNode(mirrorEntry, parentId);
+
+            return MirrorPairResult.Pair(originalNewId, mirrorNewId);
+        }
+
+        internal static bool HasCollisionAt(IReadOnlyList<SkillTreeData.SkillNodeEntry> nodes, Vector2 candidatePos, float tolerance)
+        {
+            if (nodes == null) return false;
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                if (Vector2.Distance(nodes[i].position, candidatePos) < tolerance)
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/Editor/Tools/MirrorPairGenerator.cs.meta
+++ b/Assets/Scripts/Editor/Tools/MirrorPairGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c57cdd33eef5baf4bb0aa3a7a0235cb8

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -39,6 +39,8 @@ namespace RogueliteAutoBattler.Editor.Windows
         private static readonly Color CrosshairColor = new Color(0.4f, 0.4f, 0.4f, 1f);
         private static readonly Color GridLineColor = new Color(0.2f, 0.2f, 0.2f, 1f);
         private static readonly Color BranchPreviewTintColor = new Color(1f, 1f, 1f, 0.4f);
+        private static readonly Color MirrorAxisLineColor = new Color(1f, 0.92f, 0.016f, 0.6f);
+        private static readonly Color MirrorPreviewTintColor = new Color(0f, 1f, 1f, 0.4f);
 
         private static readonly GUIContent LabelUnitSize = new GUIContent("Unit Size");
         private static readonly GUIContent LabelNodeSize = new GUIContent("Node Size");
@@ -54,6 +56,10 @@ namespace RogueliteAutoBattler.Editor.Windows
         private static readonly GUIContent LabelEdgeThickness = new GUIContent("Edge Thickness");
 
         private const string AngleSliderLabel = "Angle (deg, 0=N, 90=E)";
+        private const float MinMirrorAxisDegrees = 0f;
+        private const float MaxMirrorAxisDegrees = 360f;
+        private const string MirrorEnabledLabel = "Mirror";
+        private const string MirrorAxisSliderLabel = "Mirror Axis (deg, 0=vertical)";
 
         private const string SelectedAssetGuidEditorPrefKey = "SkillTreeDesigner.SelectedAssetGuid";
         private const string ActiveLabelPrefix = "Active: ";
@@ -112,6 +118,7 @@ namespace RogueliteAutoBattler.Editor.Windows
         private int _branchPreviewPreviousTab;
         private BranchPreviewSettings _branchPreviewSettings = BranchPreviewSettings.Defaults;
         private BranchPreviewSettings _lastBranchPreviewSettings = BranchPreviewSettings.Defaults;
+        private string _lastMirrorWarning;
 
         private static void LogError(string message)
         {
@@ -142,6 +149,8 @@ namespace RogueliteAutoBattler.Editor.Windows
             var initialEntry = ResolveInitialTreeEntry();
             BindAsset(initialEntry);
             RefreshActivePointerCache();
+            MirrorAxisPersistence.ApplyTo(ref _branchPreviewSettings);
+            MirrorAxisPersistence.ApplyTo(ref _lastBranchPreviewSettings);
         }
 
         private void RefreshTreeList()
@@ -184,6 +193,7 @@ namespace RogueliteAutoBattler.Editor.Windows
 
         private void BindAsset(SkillTreesEnumerator.TreeEntry? entry)
         {
+            _lastMirrorWarning = null;
             if (!entry.HasValue)
             {
                 _data = null;
@@ -386,6 +396,24 @@ namespace RogueliteAutoBattler.Editor.Windows
                     new Vector3(previewScreen.x, previewScreen.y, 0f),
                     BranchPreviewDottedSegmentSize);
                 Handles.DrawWireDisc(new Vector3(previewScreen.x, previewScreen.y, 0f), Vector3.forward, halfNode);
+
+                if (_branchPreviewSettings.mirrorEnabled)
+                {
+                    float halfSpan = Mathf.Max(canvasRect.width, canvasRect.height);
+                    MirrorAxisGeometry.ComputeAxisEndpoints(origin, _branchPreviewSettings.mirrorAxisDegrees, halfSpan, out var axisStart, out var axisEnd);
+                    Handles.color = MirrorAxisLineColor;
+                    Handles.DrawDottedLine(new Vector3(axisStart.x, axisStart.y, 0f), new Vector3(axisEnd.x, axisEnd.y, 0f), BranchPreviewDottedSegmentSize);
+
+                    float mirrorAngleDegrees = BranchPlacement.MirrorAngle(_branchPreviewSettings.angleDegrees, _branchPreviewSettings.mirrorAxisDegrees);
+                    Vector2 mirrorPos = BranchPlacement.ComputeBranchPosition(parentPos, _branchPreviewSettings.distance, mirrorAngleDegrees);
+                    Vector2 mirrorScreen = origin + mirrorPos * scaledUnit;
+                    Handles.color = MirrorPreviewTintColor;
+                    Handles.DrawDottedLine(
+                        new Vector3(parentScreen.x, parentScreen.y, 0f),
+                        new Vector3(mirrorScreen.x, mirrorScreen.y, 0f),
+                        BranchPreviewDottedSegmentSize);
+                    Handles.DrawWireDisc(new Vector3(mirrorScreen.x, mirrorScreen.y, 0f), Vector3.forward, halfNode);
+                }
             }
             Handles.EndGUI();
 
@@ -553,6 +581,7 @@ namespace RogueliteAutoBattler.Editor.Windows
                 _branchPreviewParentIndex = _selectedNodeIndex;
                 _branchPreviewSettings = _lastBranchPreviewSettings;
                 _branchPreviewSettings.angleDegrees = BranchPlacement.ComputeDefaultAngle(_data.Nodes[_selectedNodeIndex].position);
+                _lastMirrorWarning = null;
                 _activeTab = TabIndexBranch;
                 Repaint();
             }
@@ -658,6 +687,27 @@ namespace RogueliteAutoBattler.Editor.Windows
             if (EditorGUI.EndChangeCheck())
                 Repaint();
 
+            EditorGUI.BeginChangeCheck();
+            _branchPreviewSettings.mirrorEnabled = EditorGUILayout.Toggle(MirrorEnabledLabel, _branchPreviewSettings.mirrorEnabled);
+            if (EditorGUI.EndChangeCheck())
+                Repaint();
+
+            if (_branchPreviewSettings.mirrorEnabled)
+            {
+                EditorGUI.BeginChangeCheck();
+                _branchPreviewSettings.mirrorAxisDegrees = EditorGUILayout.Slider(MirrorAxisSliderLabel, _branchPreviewSettings.mirrorAxisDegrees, MinMirrorAxisDegrees, MaxMirrorAxisDegrees);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    MirrorAxisPersistence.Save(_branchPreviewSettings.mirrorAxisDegrees);
+                    Repaint();
+                }
+            }
+
+            if (!string.IsNullOrEmpty(_lastMirrorWarning))
+            {
+                EditorGUILayout.HelpBox(_lastMirrorWarning, MessageType.Warning);
+            }
+
             EditorGUILayout.Space(SectionSpacingSmall);
             EditorGUILayout.BeginHorizontal();
             if (GUILayout.Button("Generate"))
@@ -672,6 +722,7 @@ namespace RogueliteAutoBattler.Editor.Windows
             _branchPreviewActive = false;
             _branchPreviewParentIndex = -1;
             _activeTab = _branchPreviewPreviousTab;
+            _lastMirrorWarning = null;
             Repaint();
         }
 
@@ -680,18 +731,19 @@ namespace RogueliteAutoBattler.Editor.Windows
             int parentIndex = _branchPreviewParentIndex;
             if (parentIndex < 0 || parentIndex >= _data.Nodes.Count) return;
 
-            int parentId = _data.Nodes[parentIndex].id;
-            Vector2 newPos = BranchPlacement.ComputeBranchPosition(_data.Nodes[parentIndex].position, _branchPreviewSettings.distance, _branchPreviewSettings.angleDegrees);
-            int newId = SkillTreeNodeIdAllocator.ComputeNextNodeId(_data.Nodes);
+            string undoLabel = _branchPreviewSettings.mirrorEnabled
+                ? MirrorPairGenerator.UndoLabelMirroredPair
+                : MirrorPairGenerator.UndoLabelSingleNode;
+            Undo.RegisterCompleteObjectUndo(_data, undoLabel);
 
-            Undo.RegisterCompleteObjectUndo(_data, "Create Branch Node");
-            var newEntry = SkillTreeNodeFactory.CreateBranchNode(newId, newPos);
-            _data.AddBranchNode(newEntry, parentId);
+            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, _branchPreviewSettings);
+
             EditorUtility.SetDirty(_data);
             AssetDatabase.SaveAssets();
             _serializedData.Update();
             RebuildNodeLabels();
 
+            _lastMirrorWarning = result.WarningMessage;
             _lastBranchPreviewSettings = _branchPreviewSettings;
             _selectedNodeIndex = _data.Nodes.Count - 1;
             _branchPreviewActive = false;

--- a/Assets/Tests/EditMode/BranchPlacementMirrorAngleTests.cs
+++ b/Assets/Tests/EditMode/BranchPlacementMirrorAngleTests.cs
@@ -1,0 +1,88 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Editor.Tools;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class BranchPlacementMirrorAngleTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        [Test]
+        public void MirrorAngle_60AcrossVerticalAxis_Returns300()
+        {
+            float result = BranchPlacement.MirrorAngle(60f, 0f);
+
+            Assert.That(result, Is.EqualTo(300f).Within(Tolerance));
+        }
+
+        [Test]
+        public void MirrorAngle_OnAxisInput_ReturnsItself()
+        {
+            float result = BranchPlacement.MirrorAngle(90f, 90f);
+
+            Assert.That(result, Is.EqualTo(90f).Within(Tolerance));
+        }
+
+        [Test]
+        public void MirrorAngle_OppositeAxisLine_BehavesIdentically()
+        {
+            float result = BranchPlacement.MirrorAngle(90f, 270f);
+
+            Assert.That(result, Is.EqualTo(90f).Within(Tolerance));
+        }
+
+        [Test]
+        public void MirrorAngle_CrossQuadrant_45AcrossHorizontal_Returns135()
+        {
+            float result = BranchPlacement.MirrorAngle(45f, 90f);
+
+            Assert.That(result, Is.EqualTo(135f).Within(Tolerance));
+        }
+
+        [Test]
+        public void MirrorAngle_NegativeInput_NormalizedToPositive()
+        {
+            float result = BranchPlacement.MirrorAngle(-30f, 0f);
+
+            Assert.That(result, Is.EqualTo(30f).Within(Tolerance));
+        }
+
+        [Test]
+        public void MirrorAngle_InputAbove360_NormalizedFirst()
+        {
+            float result = BranchPlacement.MirrorAngle(420f, 0f);
+
+            Assert.That(result, Is.EqualTo(300f).Within(Tolerance));
+        }
+
+        [Test]
+        public void MirrorAngle_AxisAngleAbove360_NormalizedFirst()
+        {
+            float result = BranchPlacement.MirrorAngle(60f, 360f);
+
+            Assert.That(result, Is.EqualTo(300f).Within(Tolerance));
+        }
+
+        [Test]
+        public void MirrorAngle_ResultAlwaysInUnitCircleRange()
+        {
+            System.Random random = new System.Random(12345);
+            for (int i = 0; i < 16; i++)
+            {
+                float angle = (float)(random.NextDouble() * 1440.0 - 720.0);
+                float axis = (float)(random.NextDouble() * 1440.0 - 720.0);
+
+                float result = BranchPlacement.MirrorAngle(angle, axis);
+
+                Assert.That(result, Is.GreaterThanOrEqualTo(0f));
+                Assert.That(result, Is.LessThan(360f));
+            }
+        }
+
+        [Test]
+        public void PositionTolerance_IsOneUnit()
+        {
+            Assert.That(BranchPlacement.PositionTolerance, Is.EqualTo(1f).Within(Tolerance));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/BranchPlacementMirrorAngleTests.cs.meta
+++ b/Assets/Tests/EditMode/BranchPlacementMirrorAngleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5ccbf0e431c79da46b3fef50499c40b8

--- a/Assets/Tests/EditMode/BranchPreviewSettingsDefaultsTests.cs
+++ b/Assets/Tests/EditMode/BranchPreviewSettingsDefaultsTests.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Editor.Tools;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class BranchPreviewSettingsDefaultsTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        [Test]
+        public void Defaults_MirrorEnabled_IsFalse()
+        {
+            Assert.That(BranchPreviewSettings.Defaults.mirrorEnabled, Is.False);
+        }
+
+        [Test]
+        public void Defaults_MirrorAxisDegrees_IsZero()
+        {
+            Assert.That(BranchPreviewSettings.Defaults.mirrorAxisDegrees, Is.EqualTo(0f).Within(Tolerance));
+        }
+
+        [Test]
+        public void Defaults_DistanceAndAngleDegrees_Unchanged()
+        {
+            Assert.That(BranchPreviewSettings.Defaults.distance, Is.EqualTo(3f).Within(Tolerance));
+            Assert.That(BranchPreviewSettings.Defaults.angleDegrees, Is.EqualTo(0f).Within(Tolerance));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/BranchPreviewSettingsDefaultsTests.cs.meta
+++ b/Assets/Tests/EditMode/BranchPreviewSettingsDefaultsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3c6d9f0fc835e6a419989442c4c7944d

--- a/Assets/Tests/EditMode/MirrorAxisGeometryTests.cs
+++ b/Assets/Tests/EditMode/MirrorAxisGeometryTests.cs
@@ -38,8 +38,10 @@ namespace RogueliteAutoBattler.Tests.EditMode
             float halfSpan = Mathf.Sqrt(2f);
             MirrorAxisGeometry.ComputeAxisEndpoints(Vector2.zero, 45f, halfSpan, out var start, out var end);
 
-            Assert.AreEqual(1f, Vector2.Distance(start, new Vector2(-1f, -1f)), Tolerance);
-            Assert.AreEqual(1f, Vector2.Distance(end, new Vector2(1f, 1f)), Tolerance);
+            Assert.AreEqual(-1f, start.x, Tolerance);
+            Assert.AreEqual(-1f, start.y, Tolerance);
+            Assert.AreEqual(1f, end.x, Tolerance);
+            Assert.AreEqual(1f, end.y, Tolerance);
         }
 
         [TestCase(0f)]

--- a/Assets/Tests/EditMode/MirrorAxisGeometryTests.cs
+++ b/Assets/Tests/EditMode/MirrorAxisGeometryTests.cs
@@ -1,0 +1,60 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Editor.Tools;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    internal sealed class MirrorAxisGeometryTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        [Test]
+        public void ComputeAxisEndpoints_VerticalAxis_ReturnsVerticalLine()
+        {
+            var origin = new Vector2(100f, 100f);
+            MirrorAxisGeometry.ComputeAxisEndpoints(origin, 0f, 50f, out var start, out var end);
+
+            Assert.AreEqual(100f, start.x, Tolerance);
+            Assert.AreEqual(50f, start.y, Tolerance);
+            Assert.AreEqual(100f, end.x, Tolerance);
+            Assert.AreEqual(150f, end.y, Tolerance);
+        }
+
+        [Test]
+        public void ComputeAxisEndpoints_HorizontalAxis_ReturnsHorizontalLine()
+        {
+            var origin = new Vector2(100f, 100f);
+            MirrorAxisGeometry.ComputeAxisEndpoints(origin, 90f, 50f, out var start, out var end);
+
+            Assert.AreEqual(50f, start.x, Tolerance);
+            Assert.AreEqual(100f, start.y, Tolerance);
+            Assert.AreEqual(150f, end.x, Tolerance);
+            Assert.AreEqual(100f, end.y, Tolerance);
+        }
+
+        [Test]
+        public void ComputeAxisEndpoints_45Degrees_ReturnsDiagonal()
+        {
+            float halfSpan = Mathf.Sqrt(2f);
+            MirrorAxisGeometry.ComputeAxisEndpoints(Vector2.zero, 45f, halfSpan, out var start, out var end);
+
+            Assert.AreEqual(1f, Vector2.Distance(start, new Vector2(-1f, -1f)), Tolerance);
+            Assert.AreEqual(1f, Vector2.Distance(end, new Vector2(1f, 1f)), Tolerance);
+        }
+
+        [TestCase(0f)]
+        [TestCase(30f)]
+        [TestCase(45f)]
+        [TestCase(90f)]
+        [TestCase(180f)]
+        public void ComputeAxisEndpoints_LineCrossesOrigin(float axisAngle)
+        {
+            var origin = new Vector2(37f, 83f);
+            MirrorAxisGeometry.ComputeAxisEndpoints(origin, axisAngle, 100f, out var start, out var end);
+
+            var midpoint = (start + end) * 0.5f;
+            Assert.AreEqual(origin.x, midpoint.x, Tolerance);
+            Assert.AreEqual(origin.y, midpoint.y, Tolerance);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/MirrorAxisGeometryTests.cs.meta
+++ b/Assets/Tests/EditMode/MirrorAxisGeometryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9786b480fea9669419a8e98248f5fb3a

--- a/Assets/Tests/EditMode/MirrorAxisPersistenceTests.cs
+++ b/Assets/Tests/EditMode/MirrorAxisPersistenceTests.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Editor.Tools;
+using UnityEditor;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class MirrorAxisPersistenceTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        [SetUp]
+        public void SetUp()
+        {
+            EditorPrefs.DeleteKey(MirrorAxisPersistence.EditorPrefKey);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            EditorPrefs.DeleteKey(MirrorAxisPersistence.EditorPrefKey);
+        }
+
+        [Test]
+        public void LoadMirrorAxisDegrees_KeyAbsent_ReturnsZero()
+        {
+            float result = MirrorAxisPersistence.Load();
+
+            Assert.That(result, Is.EqualTo(0f).Within(Tolerance));
+        }
+
+        [Test]
+        public void SaveThenLoad_RoundTripsValue()
+        {
+            MirrorAxisPersistence.Save(45f);
+
+            float result = MirrorAxisPersistence.Load();
+
+            Assert.That(result, Is.EqualTo(45f).Within(Tolerance));
+        }
+
+        [Test]
+        public void SaveOverwrites_PreviousValue()
+        {
+            MirrorAxisPersistence.Save(45f);
+            MirrorAxisPersistence.Save(90f);
+
+            float result = MirrorAxisPersistence.Load();
+
+            Assert.That(result, Is.EqualTo(90f).Within(Tolerance));
+        }
+
+        [Test]
+        public void SaveLoad_NegativeValue_PreservedRaw()
+        {
+            MirrorAxisPersistence.Save(-15f);
+
+            float result = MirrorAxisPersistence.Load();
+
+            Assert.That(result, Is.EqualTo(-15f).Within(Tolerance));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/MirrorAxisPersistenceTests.cs.meta
+++ b/Assets/Tests/EditMode/MirrorAxisPersistenceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8e44b665ddfe5804dbfb89dfbfad1450

--- a/Assets/Tests/EditMode/MirrorAxisPersistenceWiringTests.cs
+++ b/Assets/Tests/EditMode/MirrorAxisPersistenceWiringTests.cs
@@ -1,0 +1,70 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Editor.Tools;
+using UnityEditor;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class MirrorAxisPersistenceWiringTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        [SetUp]
+        public void SetUp()
+        {
+            EditorPrefs.DeleteKey(MirrorAxisPersistence.EditorPrefKey);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            EditorPrefs.DeleteKey(MirrorAxisPersistence.EditorPrefKey);
+        }
+
+        [Test]
+        public void ApplyPersistedAxisTo_KeyAbsent_LeavesAxisAtZero()
+        {
+            BranchPreviewSettings settings = BranchPreviewSettings.Defaults;
+
+            MirrorAxisPersistence.ApplyTo(ref settings);
+
+            Assert.That(settings.mirrorAxisDegrees, Is.EqualTo(0f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ApplyPersistedAxisTo_KeyPresent_OverwritesAxis()
+        {
+            MirrorAxisPersistence.Save(75f);
+            BranchPreviewSettings settings = BranchPreviewSettings.Defaults;
+            settings.mirrorAxisDegrees = 0f;
+
+            MirrorAxisPersistence.ApplyTo(ref settings);
+
+            Assert.That(settings.mirrorAxisDegrees, Is.EqualTo(75f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ApplyPersistedAxisTo_DoesNotTouchMirrorEnabled()
+        {
+            BranchPreviewSettings settings = BranchPreviewSettings.Defaults;
+            settings.mirrorEnabled = true;
+            MirrorAxisPersistence.Save(50f);
+
+            MirrorAxisPersistence.ApplyTo(ref settings);
+
+            Assert.That(settings.mirrorEnabled, Is.True);
+        }
+
+        [Test]
+        public void ApplyPersistedAxisTo_DoesNotTouchDistanceOrAngle()
+        {
+            BranchPreviewSettings settings = BranchPreviewSettings.Defaults;
+            settings.distance = 7f;
+            settings.angleDegrees = 42f;
+
+            MirrorAxisPersistence.ApplyTo(ref settings);
+
+            Assert.That(settings.distance, Is.EqualTo(7f).Within(Tolerance));
+            Assert.That(settings.angleDegrees, Is.EqualTo(42f).Within(Tolerance));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/MirrorAxisPersistenceWiringTests.cs.meta
+++ b/Assets/Tests/EditMode/MirrorAxisPersistenceWiringTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 23fee7abdebbf4a4d8ecc75e9adc48d4

--- a/Assets/Tests/EditMode/MirrorPairGeneratorTests.cs
+++ b/Assets/Tests/EditMode/MirrorPairGeneratorTests.cs
@@ -1,0 +1,314 @@
+using System.Collections.Generic;
+using System.Globalization;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Editor.Tools;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class MirrorPairGeneratorTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        private SkillTreeData _data;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _data = ScriptableObject.CreateInstance<SkillTreeData>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_data);
+        }
+
+        private static SkillTreeData.SkillNodeEntry MakeNode(int id, Vector2 position)
+        {
+            return new SkillTreeData.SkillNodeEntry
+            {
+                id = id,
+                position = position,
+                connectedNodeIds = new List<int>(),
+                costType = SkillTreeData.CostType.Gold,
+                maxLevel = 5,
+                baseCost = 1,
+                costMultiplierOdd = 1f,
+                costMultiplierEven = 1f,
+                costAdditivePerLevel = 0,
+                statModifierType = StatType.Hp,
+                statModifierMode = SkillTreeData.StatModifierMode.Flat,
+                statModifierValuePerLevel = 5f
+            };
+        }
+
+        private static SkillTreeData.SkillNodeEntry MakeCentral()
+        {
+            return MakeNode(SkillTreeData.CentralNodeId, Vector2.zero);
+        }
+
+        [Test]
+        public void TryGenerate_MirrorDisabled_CreatesOnlyOriginal_ReturnsOriginalOnly()
+        {
+            var central = MakeCentral();
+            var parent = MakeNode(1, new Vector2(0f, 3f));
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
+            int initialCount = _data.Nodes.Count;
+
+            var settings = BranchPreviewSettings.Defaults;
+            settings.distance = 2f;
+            settings.angleDegrees = 90f;
+            settings.mirrorEnabled = false;
+
+            int parentIndex = 1;
+            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+
+            Assert.IsTrue(result.OriginalCreated);
+            Assert.IsFalse(result.MirrorCreated);
+            Assert.IsTrue(string.IsNullOrEmpty(result.WarningMessage));
+            Assert.AreEqual(initialCount + 1, _data.Nodes.Count);
+        }
+
+        [Test]
+        public void TryGenerate_MirrorEnabled_NoCollision_CreatesPair_BothChildrenOfParent()
+        {
+            var central = MakeCentral();
+            var parent = MakeNode(1, new Vector2(0f, 3f));
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
+            int initialCount = _data.Nodes.Count;
+
+            var settings = BranchPreviewSettings.Defaults;
+            settings.distance = 2f;
+            settings.angleDegrees = 60f;
+            settings.mirrorEnabled = true;
+            settings.mirrorAxisDegrees = 0f;
+
+            int parentIndex = 1;
+            int parentId = parent.id;
+            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+
+            Assert.IsTrue(result.OriginalCreated);
+            Assert.IsTrue(result.MirrorCreated);
+            Assert.AreEqual(initialCount + 2, _data.Nodes.Count);
+
+            float expectedMirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
+            Vector2 expectedMirrorPos = BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, expectedMirrorAngle);
+            var lastNode = _data.Nodes[_data.Nodes.Count - 1];
+            Assert.That(lastNode.position.x, Is.EqualTo(expectedMirrorPos.x).Within(Tolerance));
+            Assert.That(lastNode.position.y, Is.EqualTo(expectedMirrorPos.y).Within(Tolerance));
+
+            var edges = _data.GetEdges();
+            int edgesFromParentToNewIds = 0;
+            foreach (var (fromId, toId) in edges)
+            {
+                if (fromId == parentId && (toId == result.OriginalNewId || toId == result.MirrorNewId))
+                    edgesFromParentToNewIds++;
+            }
+            Assert.AreEqual(2, edgesFromParentToNewIds);
+        }
+
+        [Test]
+        public void TryGenerate_MirrorEnabled_CollisionAtMirrorPosition_OriginalOnly_WithWarning()
+        {
+            var central = MakeCentral();
+            var parent = MakeNode(1, new Vector2(0f, 3f));
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
+
+            float expectedMirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
+            Vector2 expectedMirrorPos = BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, expectedMirrorAngle);
+            var blocker = MakeNode(99, expectedMirrorPos);
+            _data.AddBranchNode(blocker, SkillTreeData.CentralNodeId);
+
+            int initialCount = _data.Nodes.Count;
+
+            var settings = BranchPreviewSettings.Defaults;
+            settings.distance = 2f;
+            settings.angleDegrees = 60f;
+            settings.mirrorEnabled = true;
+            settings.mirrorAxisDegrees = 0f;
+
+            int parentIndex = 1;
+            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+
+            Assert.IsTrue(result.OriginalCreated);
+            Assert.IsFalse(result.MirrorCreated);
+            Assert.AreEqual(initialCount + 1, _data.Nodes.Count);
+            string expectedWarning = string.Format(CultureInfo.InvariantCulture, MirrorPairGenerator.MirrorSkippedWarningFormat, BranchPlacement.PositionTolerance);
+            Assert.AreEqual(expectedWarning, result.WarningMessage);
+        }
+
+        [Test]
+        public void TryGenerate_CollisionWithinToleranceButNotExact_StillSkipsMirror()
+        {
+            var central = MakeCentral();
+            var parent = MakeNode(1, new Vector2(0f, 3f));
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
+
+            float expectedMirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
+            Vector2 expectedMirrorPos = BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, expectedMirrorAngle);
+            var blocker = MakeNode(99, expectedMirrorPos + new Vector2(0.5f, 0f));
+            _data.AddBranchNode(blocker, SkillTreeData.CentralNodeId);
+
+            int initialCount = _data.Nodes.Count;
+
+            var settings = BranchPreviewSettings.Defaults;
+            settings.distance = 2f;
+            settings.angleDegrees = 60f;
+            settings.mirrorEnabled = true;
+            settings.mirrorAxisDegrees = 0f;
+
+            int parentIndex = 1;
+            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+
+            Assert.IsTrue(result.OriginalCreated);
+            Assert.IsFalse(result.MirrorCreated);
+            Assert.AreEqual(initialCount + 1, _data.Nodes.Count);
+            string expectedWarning = string.Format(CultureInfo.InvariantCulture, MirrorPairGenerator.MirrorSkippedWarningFormat, BranchPlacement.PositionTolerance);
+            Assert.AreEqual(expectedWarning, result.WarningMessage);
+        }
+
+        [Test]
+        public void TryGenerate_BlockerOutsideTolerance_PairCreated()
+        {
+            var central = MakeCentral();
+            var parent = MakeNode(1, new Vector2(0f, 3f));
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
+
+            float expectedMirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
+            Vector2 expectedMirrorPos = BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, expectedMirrorAngle);
+            var blocker = MakeNode(99, expectedMirrorPos + new Vector2(1.5f, 0f));
+            _data.AddBranchNode(blocker, SkillTreeData.CentralNodeId);
+
+            var settings = BranchPreviewSettings.Defaults;
+            settings.distance = 2f;
+            settings.angleDegrees = 60f;
+            settings.mirrorEnabled = true;
+            settings.mirrorAxisDegrees = 0f;
+
+            int parentIndex = 1;
+            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+
+            Assert.IsTrue(result.OriginalCreated);
+            Assert.IsTrue(result.MirrorCreated);
+            Assert.IsTrue(string.IsNullOrEmpty(result.WarningMessage));
+        }
+
+        [Test]
+        public void TryGenerate_OnAxisAngle_PairWouldOverlap_SkipsMirror()
+        {
+            var central = MakeCentral();
+            var parent = MakeNode(1, new Vector2(0f, 3f));
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
+            int initialCount = _data.Nodes.Count;
+
+            var settings = BranchPreviewSettings.Defaults;
+            settings.distance = 2f;
+            settings.angleDegrees = 0f;
+            settings.mirrorEnabled = true;
+            settings.mirrorAxisDegrees = 0f;
+
+            int parentIndex = 1;
+            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+
+            Assert.IsTrue(result.OriginalCreated);
+            Assert.IsFalse(result.MirrorCreated);
+            Assert.AreEqual(initialCount + 1, _data.Nodes.Count);
+            string expectedWarning = string.Format(CultureInfo.InvariantCulture, MirrorPairGenerator.MirrorSkippedWarningFormat, BranchPlacement.PositionTolerance);
+            Assert.AreEqual(expectedWarning, result.WarningMessage);
+        }
+
+        [Test]
+        public void TryGenerate_AssignsSequentialIds()
+        {
+            var central = MakeCentral();
+            var parent = MakeNode(5, new Vector2(0f, 3f));
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
+
+            var settings = BranchPreviewSettings.Defaults;
+            settings.distance = 2f;
+            settings.angleDegrees = 60f;
+            settings.mirrorEnabled = true;
+            settings.mirrorAxisDegrees = 0f;
+
+            int parentIndex = 1;
+            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+
+            Assert.AreEqual(6, result.OriginalNewId);
+            Assert.AreEqual(7, result.MirrorNewId);
+        }
+
+        [Test]
+        public void TryGenerate_DataNull_ReturnsInvalid()
+        {
+            var result = MirrorPairGenerator.TryGenerate(null, 0, BranchPreviewSettings.Defaults);
+
+            Assert.IsFalse(result.OriginalCreated);
+            Assert.IsFalse(result.MirrorCreated);
+        }
+
+        [Test]
+        public void TryGenerate_InvalidParentIndex_ReturnsInvalid()
+        {
+            var central = MakeCentral();
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central });
+            int initialCount = _data.Nodes.Count;
+
+            var result = MirrorPairGenerator.TryGenerate(_data, 999, BranchPreviewSettings.Defaults);
+
+            Assert.IsFalse(result.OriginalCreated);
+            Assert.IsFalse(result.MirrorCreated);
+            Assert.AreEqual(initialCount, _data.Nodes.Count);
+        }
+
+        [Test]
+        public void HasCollisionAt_NoNodes_ReturnsFalse()
+        {
+            var nodes = new List<SkillTreeData.SkillNodeEntry>();
+
+            bool collision = MirrorPairGenerator.HasCollisionAt(nodes, new Vector2(5f, 5f), 1f);
+
+            Assert.IsFalse(collision);
+        }
+
+        [Test]
+        public void HasCollisionAt_NodeExactlyAtTolerance_ReturnsFalse()
+        {
+            var nodes = new List<SkillTreeData.SkillNodeEntry>
+            {
+                MakeNode(0, new Vector2(1f, 0f))
+            };
+
+            bool collision = MirrorPairGenerator.HasCollisionAt(nodes, Vector2.zero, 1f);
+
+            Assert.IsFalse(collision);
+        }
+
+        [Test]
+        public void HasCollisionAt_NodeJustInsideTolerance_ReturnsTrue()
+        {
+            var nodes = new List<SkillTreeData.SkillNodeEntry>
+            {
+                MakeNode(0, new Vector2(0.999f, 0f))
+            };
+
+            bool collision = MirrorPairGenerator.HasCollisionAt(nodes, Vector2.zero, 1f);
+
+            Assert.IsTrue(collision);
+        }
+
+        [Test]
+        public void UndoLabel_ForMirroredPair_MatchesSpec()
+        {
+            Assert.AreEqual("Create Branch Node Pair (Mirrored)", MirrorPairGenerator.UndoLabelMirroredPair);
+        }
+
+        [Test]
+        public void UndoLabel_ForSingleNode_MatchesExisting()
+        {
+            Assert.AreEqual("Create Branch Node", MirrorPairGenerator.UndoLabelSingleNode);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/MirrorPairGeneratorTests.cs.meta
+++ b/Assets/Tests/EditMode/MirrorPairGeneratorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e57ee7ff176f8ef42be2a65dbaa4574a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 Doc detaille : `Assets/doc/premier-jet-roguelite.html`
 
 # Project Structure
-Generated: 2026-05-01
+Generated: 2026-05-03
 
 .github/
   workflows/
@@ -152,6 +152,9 @@ Assets/
         EditorAssetFolders.cs
         HudIconsImporter.cs
         LevelDatabaseBackgroundMigrator.cs
+        MirrorAxisGeometry.cs
+        MirrorAxisPersistence.cs
+        MirrorPairGenerator.cs
         NavIconsImporter.cs
         RebuildNewGameScene.cs
         ResetPlayerProgressMenu.cs
@@ -228,8 +231,14 @@ Assets/
       AllyStatBonusServiceResolverTests.cs
       AttackSlotRegistryTests.cs
       BranchPlacementDefaultAngleTests.cs
+      BranchPlacementMirrorAngleTests.cs
       BranchPlacementTests.cs
+      BranchPreviewSettingsDefaultsTests.cs
       HudIconAssetTests.cs
+      MirrorAxisGeometryTests.cs
+      MirrorAxisPersistenceTests.cs
+      MirrorAxisPersistenceWiringTests.cs
+      MirrorPairGeneratorTests.cs
       NavBarIconsTests.cs
       SkillTreeDesignerBranchTests.cs
       SkillTreeNodeFactoryTests.cs


### PR DESCRIPTION
## Summary
- BranchPlacement.MirrorAngle helper + PositionTolerance + DirectionFromClockwiseNorthDegrees DRY extraction
- Mirror toggle (session-only) + axis slider (persisted via EditorPrefs) in Branch tab
- 3 visually distinct canvas elements: yellow dashed mirror axis, white original ghost, cyan mirror ghost
- MirrorPairGenerator pure helper with collision detection (PositionTolerance = 1f)
- Single Undo group "Create Branch Node Pair (Mirrored)" for atomic pair creation
- HelpBox warning when reflected position collides with an existing node (mirror skipped, original kept)

## Decisions (post-brainstorm)
- Default axis = 0° (vertical, left-right symmetry) — not 90° as originally specced
- `MirrorEnabled` is session-only (toggle resets to false on window open) to avoid the footgun of a forgotten persistent mirror mode
- `MirrorAxisDegrees` is persisted (workspace preference)
- `MirrorAxisPersistence` class (renamed from `BranchPreviewSettingsPersistence` for honest scope)

## Test plan
- [x] EditMode: 42 new tests + 325 existing — 367/367 passing
  - BranchPlacementMirrorAngleTests (9)
  - BranchPreviewSettingsDefaultsTests (3)
  - MirrorAxisPersistenceTests (4) + MirrorAxisPersistenceWiringTests (4)
  - MirrorAxisGeometryTests (8)
  - MirrorPairGeneratorTests (14)
- [x] Visual smoke (in Unity): toggle+slider visibility, 3-color canvas overlay, pair Undo atomicity, collision HelpBox, axe persistence, session-only toggle

Closes #281