### PR TITLE
fix(skilltree-editor): anchor mirror axis visual on working node (#290)

### DIFF
--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -441,7 +441,7 @@ namespace RogueliteAutoBattler.Editor.Windows
                 if (_branchPreviewSettings.mirrorEnabled)
                 {
                     float halfSpan = Mathf.Max(canvasRect.width, canvasRect.height);
-                    MirrorAxisGeometry.ComputeAxisEndpoints(origin, _branchPreviewSettings.mirrorAxisDegrees, halfSpan, out var axisStart, out var axisEnd);
+                    MirrorAxisGeometry.ComputeAxisEndpoints(parentScreen, _branchPreviewSettings.mirrorAxisDegrees, halfSpan, out var axisStart, out var axisEnd);
                     Handles.color = MirrorAxisLineColor;
                     Handles.DrawDottedLine(new Vector3(axisStart.x, axisStart.y, 0f), new Vector3(axisEnd.x, axisEnd.y, 0f), BranchPreviewDottedSegmentSize);
 


### PR DESCRIPTION
## Summary
- Pass `parentScreen` (working node) to `MirrorAxisGeometry.ComputeAxisEndpoints` instead of `origin` (canvas origin / node 0), so the yellow mirror axis line visually crosses the working node — matching the reflection math which already pivots there.

Fixes #290.

## Test plan
- [x] EditMode: 425/425 pass (incl. `MirrorAxisGeometryTests`, `MirrorAxisPersistence*Tests`, `BranchPlacement*Tests`, `SkillTreeDesignerBranchTests`)
- [x] PlayMode: 366/366 pass
- [ ] Manual: Skill Tree Designer → select non-central node → enable Mirror → yellow axis line crosses the selected node (not node 0)
- [ ] Manual: change selected node mid-preview → axis re-centers instantly