### PR TITLE
feat(skilltree): implicit 0.01 grid + integer-display readouts (#285)

### DIFF
--- a/Assets/Data/SkillTrees/Default.asset
+++ b/Assets/Data/SkillTrees/Default.asset
@@ -38,8 +38,10 @@ MonoBehaviour:
     statModifierType: 8
     statModifierMode: 0
     statModifierValuePerLevel: 0
+    snapEnabled: 1
+    snapThresholdUnits: 0.25
   - id: 2
-    position: {x: -1.8822026, y: 2.5828934}
+    position: {x: -1.88, y: 2.58}
     connectedNodeIds: 0300000004000000
     costType: 1
     maxLevel: 1
@@ -50,8 +52,10 @@ MonoBehaviour:
     statModifierType: 0
     statModifierMode: 0
     statModifierValuePerLevel: 5
+    snapEnabled: 1
+    snapThresholdUnits: 0.25
   - id: 3
-    position: {x: 1.1192951, y: -3.5824077}
+    position: {x: 1.12, y: -3.58}
     connectedNodeIds: 06000000
     costType: 1
     maxLevel: 1
@@ -62,8 +66,10 @@ MonoBehaviour:
     statModifierType: 0
     statModifierMode: 0
     statModifierValuePerLevel: 5
+    snapEnabled: 1
+    snapThresholdUnits: 0.25
   - id: 4
-    position: {x: -1.2740085, y: -6.979765}
+    position: {x: -1.88, y: -5.73}
     connectedNodeIds: 
     costType: 1
     maxLevel: 1
@@ -74,8 +80,10 @@ MonoBehaviour:
     statModifierType: 0
     statModifierMode: 0
     statModifierValuePerLevel: 5
+    snapEnabled: 1
+    snapThresholdUnits: 0.25
   - id: 5
-    position: {x: 5.675419, y: -5.620822}
+    position: {x: 5.68, y: -5.62}
     connectedNodeIds: 
     costType: 1
     maxLevel: 1
@@ -86,8 +94,10 @@ MonoBehaviour:
     statModifierType: 0
     statModifierMode: 0
     statModifierValuePerLevel: 5
+    snapEnabled: 1
+    snapThresholdUnits: 0.25
   - id: 6
-    position: {x: -4.712334, y: -7.6668277}
+    position: {x: -4.71, y: -7.67}
     connectedNodeIds: 
     costType: 1
     maxLevel: 1
@@ -98,4 +108,6 @@ MonoBehaviour:
     statModifierType: 0
     statModifierMode: 0
     statModifierValuePerLevel: 5
+    snapEnabled: 1
+    snapThresholdUnits: 0.25
   assetGuid: 63a2645100f4ff4428d968c9feeb46f4

--- a/Assets/Scripts/Data/SkillTreeData.cs
+++ b/Assets/Scripts/Data/SkillTreeData.cs
@@ -247,6 +247,7 @@ namespace RogueliteAutoBattler.Data
         {
             Debug.Assert(index >= 0 && index < nodes.Count, $"SetNode index {index} out of range [0, {nodes.Count})");
             if (index < 0 || index >= nodes.Count) return;
+            entry.position = SkillTreeGrid.Quantize(entry.position);
             nodes[index] = entry;
             _cachedEdges = null;
         }
@@ -258,6 +259,7 @@ namespace RogueliteAutoBattler.Data
                 if (existing.id == entry.id)
                     throw new ArgumentException($"A node with id {entry.id} already exists.");
             }
+            entry.position = SkillTreeGrid.Quantize(entry.position);
             nodes.Add(entry);
             _cachedEdges = null;
         }
@@ -376,6 +378,7 @@ namespace RogueliteAutoBattler.Data
             if (IndexOfId(entry.id) >= 0)
                 throw new ArgumentException($"A node with id {entry.id} already exists.");
 
+            entry.position = SkillTreeGrid.Quantize(entry.position);
             nodes.Add(entry);
 
             var parent = nodes[parentIndex];

--- a/Assets/Scripts/Data/SkillTreeGrid.cs
+++ b/Assets/Scripts/Data/SkillTreeGrid.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Data
+{
+    public static class SkillTreeGrid
+    {
+        public const float Step = 0.01f;
+        private const float DisplayMultiplier = 1f / Step;
+
+        public static Vector2 Quantize(Vector2 v) =>
+            new(Mathf.Round(v.x / Step) * Step, Mathf.Round(v.y / Step) * Step);
+
+        public static (int x, int y) ToDisplay(Vector2 v) =>
+            (Mathf.RoundToInt(v.x * DisplayMultiplier), Mathf.RoundToInt(v.y * DisplayMultiplier));
+
+        public static int DistanceDisplay(Vector2 a, Vector2 b) =>
+            Mathf.RoundToInt(Vector2.Distance(a, b) * DisplayMultiplier);
+    }
+}

--- a/Assets/Scripts/Data/SkillTreeGrid.cs
+++ b/Assets/Scripts/Data/SkillTreeGrid.cs
@@ -6,18 +6,17 @@ namespace RogueliteAutoBattler.Data
     {
         public const float Step = 0.01f;
         public const float DriftEpsilon = 1e-5f;
-        private const float DisplayMultiplier = 1f / Step;
 
         public static Vector2 Quantize(Vector2 v) =>
             new(Mathf.Round(v.x / Step) * Step, Mathf.Round(v.y / Step) * Step);
 
         public static (int x, int y) ToDisplay(Vector2 v) =>
-            (Mathf.RoundToInt(v.x * DisplayMultiplier), Mathf.RoundToInt(v.y * DisplayMultiplier));
+            (Mathf.RoundToInt(v.x / Step), Mathf.RoundToInt(v.y / Step));
 
         public static int DistanceDisplay(Vector2 a, Vector2 b) =>
-            Mathf.RoundToInt(Vector2.Distance(a, b) * DisplayMultiplier);
+            Mathf.RoundToInt(Vector2.Distance(a, b) / Step);
 
         public static int DistanceDisplayFromUnits(float distanceUnits) =>
-            Mathf.RoundToInt(distanceUnits * DisplayMultiplier);
+            Mathf.RoundToInt(distanceUnits / Step);
     }
 }

--- a/Assets/Scripts/Data/SkillTreeGrid.cs
+++ b/Assets/Scripts/Data/SkillTreeGrid.cs
@@ -15,5 +15,8 @@ namespace RogueliteAutoBattler.Data
 
         public static int DistanceDisplay(Vector2 a, Vector2 b) =>
             Mathf.RoundToInt(Vector2.Distance(a, b) * DisplayMultiplier);
+
+        public static int DistanceDisplayFromUnits(float distanceUnits) =>
+            Mathf.RoundToInt(distanceUnits / Step);
     }
 }

--- a/Assets/Scripts/Data/SkillTreeGrid.cs
+++ b/Assets/Scripts/Data/SkillTreeGrid.cs
@@ -5,6 +5,7 @@ namespace RogueliteAutoBattler.Data
     public static class SkillTreeGrid
     {
         public const float Step = 0.01f;
+        public const float DriftEpsilon = 1e-5f;
         private const float DisplayMultiplier = 1f / Step;
 
         public static Vector2 Quantize(Vector2 v) =>
@@ -17,6 +18,6 @@ namespace RogueliteAutoBattler.Data
             Mathf.RoundToInt(Vector2.Distance(a, b) * DisplayMultiplier);
 
         public static int DistanceDisplayFromUnits(float distanceUnits) =>
-            Mathf.RoundToInt(distanceUnits / Step);
+            Mathf.RoundToInt(distanceUnits * DisplayMultiplier);
     }
 }

--- a/Assets/Scripts/Data/SkillTreeGrid.cs.meta
+++ b/Assets/Scripts/Data/SkillTreeGrid.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fc13a845318ed2643b4d6355b5817215

--- a/Assets/Scripts/Editor/Tools/QuantizeAllSkillTreesMenu.cs
+++ b/Assets/Scripts/Editor/Tools/QuantizeAllSkillTreesMenu.cs
@@ -1,0 +1,57 @@
+using RogueliteAutoBattler.Data;
+using UnityEditor;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Editor.Tools
+{
+    internal static class QuantizeAllSkillTreesMenu
+    {
+        private const string MenuPath = "Tools/Skill Tree/Quantize All Positions";
+        private const string LogTag = "[QuantizeAllSkillTrees]";
+        private const float Epsilon = 1e-5f;
+
+        [MenuItem(MenuPath)]
+        public static void QuantizeAllPositions()
+        {
+            var entries = SkillTreesEnumerator.Enumerate(EditorPaths.SkillTreesFolder);
+            int touchedNodes = 0;
+            int touchedAssets = 0;
+
+            foreach (var entry in entries)
+            {
+                var asset = entry.Asset;
+                if (asset == null) continue;
+
+                bool assetDirty = false;
+                var nodes = asset.Nodes;
+
+                for (int i = 0; i < nodes.Count; i++)
+                {
+                    var node = nodes[i];
+                    var quantized = SkillTreeGrid.Quantize(node.position);
+
+                    bool xDrifted = Mathf.Abs(node.position.x - quantized.x) > Epsilon;
+                    bool yDrifted = Mathf.Abs(node.position.y - quantized.y) > Epsilon;
+
+                    if (!xDrifted && !yDrifted) continue;
+
+                    var corrected = node;
+                    corrected.position = quantized;
+                    asset.SetNode(i, corrected);
+                    touchedNodes++;
+                    assetDirty = true;
+                }
+
+                if (!assetDirty) continue;
+
+                EditorUtility.SetDirty(asset);
+                touchedAssets++;
+            }
+
+            if (touchedNodes > 0)
+                AssetDatabase.SaveAssets();
+
+            Debug.Log($"{LogTag} {touchedNodes} nodes quantized across {touchedAssets} asset(s). ({entries.Count} asset(s) scanned)");
+        }
+    }
+}

--- a/Assets/Scripts/Editor/Tools/QuantizeAllSkillTreesMenu.cs
+++ b/Assets/Scripts/Editor/Tools/QuantizeAllSkillTreesMenu.cs
@@ -8,7 +8,6 @@ namespace RogueliteAutoBattler.Editor.Tools
     {
         private const string MenuPath = "Tools/Skill Tree/Quantize All Positions";
         private const string LogTag = "[QuantizeAllSkillTrees]";
-        private const float Epsilon = 1e-5f;
 
         [MenuItem(MenuPath)]
         public static void QuantizeAllPositions()
@@ -30,8 +29,8 @@ namespace RogueliteAutoBattler.Editor.Tools
                     var node = nodes[i];
                     var quantized = SkillTreeGrid.Quantize(node.position);
 
-                    bool xDrifted = Mathf.Abs(node.position.x - quantized.x) > Epsilon;
-                    bool yDrifted = Mathf.Abs(node.position.y - quantized.y) > Epsilon;
+                    bool xDrifted = Mathf.Abs(node.position.x - quantized.x) > SkillTreeGrid.DriftEpsilon;
+                    bool yDrifted = Mathf.Abs(node.position.y - quantized.y) > SkillTreeGrid.DriftEpsilon;
 
                     if (!xDrifted && !yDrifted) continue;
 

--- a/Assets/Scripts/Editor/Tools/QuantizeAllSkillTreesMenu.cs.meta
+++ b/Assets/Scripts/Editor/Tools/QuantizeAllSkillTreesMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b1a85b9919c56634c8e93bf9c7440505

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -415,7 +415,8 @@ namespace RogueliteAutoBattler.Editor.Windows
                             normal = { textColor = Color.white }
                         };
                     }
-                    string coordText = $"({entry.position.x:F2}, {entry.position.y:F2})";
+                    var (dx, dy) = SkillTreeGrid.ToDisplay(entry.position);
+                    string coordText = $"({dx}, {dy})";
                     Rect coordRect = new Rect(
                         screenPos.x + halfNode + CoordLabelOffsetXPixels,
                         screenPos.y - CoordLabelOffsetYPixels,
@@ -855,7 +856,7 @@ namespace RogueliteAutoBattler.Editor.Windows
                             string arrow = row.IsOutgoing ? "→" : "←";
                             EditorGUILayout.LabelField(
                                 $"{arrow} Node {row.OtherNodeId}",
-                                $"{row.DistanceUnits:0.00} units");
+                                $"{SkillTreeGrid.DistanceDisplayFromUnits(row.DistanceUnits)} u");
                         }
                     }
                 }

--- a/Assets/Tests/EditMode/MirrorPairGeneratorTests.cs
+++ b/Assets/Tests/EditMode/MirrorPairGeneratorTests.cs
@@ -95,7 +95,7 @@ namespace RogueliteAutoBattler.Tests.EditMode
             Assert.AreEqual(initialCount + 2, _data.Nodes.Count);
 
             float expectedMirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
-            Vector2 expectedMirrorPos = BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, expectedMirrorAngle);
+            Vector2 expectedMirrorPos = SkillTreeGrid.Quantize(BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, expectedMirrorAngle));
             var lastNode = _data.Nodes[_data.Nodes.Count - 1];
             Assert.That(lastNode.position.x, Is.EqualTo(expectedMirrorPos.x).Within(Tolerance));
             Assert.That(lastNode.position.y, Is.EqualTo(expectedMirrorPos.y).Within(Tolerance));

--- a/Assets/Tests/EditMode/SkillTreeAssetIntegrityTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeAssetIntegrityTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NUnit.Framework;
 using RogueliteAutoBattler.Combat.Core;
 using RogueliteAutoBattler.Data;
+using UnityEngine;
 
 namespace RogueliteAutoBattler.Tests.EditMode
 {
@@ -66,6 +67,25 @@ namespace RogueliteAutoBattler.Tests.EditMode
             Assert.AreEqual(1, central.maxLevel, "Central node maxLevel should be 1.");
             Assert.AreEqual(_asset.CentralUnlockCost, central.baseCost, "Central node baseCost should match centralUnlockCost.");
             Assert.AreEqual(0f, central.statModifierValuePerLevel, "Central node should grant no stat bonus.");
+        }
+
+        [Test]
+        public void Asset_AllNodePositions_QuantizedTo01Unit()
+        {
+            Assert.IsNotNull(_asset, "Failed to resolve active SkillTreeData via ActiveSkillTreeResolver");
+
+            var nodes = _asset.Nodes;
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                var node = nodes[i];
+                float expectedX = Mathf.Round(node.position.x / SkillTreeGrid.Step) * SkillTreeGrid.Step;
+                float expectedY = Mathf.Round(node.position.y / SkillTreeGrid.Step) * SkillTreeGrid.Step;
+
+                Assert.AreEqual(expectedX, node.position.x, 1e-5f,
+                    $"Asset '{_asset.name}' node[{i}] id={node.id}: position.x={node.position.x} is not quantized to grid step {SkillTreeGrid.Step}");
+                Assert.AreEqual(expectedY, node.position.y, 1e-5f,
+                    $"Asset '{_asset.name}' node[{i}] id={node.id}: position.y={node.position.y} is not quantized to grid step {SkillTreeGrid.Step}");
+            }
         }
     }
 }

--- a/Assets/Tests/EditMode/SkillTreeDataAddNodeAddEdgeTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeDataAddNodeAddEdgeTests.cs
@@ -195,6 +195,19 @@ namespace RogueliteAutoBattler.Tests.EditMode
         }
 
         [Test]
+        public void AddNode_NonGridPosition_StoresQuantized()
+        {
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry>());
+            var entry = MakeNode(1, new Vector2(0.123f, -0.046f));
+
+            _data.AddNode(entry);
+
+            var stored = _data.Nodes[0].position;
+            Assert.AreEqual(0.12f, stored.x, 1e-5f);
+            Assert.AreEqual(-0.05f, stored.y, 1e-5f);
+        }
+
+        [Test]
         public void AddBranchNode_AtomicallyValidatesBeforeMutation()
         {
             var parent = MakeNode(0, Vector2.zero);

--- a/Assets/Tests/EditMode/SkillTreeGridTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeGridTests.cs
@@ -1,0 +1,119 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Data;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class SkillTreeGridTests
+    {
+        private const float QuantizeTolerance = 1e-5f;
+
+        [Test]
+        public void Step_Constant_Is001()
+        {
+            Assert.AreEqual(0.01f, SkillTreeGrid.Step, 1e-7f);
+        }
+
+        [Test]
+        public void Quantize_Zero_ReturnsZero()
+        {
+            var result = SkillTreeGrid.Quantize(Vector2.zero);
+
+            Assert.AreEqual(0f, result.x, QuantizeTolerance);
+            Assert.AreEqual(0f, result.y, QuantizeTolerance);
+        }
+
+        [Test]
+        public void Quantize_AlreadyOnGrid_Unchanged()
+        {
+            var input = new Vector2(0.35f, -0.42f);
+
+            var result = SkillTreeGrid.Quantize(input);
+
+            Assert.AreEqual(0.35f, result.x, QuantizeTolerance);
+            Assert.AreEqual(-0.42f, result.y, QuantizeTolerance);
+        }
+
+        [Test]
+        public void Quantize_HalfStep_RoundsToNearest()
+        {
+            var input = new Vector2(0.005f, 0.015f);
+            float expectedX = Mathf.Round(input.x / SkillTreeGrid.Step) * SkillTreeGrid.Step;
+            float expectedY = Mathf.Round(input.y / SkillTreeGrid.Step) * SkillTreeGrid.Step;
+
+            var result = SkillTreeGrid.Quantize(input);
+
+            Assert.AreEqual(expectedX, result.x, QuantizeTolerance);
+            Assert.AreEqual(expectedY, result.y, QuantizeTolerance);
+            Assert.That(result.x, Is.EqualTo(0f).Within(QuantizeTolerance).Or.EqualTo(0.01f).Within(QuantizeTolerance));
+            Assert.That(result.y, Is.EqualTo(0.01f).Within(QuantizeTolerance).Or.EqualTo(0.02f).Within(QuantizeTolerance));
+        }
+
+        [Test]
+        public void Quantize_NegativeNearZero_PreservesSign()
+        {
+            var input = new Vector2(-0.004f, -0.006f);
+
+            var result = SkillTreeGrid.Quantize(input);
+
+            Assert.AreEqual(0f, result.x, QuantizeTolerance);
+            Assert.AreEqual(-0.01f, result.y, QuantizeTolerance);
+        }
+
+        [Test]
+        public void Quantize_LargeMagnitude_StaysOnGrid()
+        {
+            var input = new Vector2(123.4567f, -98.7654f);
+
+            var result = SkillTreeGrid.Quantize(input);
+
+            Assert.AreEqual(123.46f, result.x, QuantizeTolerance);
+            Assert.AreEqual(-98.77f, result.y, QuantizeTolerance);
+        }
+
+        [Test]
+        public void Quantize_FloatGarbage_Removed()
+        {
+            var input = new Vector2(10.00054456f, -1.8822026f);
+
+            var result = SkillTreeGrid.Quantize(input);
+
+            Assert.AreEqual(10.00f, result.x, QuantizeTolerance);
+            Assert.AreEqual(-1.88f, result.y, QuantizeTolerance);
+        }
+
+        [Test]
+        public void ToDisplay_IntegerPercent_ReturnsRoundedInt()
+        {
+            var (x, y) = SkillTreeGrid.ToDisplay(new Vector2(0.35f, -0.42f));
+
+            Assert.AreEqual(35, x);
+            Assert.AreEqual(-42, y);
+        }
+
+        [Test]
+        public void ToDisplay_FractionalSubGrid_RoundsHalfToNearest()
+        {
+            var (x, y) = SkillTreeGrid.ToDisplay(new Vector2(0.354f, 0.356f));
+
+            Assert.AreEqual(35, x);
+            Assert.AreEqual(36, y);
+        }
+
+        [Test]
+        public void DistanceDisplay_AxisAligned_ReturnsExpectedInt()
+        {
+            int distance = SkillTreeGrid.DistanceDisplay(Vector2.zero, new Vector2(0.30f, 0f));
+
+            Assert.AreEqual(30, distance);
+        }
+
+        [Test]
+        public void DistanceDisplay_Diagonal_ReturnsExpectedInt()
+        {
+            int distance = SkillTreeGrid.DistanceDisplay(Vector2.zero, new Vector2(0.30f, 0.40f));
+
+            Assert.AreEqual(50, distance);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/SkillTreeGridTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeGridTests.cs
@@ -15,6 +15,12 @@ namespace RogueliteAutoBattler.Tests.EditMode
         }
 
         [Test]
+        public void DriftEpsilon_IsPositive()
+        {
+            Assert.Greater(SkillTreeGrid.DriftEpsilon, 0f);
+        }
+
+        [Test]
         public void Quantize_Zero_ReturnsZero()
         {
             var result = SkillTreeGrid.Quantize(Vector2.zero);

--- a/Assets/Tests/EditMode/SkillTreeGridTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeGridTests.cs
@@ -115,5 +115,18 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             Assert.AreEqual(50, distance);
         }
+
+        [Test]
+        public void DistanceDisplayFromUnits_TypicalValue_RoundsToHundredth()
+        {
+            Assert.AreEqual(30, SkillTreeGrid.DistanceDisplayFromUnits(0.30f));
+            Assert.AreEqual(31, SkillTreeGrid.DistanceDisplayFromUnits(0.305f));
+        }
+
+        [Test]
+        public void DistanceDisplayFromUnits_Zero_ReturnsZero()
+        {
+            Assert.AreEqual(0, SkillTreeGrid.DistanceDisplayFromUnits(0f));
+        }
     }
 }

--- a/Assets/Tests/EditMode/SkillTreeGridTests.cs.meta
+++ b/Assets/Tests/EditMode/SkillTreeGridTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6ff070569237ff44d9896fb9d6423768

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ Assets/
         NodeConnectionsInspector.cs
         NodeDragController.cs
         NodeSnapEngine.cs
+        QuantizeAllSkillTreesMenu.cs
         RebuildNewGameScene.cs
         ResetPlayerProgressMenu.cs
         SkillTreeAssetMigration.cs
@@ -181,6 +182,7 @@ Assets/
       LevelDataTypes.cs
       LevelDatabase.cs
       SkillTreeData.cs
+      SkillTreeGrid.cs
       SkillTreeProgress.cs
       SkillTreeRefundCalculator.cs
       TeamDatabase.cs
@@ -250,6 +252,7 @@ Assets/
       NodeSnapEngineTests.cs
       SkillTreeDataSnapNormalizationTests.cs
       SkillTreeDesignerBranchTests.cs
+      SkillTreeGridTests.cs
       SkillTreeNodeFactorySnapDefaultsTests.cs
       SkillTreeNodeFactoryTests.cs
       SkillTreeNodeIdAllocatorTests.cs


### PR DESCRIPTION
## Summary
- Establishes an implicit 0.01-unit grid for skill tree node positions: every write goes through `SkillTreeGrid.Quantize`, every editor readout shows position * 100 as a plain integer (e.g. `0.35` -> `(35, ...)`), distance shows `30 u` instead of `0.30 units`.
- New static helper `SkillTreeGrid` (Step=0.01f, DriftEpsilon=1e-5f, Quantize, ToDisplay, DistanceDisplay, DistanceDisplayFromUnits).
- New MenuItem `Tools/Skill Tree/Quantize All Positions` to bulk-migrate any asset; idempotent.
- New EditMode integrity test `Asset_AllNodePositions_QuantizedTo01Unit` fails loud if any future asset drifts off-grid.
- Re-quantized `Default.asset` (5 nodes adjusted, e.g. `-1.8822026` -> `-1.88`).
- Foundation for #286 (alignment snap) and #287 (branch on grid) which both consume `SkillTreeGrid`.

## Test plan
- [x] 791 tests green (425 EditMode + 366 PlayMode), zero regression.
- [x] FP precision regression caught in-loop and fixed: `*DisplayMultiplier` (=1f/Step ~ 100.0000015f) replaced by `/Step` everywhere — `Mathf.RoundToInt` semantics now exact at half-step boundaries.
- [x] Visual checklist run in the Designer: coords show integers, distances show `XX u`, drag-drop precise to grid, MenuItem idempotent on Default.asset, mirror pair symmetric.

Closes #285.