### PR TITLE
feat(skilltree-editor): pick mirror source node + relative-to-mirror angle (#292)

### DIFF
--- a/Assets/Scripts/Editor/Tools/BranchPlacement.cs
+++ b/Assets/Scripts/Editor/Tools/BranchPlacement.cs
@@ -11,6 +11,7 @@ namespace RogueliteAutoBattler.Editor.Tools
         private const float DefaultAngleForOriginParent = 0f;
 
         public const float PositionTolerance = 1f;
+        internal const int NoMirrorSourceOverride = -1;
 
         public static Vector2 ComputeBranchPosition(Vector2 parentPosition, float distance)
         {
@@ -20,10 +21,6 @@ namespace RogueliteAutoBattler.Editor.Tools
             return parentPosition + direction * distance;
         }
 
-        /// <summary>
-        /// Compute a branch child position offset from <paramref name="parentPosition"/>.
-        /// Angle convention is clockwise from north: 0 = north, 90 = east, 180 = south, 270 = west.
-        /// </summary>
         public static Vector2 ComputeBranchPosition(Vector2 parentPosition, float distance, float clockwiseFromNorthDegrees)
         {
             Vector2 direction = DirectionFromClockwiseNorthDegrees(clockwiseFromNorthDegrees);
@@ -36,11 +33,6 @@ namespace RogueliteAutoBattler.Editor.Tools
             return new Vector2(Mathf.Sin(radians), Mathf.Cos(radians));
         }
 
-        /// <summary>
-        /// Compute the default branch angle pointing outward from the origin through
-        /// <paramref name="parentPosition"/>. Returned value uses the clockwise-from-north
-        /// convention (0 = north, 90 = east, 180 = south, 270 = west).
-        /// </summary>
         public static float ComputeDefaultAngle(Vector2 parentPosition)
         {
             if (parentPosition.sqrMagnitude < DegenerateMagnitudeThreshold)
@@ -50,18 +42,12 @@ namespace RogueliteAutoBattler.Editor.Tools
             return NormalizeDegrees(clockwiseFromNorthDegrees);
         }
 
-        /// <summary>
-        /// Reflect <paramref name="angleDegrees"/> across the axis line defined by
-        /// <paramref name="axisAngleDegrees"/>. Angles use the clockwise-from-north convention
-        /// (0 = north, 90 = east, 180 = south, 270 = west). Formula:
-        /// normalize(2 * normalize(axis) - normalize(angle)). Result is normalized to [0, 360).
-        /// </summary>
         public static float MirrorAngle(float angleDegrees, float axisAngleDegrees)
         {
             return NormalizeDegrees(2f * NormalizeDegrees(axisAngleDegrees) - NormalizeDegrees(angleDegrees));
         }
 
-        public static float ResolveAbsoluteAngle(float relative, float axis, bool isRelative)
+        internal static float ResolveAbsoluteAngle(float relative, float axis, bool isRelative)
         {
             if (!isRelative) return relative;
             return NormalizeDegrees(relative + axis);
@@ -80,7 +66,25 @@ namespace RogueliteAutoBattler.Editor.Tools
             return Vector2.zero;
         }
 
-        internal static float NormalizeDegrees(float angleDegrees)
+        internal static (Vector2 parentPos, Vector2 mirrorSourcePos, float resolvedAngle, float mirrorBranchAngle) ResolveBranchPlan(
+            IReadOnlyList<SkillTreeData.SkillNodeEntry> nodes,
+            int parentIndex,
+            int mirrorSourceOverrideIndex,
+            float angleDegrees,
+            float mirrorAxisDegrees,
+            bool angleIsRelativeToMirrorAxis,
+            bool mirrorEnabled)
+        {
+            Vector2 parentPos = (nodes != null && parentIndex >= 0 && parentIndex < nodes.Count)
+                ? nodes[parentIndex].position
+                : Vector2.zero;
+            Vector2 mirrorSourcePos = ResolveMirrorSourcePosition(nodes, parentIndex, mirrorSourceOverrideIndex);
+            float resolvedAngle = ResolveAbsoluteAngle(angleDegrees, mirrorAxisDegrees, angleIsRelativeToMirrorAxis && mirrorEnabled);
+            float mirrorBranchAngle = mirrorEnabled ? MirrorAngle(resolvedAngle, mirrorAxisDegrees) : resolvedAngle;
+            return (parentPos, mirrorSourcePos, resolvedAngle, mirrorBranchAngle);
+        }
+
+        private static float NormalizeDegrees(float angleDegrees)
         {
             return (angleDegrees % FullCircleDegrees + FullCircleDegrees) % FullCircleDegrees;
         }

--- a/Assets/Scripts/Editor/Tools/BranchPlacement.cs
+++ b/Assets/Scripts/Editor/Tools/BranchPlacement.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using RogueliteAutoBattler.Data;
 using UnityEngine;
 
 namespace RogueliteAutoBattler.Editor.Tools
@@ -59,7 +61,26 @@ namespace RogueliteAutoBattler.Editor.Tools
             return NormalizeDegrees(2f * NormalizeDegrees(axisAngleDegrees) - NormalizeDegrees(angleDegrees));
         }
 
-        private static float NormalizeDegrees(float angleDegrees)
+        public static float ResolveAbsoluteAngle(float relative, float axis, bool isRelative)
+        {
+            if (!isRelative) return relative;
+            return NormalizeDegrees(relative + axis);
+        }
+
+        internal static Vector2 ResolveMirrorSourcePosition(
+            IReadOnlyList<SkillTreeData.SkillNodeEntry> nodes,
+            int parentIndex,
+            int sourceOverrideIndex)
+        {
+            if (nodes == null) return Vector2.zero;
+            if (sourceOverrideIndex >= 0 && sourceOverrideIndex < nodes.Count)
+                return nodes[sourceOverrideIndex].position;
+            if (parentIndex >= 0 && parentIndex < nodes.Count)
+                return nodes[parentIndex].position;
+            return Vector2.zero;
+        }
+
+        internal static float NormalizeDegrees(float angleDegrees)
         {
             return (angleDegrees % FullCircleDegrees + FullCircleDegrees) % FullCircleDegrees;
         }

--- a/Assets/Scripts/Editor/Tools/MirrorPairGenerator.cs
+++ b/Assets/Scripts/Editor/Tools/MirrorPairGenerator.cs
@@ -37,7 +37,14 @@ namespace RogueliteAutoBattler.Editor.Tools
             internal static MirrorPairResult Pair(int originalNodeId, int mirrorNodeId) => new MirrorPairResult(true, true, null, originalNodeId, mirrorNodeId);
         }
 
-        public static MirrorPairResult TryGenerate(SkillTreeData data, int parentIndex, BranchPreviewSettings settings)
+        public static MirrorPairResult TryGenerate(
+            SkillTreeData data,
+            int parentIndex,
+            float distance,
+            float resolvedAngleDegrees,
+            bool mirrorEnabled,
+            Vector2 mirrorSourcePosition,
+            float mirrorBranchAngleDegrees)
         {
             if (data == null)
                 return MirrorPairResult.Invalid(ErrorDataNull);
@@ -49,16 +56,15 @@ namespace RogueliteAutoBattler.Editor.Tools
             Vector2 parentPosition = parentEntry.position;
             int parentId = parentEntry.id;
 
-            Vector2 originalPos = BranchPlacement.ComputeBranchPosition(parentPosition, settings.distance, settings.angleDegrees);
+            Vector2 originalPos = BranchPlacement.ComputeBranchPosition(parentPosition, distance, resolvedAngleDegrees);
             int originalNewId = SkillTreeNodeIdAllocator.ComputeNextNodeId(data.Nodes);
             var originalEntry = SkillTreeNodeFactory.CreateBranchNode(originalNewId, originalPos);
             data.AddBranchNode(originalEntry, parentId);
 
-            if (!settings.mirrorEnabled)
+            if (!mirrorEnabled)
                 return MirrorPairResult.OriginalOnly(originalNewId);
 
-            float mirrorAngle = BranchPlacement.MirrorAngle(settings.angleDegrees, settings.mirrorAxisDegrees);
-            Vector2 mirrorPos = BranchPlacement.ComputeBranchPosition(parentPosition, settings.distance, mirrorAngle);
+            Vector2 mirrorPos = BranchPlacement.ComputeBranchPosition(mirrorSourcePosition, distance, mirrorBranchAngleDegrees);
 
             if (HasCollisionAt(data.Nodes, mirrorPos, BranchPlacement.PositionTolerance))
             {

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -137,6 +137,8 @@ namespace RogueliteAutoBattler.Editor.Windows
         private int _branchPreviewPreviousTab;
         private BranchPreviewSettings _branchPreviewSettings = BranchPreviewSettings.Defaults;
         private BranchPreviewSettings _lastBranchPreviewSettings = BranchPreviewSettings.Defaults;
+        private int _mirrorSourceNodeIndex = -1;
+        private bool _angleRelativeToAxis;
         private string _lastMirrorWarning;
         private bool _connectionsFoldoutOpen = true;
         private readonly List<NodeConnectionsInspector.ConnectionRow> _connectionsBuffer = new List<NodeConnectionsInspector.ConnectionRow>();
@@ -427,9 +429,9 @@ namespace RogueliteAutoBattler.Editor.Windows
             }
             if (_branchPreviewActive && _branchPreviewParentIndex >= 0 && _branchPreviewParentIndex < _data.Nodes.Count)
             {
-                Vector2 parentPos = _data.Nodes[_branchPreviewParentIndex].position;
-                Vector2 previewPos = BranchPlacement.ComputeBranchPosition(parentPos, _branchPreviewSettings.distance, _branchPreviewSettings.angleDegrees);
-                Vector2 parentScreen = origin + parentPos * scaledUnit;
+                var (workingPos, mirrorSourcePos, resolvedAngle, mirrorAngle) = ComputeResolvedPreview();
+                Vector2 previewPos = BranchPlacement.ComputeBranchPosition(workingPos, _branchPreviewSettings.distance, resolvedAngle);
+                Vector2 parentScreen = origin + workingPos * scaledUnit;
                 Vector2 previewScreen = origin + previewPos * scaledUnit;
                 Handles.color = BranchPreviewTintColor;
                 Handles.DrawDottedLine(
@@ -440,17 +442,17 @@ namespace RogueliteAutoBattler.Editor.Windows
 
                 if (_branchPreviewSettings.mirrorEnabled)
                 {
+                    Vector2 mirrorSourceScreen = origin + mirrorSourcePos * scaledUnit;
                     float halfSpan = Mathf.Max(canvasRect.width, canvasRect.height);
-                    MirrorAxisGeometry.ComputeAxisEndpoints(parentScreen, _branchPreviewSettings.mirrorAxisDegrees, halfSpan, out var axisStart, out var axisEnd);
+                    MirrorAxisGeometry.ComputeAxisEndpoints(mirrorSourceScreen, _branchPreviewSettings.mirrorAxisDegrees, halfSpan, out var axisStart, out var axisEnd);
                     Handles.color = MirrorAxisLineColor;
                     Handles.DrawDottedLine(new Vector3(axisStart.x, axisStart.y, 0f), new Vector3(axisEnd.x, axisEnd.y, 0f), BranchPreviewDottedSegmentSize);
 
-                    float mirrorAngleDegrees = BranchPlacement.MirrorAngle(_branchPreviewSettings.angleDegrees, _branchPreviewSettings.mirrorAxisDegrees);
-                    Vector2 mirrorPos = BranchPlacement.ComputeBranchPosition(parentPos, _branchPreviewSettings.distance, mirrorAngleDegrees);
+                    Vector2 mirrorPos = BranchPlacement.ComputeBranchPosition(mirrorSourcePos, _branchPreviewSettings.distance, mirrorAngle);
                     Vector2 mirrorScreen = origin + mirrorPos * scaledUnit;
                     Handles.color = MirrorPreviewTintColor;
                     Handles.DrawDottedLine(
-                        new Vector3(parentScreen.x, parentScreen.y, 0f),
+                        new Vector3(mirrorSourceScreen.x, mirrorSourceScreen.y, 0f),
                         new Vector3(mirrorScreen.x, mirrorScreen.y, 0f),
                         BranchPreviewDottedSegmentSize);
                     Handles.DrawWireDisc(new Vector3(mirrorScreen.x, mirrorScreen.y, 0f), Vector3.forward, halfNode);
@@ -768,14 +770,7 @@ namespace RogueliteAutoBattler.Editor.Windows
 
             if (GUILayout.Button("Create Branch from Selected"))
             {
-                _branchPreviewPreviousTab = _activeTab;
-                _branchPreviewActive = true;
-                _branchPreviewParentIndex = _selectedNodeIndex;
-                _branchPreviewSettings = _lastBranchPreviewSettings;
-                _branchPreviewSettings.angleDegrees = BranchPlacement.ComputeDefaultAngle(_data.Nodes[_selectedNodeIndex].position);
-                _lastMirrorWarning = null;
-                _activeTab = TabIndexBranch;
-                Repaint();
+                BeginBranchPreview(_selectedNodeIndex);
             }
 
             EditorGUILayout.Space(SectionSpacingSmall);
@@ -871,6 +866,7 @@ namespace RogueliteAutoBattler.Editor.Windows
             {
                 Undo.RegisterCompleteObjectUndo(_data, "Delete Node");
                 _data.RemoveNode(node.id);
+                ClampMirrorSourceIndex();
                 EditorUtility.SetDirty(_data);
                 AssetDatabase.SaveAssets();
                 _selectedNodeIndex = -1;
@@ -908,9 +904,12 @@ namespace RogueliteAutoBattler.Editor.Windows
                 Repaint();
 
             EditorGUI.BeginChangeCheck();
-            _branchPreviewSettings.mirrorEnabled = EditorGUILayout.Toggle(MirrorEnabledLabel, _branchPreviewSettings.mirrorEnabled);
+            bool newMirrorEnabled = EditorGUILayout.Toggle(MirrorEnabledLabel, _branchPreviewSettings.mirrorEnabled);
             if (EditorGUI.EndChangeCheck())
+            {
+                SetMirrorEnabled(newMirrorEnabled);
                 Repaint();
+            }
 
             if (_branchPreviewSettings.mirrorEnabled)
             {
@@ -937,10 +936,83 @@ namespace RogueliteAutoBattler.Editor.Windows
             EditorGUILayout.EndHorizontal();
         }
 
-        private void CancelBranchPreview()
+        internal void BeginBranchPreview(int parentIndex)
+        {
+            _branchPreviewPreviousTab = _activeTab;
+            _branchPreviewActive = true;
+            _branchPreviewParentIndex = parentIndex;
+            _branchPreviewSettings = _lastBranchPreviewSettings;
+            if (_data != null && parentIndex >= 0 && parentIndex < _data.Nodes.Count)
+                _branchPreviewSettings.angleDegrees = BranchPlacement.ComputeDefaultAngle(_data.Nodes[parentIndex].position);
+            _mirrorSourceNodeIndex = -1;
+            _lastMirrorWarning = null;
+            _activeTab = TabIndexBranch;
+            Repaint();
+        }
+
+        internal void EndBranchPreview()
         {
             _branchPreviewActive = false;
             _branchPreviewParentIndex = -1;
+            _mirrorSourceNodeIndex = -1;
+        }
+
+        internal void SetMirrorEnabled(bool enabled)
+        {
+            bool wasEnabled = _branchPreviewSettings.mirrorEnabled;
+            _branchPreviewSettings.mirrorEnabled = enabled;
+            if (!wasEnabled && enabled)
+                _angleRelativeToAxis = false;
+        }
+
+        internal void ClampMirrorSourceIndex()
+        {
+            int nodeCount = _data != null ? _data.Nodes.Count : 0;
+            if (_mirrorSourceNodeIndex < -1 || _mirrorSourceNodeIndex >= nodeCount)
+                _mirrorSourceNodeIndex = -1;
+        }
+
+        internal (Vector2 workingPos, Vector2 mirrorSourcePos, float resolvedAngle, float mirrorAngle) ComputeResolvedPreview()
+        {
+            if (!_branchPreviewActive || _data == null
+                || _branchPreviewParentIndex < 0 || _branchPreviewParentIndex >= _data.Nodes.Count)
+            {
+                return (Vector2.zero, Vector2.zero, 0f, 0f);
+            }
+
+            Vector2 workingPos = _data.Nodes[_branchPreviewParentIndex].position;
+            Vector2 mirrorSourcePos = BranchPlacement.ResolveMirrorSourcePosition(
+                _data.Nodes, _branchPreviewParentIndex, _mirrorSourceNodeIndex);
+            float resolvedAngle = BranchPlacement.ResolveAbsoluteAngle(
+                _branchPreviewSettings.angleDegrees,
+                _branchPreviewSettings.mirrorAxisDegrees,
+                _angleRelativeToAxis);
+            float mirrorAngle = BranchPlacement.MirrorAngle(resolvedAngle, _branchPreviewSettings.mirrorAxisDegrees);
+            return (workingPos, mirrorSourcePos, resolvedAngle, mirrorAngle);
+        }
+
+        internal int MirrorSourceNodeIndexForTests
+        {
+            get => _mirrorSourceNodeIndex;
+            set => _mirrorSourceNodeIndex = value;
+        }
+
+        internal bool AngleRelativeToAxisForTests
+        {
+            get => _angleRelativeToAxis;
+            set => _angleRelativeToAxis = value;
+        }
+
+        internal ref BranchPreviewSettings BranchPreviewSettingsForTests => ref _branchPreviewSettings;
+
+        internal void SetDataForTests(SkillTreeData data)
+        {
+            _data = data;
+        }
+
+        private void CancelBranchPreview()
+        {
+            EndBranchPreview();
             _activeTab = _branchPreviewPreviousTab;
             _lastMirrorWarning = null;
             Repaint();
@@ -966,8 +1038,8 @@ namespace RogueliteAutoBattler.Editor.Windows
             _lastMirrorWarning = result.WarningMessage;
             _lastBranchPreviewSettings = _branchPreviewSettings;
             _selectedNodeIndex = _data.Nodes.Count - 1;
-            _branchPreviewActive = false;
-            _branchPreviewParentIndex = -1;
+            EndBranchPreview();
+            ClampMirrorSourceIndex();
             _activeTab = TabIndexNode;
             Repaint();
         }

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -137,8 +137,8 @@ namespace RogueliteAutoBattler.Editor.Windows
         private int _branchPreviewPreviousTab;
         private BranchPreviewSettings _branchPreviewSettings = BranchPreviewSettings.Defaults;
         private BranchPreviewSettings _lastBranchPreviewSettings = BranchPreviewSettings.Defaults;
-        private int _mirrorSourceNodeIndex = -1;
-        private bool _angleRelativeToAxis;
+        private int _mirrorSourceNodeIndex = BranchPlacement.NoMirrorSourceOverride;
+        private bool _angleIsRelativeToMirrorAxis;
         private string _lastMirrorWarning;
         private bool _connectionsFoldoutOpen = true;
         private readonly List<NodeConnectionsInspector.ConnectionRow> _connectionsBuffer = new List<NodeConnectionsInspector.ConnectionRow>();
@@ -429,9 +429,9 @@ namespace RogueliteAutoBattler.Editor.Windows
             }
             if (_branchPreviewActive && _branchPreviewParentIndex >= 0 && _branchPreviewParentIndex < _data.Nodes.Count)
             {
-                var (workingPos, mirrorSourcePos, resolvedAngle, mirrorAngle) = ComputeResolvedPreview();
-                Vector2 previewPos = BranchPlacement.ComputeBranchPosition(workingPos, _branchPreviewSettings.distance, resolvedAngle);
-                Vector2 parentScreen = origin + workingPos * scaledUnit;
+                var (parentPos, mirrorSourcePos, resolvedAngle, mirrorBranchAngle) = ComputeResolvedPreview();
+                Vector2 previewPos = BranchPlacement.ComputeBranchPosition(parentPos, _branchPreviewSettings.distance, resolvedAngle);
+                Vector2 parentScreen = origin + parentPos * scaledUnit;
                 Vector2 previewScreen = origin + previewPos * scaledUnit;
                 Handles.color = BranchPreviewTintColor;
                 Handles.DrawDottedLine(
@@ -448,7 +448,7 @@ namespace RogueliteAutoBattler.Editor.Windows
                     Handles.color = MirrorAxisLineColor;
                     Handles.DrawDottedLine(new Vector3(axisStart.x, axisStart.y, 0f), new Vector3(axisEnd.x, axisEnd.y, 0f), BranchPreviewDottedSegmentSize);
 
-                    Vector2 mirrorPos = BranchPlacement.ComputeBranchPosition(mirrorSourcePos, _branchPreviewSettings.distance, mirrorAngle);
+                    Vector2 mirrorPos = BranchPlacement.ComputeBranchPosition(mirrorSourcePos, _branchPreviewSettings.distance, mirrorBranchAngle);
                     Vector2 mirrorScreen = origin + mirrorPos * scaledUnit;
                     Handles.color = MirrorPreviewTintColor;
                     Handles.DrawDottedLine(
@@ -866,7 +866,7 @@ namespace RogueliteAutoBattler.Editor.Windows
             {
                 Undo.RegisterCompleteObjectUndo(_data, "Delete Node");
                 _data.RemoveNode(node.id);
-                ClampMirrorSourceIndex();
+                InvalidateMirrorSourceIfOutOfRange();
                 EditorUtility.SetDirty(_data);
                 AssetDatabase.SaveAssets();
                 _selectedNodeIndex = -1;
@@ -944,7 +944,8 @@ namespace RogueliteAutoBattler.Editor.Windows
             _branchPreviewSettings = _lastBranchPreviewSettings;
             if (_data != null && parentIndex >= 0 && parentIndex < _data.Nodes.Count)
                 _branchPreviewSettings.angleDegrees = BranchPlacement.ComputeDefaultAngle(_data.Nodes[parentIndex].position);
-            _mirrorSourceNodeIndex = -1;
+            _mirrorSourceNodeIndex = BranchPlacement.NoMirrorSourceOverride;
+            _angleIsRelativeToMirrorAxis = false;
             _lastMirrorWarning = null;
             _activeTab = TabIndexBranch;
             Repaint();
@@ -954,7 +955,8 @@ namespace RogueliteAutoBattler.Editor.Windows
         {
             _branchPreviewActive = false;
             _branchPreviewParentIndex = -1;
-            _mirrorSourceNodeIndex = -1;
+            _mirrorSourceNodeIndex = BranchPlacement.NoMirrorSourceOverride;
+            _angleIsRelativeToMirrorAxis = false;
         }
 
         internal void SetMirrorEnabled(bool enabled)
@@ -962,17 +964,17 @@ namespace RogueliteAutoBattler.Editor.Windows
             bool wasEnabled = _branchPreviewSettings.mirrorEnabled;
             _branchPreviewSettings.mirrorEnabled = enabled;
             if (!wasEnabled && enabled)
-                _angleRelativeToAxis = false;
+                _angleIsRelativeToMirrorAxis = false;
         }
 
-        internal void ClampMirrorSourceIndex()
+        internal void InvalidateMirrorSourceIfOutOfRange()
         {
             int nodeCount = _data != null ? _data.Nodes.Count : 0;
-            if (_mirrorSourceNodeIndex < -1 || _mirrorSourceNodeIndex >= nodeCount)
-                _mirrorSourceNodeIndex = -1;
+            if (_mirrorSourceNodeIndex >= nodeCount)
+                _mirrorSourceNodeIndex = BranchPlacement.NoMirrorSourceOverride;
         }
 
-        internal (Vector2 workingPos, Vector2 mirrorSourcePos, float resolvedAngle, float mirrorAngle) ComputeResolvedPreview()
+        internal (Vector2 parentPos, Vector2 mirrorSourcePos, float resolvedAngle, float mirrorBranchAngle) ComputeResolvedPreview()
         {
             if (!_branchPreviewActive || _data == null
                 || _branchPreviewParentIndex < 0 || _branchPreviewParentIndex >= _data.Nodes.Count)
@@ -980,15 +982,14 @@ namespace RogueliteAutoBattler.Editor.Windows
                 return (Vector2.zero, Vector2.zero, 0f, 0f);
             }
 
-            Vector2 workingPos = _data.Nodes[_branchPreviewParentIndex].position;
-            Vector2 mirrorSourcePos = BranchPlacement.ResolveMirrorSourcePosition(
-                _data.Nodes, _branchPreviewParentIndex, _mirrorSourceNodeIndex);
-            float resolvedAngle = BranchPlacement.ResolveAbsoluteAngle(
+            return BranchPlacement.ResolveBranchPlan(
+                _data.Nodes,
+                _branchPreviewParentIndex,
+                _mirrorSourceNodeIndex,
                 _branchPreviewSettings.angleDegrees,
                 _branchPreviewSettings.mirrorAxisDegrees,
-                _angleRelativeToAxis);
-            float mirrorAngle = BranchPlacement.MirrorAngle(resolvedAngle, _branchPreviewSettings.mirrorAxisDegrees);
-            return (workingPos, mirrorSourcePos, resolvedAngle, mirrorAngle);
+                _angleIsRelativeToMirrorAxis,
+                _branchPreviewSettings.mirrorEnabled);
         }
 
         internal int MirrorSourceNodeIndexForTests
@@ -997,13 +998,11 @@ namespace RogueliteAutoBattler.Editor.Windows
             set => _mirrorSourceNodeIndex = value;
         }
 
-        internal bool AngleRelativeToAxisForTests
+        internal bool AngleIsRelativeToMirrorAxisForTests
         {
-            get => _angleRelativeToAxis;
-            set => _angleRelativeToAxis = value;
+            get => _angleIsRelativeToMirrorAxis;
+            set => _angleIsRelativeToMirrorAxis = value;
         }
-
-        internal ref BranchPreviewSettings BranchPreviewSettingsForTests => ref _branchPreviewSettings;
 
         internal void SetDataForTests(SkillTreeData data)
         {
@@ -1028,7 +1027,23 @@ namespace RogueliteAutoBattler.Editor.Windows
                 : MirrorPairGenerator.UndoLabelSingleNode;
             Undo.RegisterCompleteObjectUndo(_data, undoLabel);
 
-            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, _branchPreviewSettings);
+            var (_, mirrorSourcePos, resolvedAngle, mirrorBranchAngle) = BranchPlacement.ResolveBranchPlan(
+                _data.Nodes,
+                parentIndex,
+                _mirrorSourceNodeIndex,
+                _branchPreviewSettings.angleDegrees,
+                _branchPreviewSettings.mirrorAxisDegrees,
+                _angleIsRelativeToMirrorAxis,
+                _branchPreviewSettings.mirrorEnabled);
+
+            var result = MirrorPairGenerator.TryGenerate(
+                _data,
+                parentIndex,
+                _branchPreviewSettings.distance,
+                resolvedAngle,
+                _branchPreviewSettings.mirrorEnabled,
+                mirrorSourcePos,
+                mirrorBranchAngle);
 
             EditorUtility.SetDirty(_data);
             AssetDatabase.SaveAssets();
@@ -1039,7 +1054,7 @@ namespace RogueliteAutoBattler.Editor.Windows
             _lastBranchPreviewSettings = _branchPreviewSettings;
             _selectedNodeIndex = _data.Nodes.Count - 1;
             EndBranchPreview();
-            ClampMirrorSourceIndex();
+            InvalidateMirrorSourceIfOutOfRange();
             _activeTab = TabIndexNode;
             Repaint();
         }

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -42,6 +42,8 @@ namespace RogueliteAutoBattler.Editor.Windows
         private static readonly Color BranchPreviewTintColor = new Color(1f, 1f, 1f, 0.4f);
         private static readonly Color MirrorAxisLineColor = new Color(1f, 0.92f, 0.016f, 0.6f);
         private static readonly Color MirrorPreviewTintColor = new Color(0f, 1f, 1f, 0.4f);
+        private static readonly Color MirrorSourceRingColor = new Color(1f, 0.92f, 0.016f, 0.5f);
+        private const float MirrorSourceRingRadiusBoost = 1.5f;
 
         private static readonly GUIContent LabelUnitSize = new GUIContent("Unit Size");
         private static readonly GUIContent LabelNodeSize = new GUIContent("Node Size");
@@ -61,6 +63,12 @@ namespace RogueliteAutoBattler.Editor.Windows
         private const float MaxMirrorAxisDegrees = 360f;
         private const string MirrorEnabledLabel = "Mirror";
         private const string MirrorAxisSliderLabel = "Mirror Axis (deg, 0=vertical)";
+        private const string PickMirrorSourceLabel = "Pick Mirror Source";
+        private const string CancelPickLabel = "Cancel pick";
+        private const string MirrorSourceStatusWorkingNode = "currently: working node";
+        private const string MirrorSourceStatusFormatNode = "currently: Node {0}";
+        private const string AngleRelativeToggleLabel = "Angle from mirror axis";
+        private const string ResolvedAbsoluteAngleFormat = "Resolved absolute angle: {0:F1}°";
 
         private const float MinSnapThresholdUnits = 0f;
         private const float MaxSnapThresholdUnits = 2f;
@@ -139,6 +147,7 @@ namespace RogueliteAutoBattler.Editor.Windows
         private BranchPreviewSettings _lastBranchPreviewSettings = BranchPreviewSettings.Defaults;
         private int _mirrorSourceNodeIndex = BranchPlacement.NoMirrorSourceOverride;
         private bool _angleIsRelativeToMirrorAxis;
+        private bool _pickMirrorSourceMode;
         private string _lastMirrorWarning;
         private bool _connectionsFoldoutOpen = true;
         private readonly List<NodeConnectionsInspector.ConnectionRow> _connectionsBuffer = new List<NodeConnectionsInspector.ConnectionRow>();
@@ -398,6 +407,13 @@ namespace RogueliteAutoBattler.Editor.Windows
                 Vector3 center3D = new Vector3(screenPos.x, screenPos.y, 0f);
                 Rect nodeRect = new Rect(screenPos.x - halfNode, screenPos.y - halfNode, scaledNodeSize, scaledNodeSize);
 
+                if (_branchPreviewActive && _branchPreviewSettings.mirrorEnabled
+                    && _mirrorSourceNodeIndex == i && i != _branchPreviewParentIndex)
+                {
+                    Handles.color = MirrorSourceRingColor;
+                    Handles.DrawSolidDisc(center3D, Vector3.forward, halfNode + scaledBorder * MirrorSourceRingRadiusBoost);
+                }
+
                 Handles.color = (i == _selectedNodeIndex) ? _data.BorderSelectedColor : _data.BorderNormalColor;
                 Handles.DrawSolidDisc(center3D, Vector3.forward, halfNode + scaledBorder);
 
@@ -508,7 +524,33 @@ namespace RogueliteAutoBattler.Editor.Windows
         private void HandleCanvasInput(Rect canvasRect)
         {
             Event evt = Event.current;
+
+            if (_pickMirrorSourceMode && evt.type == EventType.KeyDown && evt.keyCode == KeyCode.Escape)
+            {
+                CancelMirrorSourcePickMode();
+                evt.Use();
+                return;
+            }
+
             if (!canvasRect.Contains(evt.mousePosition)) return;
+
+            if (_pickMirrorSourceMode && evt.type == EventType.MouseDown && evt.button == LeftMouseButton && !evt.alt)
+            {
+                Vector2 pickCenter = new Vector2(canvasRect.width * 0.5f, canvasRect.height * 0.5f);
+                Vector2 pickOrigin = pickCenter + _canvasOffset;
+                int pickHitIndex = HitTestNode(evt.mousePosition, pickOrigin, _data.Nodes, _data.UnitSize, _data.NodeSize, _canvasZoom);
+                if (pickHitIndex >= 0 && pickHitIndex != _branchPreviewParentIndex)
+                {
+                    _mirrorSourceNodeIndex = pickHitIndex;
+                    CancelMirrorSourcePickMode();
+                }
+                else
+                {
+                    CancelMirrorSourcePickMode();
+                }
+                evt.Use();
+                return;
+            }
 
             if (evt.type == EventType.ScrollWheel)
             {
@@ -920,6 +962,36 @@ namespace RogueliteAutoBattler.Editor.Windows
                     MirrorAxisPersistence.Save(_branchPreviewSettings.mirrorAxisDegrees);
                     Repaint();
                 }
+
+                if (GUILayout.Button(_pickMirrorSourceMode ? CancelPickLabel : PickMirrorSourceLabel))
+                {
+                    if (_pickMirrorSourceMode)
+                        CancelMirrorSourcePickMode();
+                    else
+                        StartMirrorSourcePickMode();
+                }
+
+                string sourceStatus = _mirrorSourceNodeIndex == BranchPlacement.NoMirrorSourceOverride
+                    ? MirrorSourceStatusWorkingNode
+                    : string.Format(MirrorSourceStatusFormatNode, _mirrorSourceNodeIndex);
+                EditorGUILayout.LabelField(sourceStatus);
+
+                EditorGUI.BeginChangeCheck();
+                bool newRel = EditorGUILayout.Toggle(AngleRelativeToggleLabel, _angleIsRelativeToMirrorAxis);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    _angleIsRelativeToMirrorAxis = newRel;
+                    Repaint();
+                }
+
+                if (_angleIsRelativeToMirrorAxis)
+                {
+                    float resolvedAbs = BranchPlacement.ResolveAbsoluteAngle(
+                        _branchPreviewSettings.angleDegrees,
+                        _branchPreviewSettings.mirrorAxisDegrees,
+                        true);
+                    EditorGUILayout.LabelField(string.Format(ResolvedAbsoluteAngleFormat, resolvedAbs));
+                }
             }
 
             if (!string.IsNullOrEmpty(_lastMirrorWarning))
@@ -946,6 +1018,7 @@ namespace RogueliteAutoBattler.Editor.Windows
                 _branchPreviewSettings.angleDegrees = BranchPlacement.ComputeDefaultAngle(_data.Nodes[parentIndex].position);
             _mirrorSourceNodeIndex = BranchPlacement.NoMirrorSourceOverride;
             _angleIsRelativeToMirrorAxis = false;
+            _pickMirrorSourceMode = false;
             _lastMirrorWarning = null;
             _activeTab = TabIndexBranch;
             Repaint();
@@ -957,6 +1030,7 @@ namespace RogueliteAutoBattler.Editor.Windows
             _branchPreviewParentIndex = -1;
             _mirrorSourceNodeIndex = BranchPlacement.NoMirrorSourceOverride;
             _angleIsRelativeToMirrorAxis = false;
+            _pickMirrorSourceMode = false;
         }
 
         internal void SetMirrorEnabled(bool enabled)
@@ -965,7 +1039,26 @@ namespace RogueliteAutoBattler.Editor.Windows
             _branchPreviewSettings.mirrorEnabled = enabled;
             if (!wasEnabled && enabled)
                 _angleIsRelativeToMirrorAxis = false;
+            if (!enabled)
+                _pickMirrorSourceMode = false;
         }
+
+        internal void StartMirrorSourcePickMode()
+        {
+            if (!_branchPreviewActive || !_branchPreviewSettings.mirrorEnabled) return;
+            _pickMirrorSourceMode = true;
+            Repaint();
+        }
+
+        internal void CancelMirrorSourcePickMode()
+        {
+            _pickMirrorSourceMode = false;
+            Repaint();
+        }
+
+        internal bool IsMirrorSourcePickModeActiveForTests => _pickMirrorSourceMode;
+
+        internal bool PendingDragArmForTests => _pendingDragArm;
 
         internal void InvalidateMirrorSourceIfOutOfRange()
         {

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -40,10 +40,11 @@ namespace RogueliteAutoBattler.Editor.Windows
         private static readonly Color CrosshairColor = new Color(0.4f, 0.4f, 0.4f, 1f);
         private static readonly Color GridLineColor = new Color(0.2f, 0.2f, 0.2f, 1f);
         private static readonly Color BranchPreviewTintColor = new Color(1f, 1f, 1f, 0.4f);
-        private static readonly Color MirrorAxisLineColor = new Color(1f, 0.92f, 0.016f, 0.6f);
+        private static readonly Color MirrorAccentRgb = new Color(1f, 0.92f, 0.016f);
+        private static readonly Color MirrorAxisLineColor = new Color(MirrorAccentRgb.r, MirrorAccentRgb.g, MirrorAccentRgb.b, 0.6f);
         private static readonly Color MirrorPreviewTintColor = new Color(0f, 1f, 1f, 0.4f);
-        private static readonly Color MirrorSourceRingColor = new Color(1f, 0.92f, 0.016f, 0.5f);
-        private const float MirrorSourceRingRadiusBoost = 1.5f;
+        private static readonly Color MirrorSourceRingColor = new Color(MirrorAccentRgb.r, MirrorAccentRgb.g, MirrorAccentRgb.b, 0.5f);
+        private const float MirrorSourceRingThicknessMultiplier = 1.5f;
 
         private static readonly GUIContent LabelUnitSize = new GUIContent("Unit Size");
         private static readonly GUIContent LabelNodeSize = new GUIContent("Node Size");
@@ -64,9 +65,9 @@ namespace RogueliteAutoBattler.Editor.Windows
         private const string MirrorEnabledLabel = "Mirror";
         private const string MirrorAxisSliderLabel = "Mirror Axis (deg, 0=vertical)";
         private const string PickMirrorSourceLabel = "Pick Mirror Source";
-        private const string CancelPickLabel = "Cancel pick";
-        private const string MirrorSourceStatusWorkingNode = "currently: working node";
-        private const string MirrorSourceStatusFormatNode = "currently: Node {0}";
+        private const string CancelPickLabel = "Cancel Pick";
+        private const string MirrorSourceStatusWorkingNode = "Source: working node";
+        private const string MirrorSourceStatusFormatNode = "Source: Node {0}";
         private const string AngleRelativeToggleLabel = "Angle from mirror axis";
         private const string ResolvedAbsoluteAngleFormat = "Resolved absolute angle: {0:F1}°";
 
@@ -366,8 +367,7 @@ namespace RogueliteAutoBattler.Editor.Windows
 
             GUI.BeginClip(canvasRect);
 
-            Vector2 center = new Vector2(canvasRect.width * 0.5f, canvasRect.height * 0.5f);
-            Vector2 origin = center + _canvasOffset;
+            Vector2 origin = ComputeCanvasOrigin(canvasRect);
 
             DrawGrid(canvasRect, origin);
 
@@ -411,7 +411,7 @@ namespace RogueliteAutoBattler.Editor.Windows
                     && _mirrorSourceNodeIndex == i && i != _branchPreviewParentIndex)
                 {
                     Handles.color = MirrorSourceRingColor;
-                    Handles.DrawSolidDisc(center3D, Vector3.forward, halfNode + scaledBorder * MirrorSourceRingRadiusBoost);
+                    Handles.DrawSolidDisc(center3D, Vector3.forward, halfNode + scaledBorder * MirrorSourceRingThicknessMultiplier);
                 }
 
                 Handles.color = (i == _selectedNodeIndex) ? _data.BorderSelectedColor : _data.BorderNormalColor;
@@ -536,18 +536,10 @@ namespace RogueliteAutoBattler.Editor.Windows
 
             if (_pickMirrorSourceMode && evt.type == EventType.MouseDown && evt.button == LeftMouseButton && !evt.alt)
             {
-                Vector2 pickCenter = new Vector2(canvasRect.width * 0.5f, canvasRect.height * 0.5f);
-                Vector2 pickOrigin = pickCenter + _canvasOffset;
-                int pickHitIndex = HitTestNode(evt.mousePosition, pickOrigin, _data.Nodes, _data.UnitSize, _data.NodeSize, _canvasZoom);
+                int pickHitIndex = HitTestNodeAt(evt.mousePosition, canvasRect);
                 if (pickHitIndex >= 0 && pickHitIndex != _branchPreviewParentIndex)
-                {
                     _mirrorSourceNodeIndex = pickHitIndex;
-                    CancelMirrorSourcePickMode();
-                }
-                else
-                {
-                    CancelMirrorSourcePickMode();
-                }
+                CancelMirrorSourcePickMode();
                 evt.Use();
                 return;
             }
@@ -562,11 +554,7 @@ namespace RogueliteAutoBattler.Editor.Windows
 
             if (evt.type == EventType.MouseDown && evt.button == LeftMouseButton && !evt.alt)
             {
-                Vector2 mouseInCanvas = evt.mousePosition;
-                Vector2 center = new Vector2(canvasRect.width * 0.5f, canvasRect.height * 0.5f);
-                Vector2 origin = center + _canvasOffset;
-
-                int hitIndex = HitTestNode(mouseInCanvas, origin, _data.Nodes, _data.UnitSize, _data.NodeSize, _canvasZoom);
+                int hitIndex = HitTestNodeAt(evt.mousePosition, canvasRect);
                 _selectedNodeIndex = hitIndex;
                 if (!_branchPreviewActive)
                     _activeTab = hitIndex >= 0 ? TabIndexNode : TabIndexSkillTree;
@@ -963,35 +951,7 @@ namespace RogueliteAutoBattler.Editor.Windows
                     Repaint();
                 }
 
-                if (GUILayout.Button(_pickMirrorSourceMode ? CancelPickLabel : PickMirrorSourceLabel))
-                {
-                    if (_pickMirrorSourceMode)
-                        CancelMirrorSourcePickMode();
-                    else
-                        StartMirrorSourcePickMode();
-                }
-
-                string sourceStatus = _mirrorSourceNodeIndex == BranchPlacement.NoMirrorSourceOverride
-                    ? MirrorSourceStatusWorkingNode
-                    : string.Format(MirrorSourceStatusFormatNode, _mirrorSourceNodeIndex);
-                EditorGUILayout.LabelField(sourceStatus);
-
-                EditorGUI.BeginChangeCheck();
-                bool newRel = EditorGUILayout.Toggle(AngleRelativeToggleLabel, _angleIsRelativeToMirrorAxis);
-                if (EditorGUI.EndChangeCheck())
-                {
-                    _angleIsRelativeToMirrorAxis = newRel;
-                    Repaint();
-                }
-
-                if (_angleIsRelativeToMirrorAxis)
-                {
-                    float resolvedAbs = BranchPlacement.ResolveAbsoluteAngle(
-                        _branchPreviewSettings.angleDegrees,
-                        _branchPreviewSettings.mirrorAxisDegrees,
-                        true);
-                    EditorGUILayout.LabelField(string.Format(ResolvedAbsoluteAngleFormat, resolvedAbs));
-                }
+                DrawMirrorSourceControls();
             }
 
             if (!string.IsNullOrEmpty(_lastMirrorWarning))
@@ -1006,6 +966,42 @@ namespace RogueliteAutoBattler.Editor.Windows
             if (GUILayout.Button("Cancel"))
                 CancelBranchPreview();
             EditorGUILayout.EndHorizontal();
+        }
+
+        private void DrawMirrorSourceControls()
+        {
+            if (GUILayout.Button(_pickMirrorSourceMode ? CancelPickLabel : PickMirrorSourceLabel))
+                TogglePickMirrorSourceMode();
+
+            string sourceStatus = _mirrorSourceNodeIndex == BranchPlacement.NoMirrorSourceOverride
+                ? MirrorSourceStatusWorkingNode
+                : string.Format(MirrorSourceStatusFormatNode, _mirrorSourceNodeIndex);
+            EditorGUILayout.LabelField(sourceStatus);
+
+            EditorGUI.BeginChangeCheck();
+            bool newRel = EditorGUILayout.Toggle(AngleRelativeToggleLabel, _angleIsRelativeToMirrorAxis);
+            if (EditorGUI.EndChangeCheck())
+            {
+                _angleIsRelativeToMirrorAxis = newRel;
+                Repaint();
+            }
+
+            if (_angleIsRelativeToMirrorAxis)
+            {
+                float resolvedAbs = BranchPlacement.ResolveAbsoluteAngle(
+                    _branchPreviewSettings.angleDegrees,
+                    _branchPreviewSettings.mirrorAxisDegrees,
+                    true);
+                EditorGUILayout.LabelField(string.Format(ResolvedAbsoluteAngleFormat, resolvedAbs));
+            }
+        }
+
+        internal void TogglePickMirrorSourceMode()
+        {
+            if (_pickMirrorSourceMode)
+                CancelMirrorSourcePickMode();
+            else
+                StartMirrorSourcePickMode();
         }
 
         internal void BeginBranchPreview(int parentIndex)
@@ -1057,8 +1053,6 @@ namespace RogueliteAutoBattler.Editor.Windows
         }
 
         internal bool IsMirrorSourcePickModeActiveForTests => _pickMirrorSourceMode;
-
-        internal bool PendingDragArmForTests => _pendingDragArm;
 
         internal void InvalidateMirrorSourceIfOutOfRange()
         {
@@ -1150,6 +1144,16 @@ namespace RogueliteAutoBattler.Editor.Windows
             InvalidateMirrorSourceIfOutOfRange();
             _activeTab = TabIndexNode;
             Repaint();
+        }
+
+        private Vector2 ComputeCanvasOrigin(Rect canvasRect)
+        {
+            return new Vector2(canvasRect.width * 0.5f, canvasRect.height * 0.5f) + _canvasOffset;
+        }
+
+        private int HitTestNodeAt(Vector2 mousePos, Rect canvasRect)
+        {
+            return HitTestNode(mousePos, ComputeCanvasOrigin(canvasRect), _data.Nodes, _data.UnitSize, _data.NodeSize, _canvasZoom);
         }
 
         internal static int HitTestNode(Vector2 mousePos, Vector2 origin, IReadOnlyList<SkillTreeData.SkillNodeEntry> nodes, float unitSize, float nodeSize, float zoom)

--- a/Assets/Tests/EditMode/BranchPlacementResolveAbsoluteAngleTests.cs
+++ b/Assets/Tests/EditMode/BranchPlacementResolveAbsoluteAngleTests.cs
@@ -1,0 +1,66 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Editor.Tools;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class BranchPlacementResolveAbsoluteAngleTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        [Test]
+        public void ResolveAbsoluteAngle_NotRelative_ReturnsInputUnchanged()
+        {
+            float result = BranchPlacement.ResolveAbsoluteAngle(73f, 200f, isRelative: false);
+
+            Assert.That(result, Is.EqualTo(73f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveAbsoluteAngle_Relative_AddsAxisToRelative()
+        {
+            float result = BranchPlacement.ResolveAbsoluteAngle(0f, 45f, isRelative: true);
+
+            Assert.That(result, Is.EqualTo(45f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveAbsoluteAngle_Relative_WrapsAround360()
+        {
+            float result = BranchPlacement.ResolveAbsoluteAngle(90f, 270f, isRelative: true);
+
+            Assert.That(result, Is.EqualTo(0f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveAbsoluteAngle_Relative_NormalizesNegativeRelative()
+        {
+            float result = BranchPlacement.ResolveAbsoluteAngle(-10f, 0f, isRelative: true);
+
+            Assert.That(result, Is.EqualTo(350f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveAbsoluteAngle_Relative_NormalizesAxisAbove360()
+        {
+            float result = BranchPlacement.ResolveAbsoluteAngle(30f, 420f, isRelative: true);
+
+            Assert.That(result, Is.EqualTo(90f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveAbsoluteAngle_Relative_AlwaysProducesResultInUnitCircleRange()
+        {
+            System.Random random = new System.Random(424242);
+            for (int i = 0; i < 32; i++)
+            {
+                float relative = (float)(random.NextDouble() * 1440.0 - 720.0);
+                float axis = (float)(random.NextDouble() * 1440.0 - 720.0);
+
+                float result = BranchPlacement.ResolveAbsoluteAngle(relative, axis, isRelative: true);
+
+                Assert.That(result, Is.GreaterThanOrEqualTo(0f));
+                Assert.That(result, Is.LessThan(360f));
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/BranchPlacementResolveAbsoluteAngleTests.cs.meta
+++ b/Assets/Tests/EditMode/BranchPlacementResolveAbsoluteAngleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 27c265297f7a50c4aa6bffe12d8a01a1

--- a/Assets/Tests/EditMode/BranchPlacementResolveBranchPlanTests.cs
+++ b/Assets/Tests/EditMode/BranchPlacementResolveBranchPlanTests.cs
@@ -1,0 +1,192 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Editor.Tools;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class BranchPlacementResolveBranchPlanTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        private static SkillTreeData.SkillNodeEntry MakeNode(int id, Vector2 position)
+        {
+            return new SkillTreeData.SkillNodeEntry
+            {
+                id = id,
+                position = position,
+                connectedNodeIds = new List<int>(),
+                costType = SkillTreeData.CostType.Gold,
+                maxLevel = 1,
+                baseCost = 1,
+                costMultiplierOdd = 1f,
+                costMultiplierEven = 1f,
+                costAdditivePerLevel = 0,
+                statModifierType = StatType.Hp,
+                statModifierMode = SkillTreeData.StatModifierMode.Flat,
+                statModifierValuePerLevel = 1f
+            };
+        }
+
+        private static List<SkillTreeData.SkillNodeEntry> MakeStandardNodes()
+        {
+            return new List<SkillTreeData.SkillNodeEntry>
+            {
+                MakeNode(0, Vector2.zero),
+                MakeNode(1, new Vector2(2f, 0f)),
+                MakeNode(2, new Vector2(0f, 3f))
+            };
+        }
+
+        [Test]
+        public void ResolveBranchPlan_MirrorDisabled_RelativeFlagIgnored()
+        {
+            var nodes = MakeStandardNodes();
+
+            var (parentPos, mirrorSourcePos, resolvedAngle, mirrorBranchAngle) = BranchPlacement.ResolveBranchPlan(
+                nodes,
+                parentIndex: 1,
+                mirrorSourceOverrideIndex: 2,
+                angleDegrees: 30f,
+                mirrorAxisDegrees: 45f,
+                angleIsRelativeToMirrorAxis: true,
+                mirrorEnabled: false);
+
+            Assert.That(parentPos.x, Is.EqualTo(2f).Within(Tolerance));
+            Assert.That(parentPos.y, Is.EqualTo(0f).Within(Tolerance));
+            Assert.That(resolvedAngle, Is.EqualTo(30f).Within(Tolerance));
+            Assert.That(mirrorBranchAngle, Is.EqualTo(30f).Within(Tolerance));
+            Assert.That(mirrorSourcePos.x, Is.EqualTo(0f).Within(Tolerance));
+            Assert.That(mirrorSourcePos.y, Is.EqualTo(3f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveBranchPlan_MirrorEnabled_RelativeFalse_UsesAngleDirectly()
+        {
+            var nodes = MakeStandardNodes();
+
+            var (_, _, resolvedAngle, mirrorBranchAngle) = BranchPlacement.ResolveBranchPlan(
+                nodes,
+                parentIndex: 1,
+                mirrorSourceOverrideIndex: BranchPlacement.NoMirrorSourceOverride,
+                angleDegrees: 60f,
+                mirrorAxisDegrees: 90f,
+                angleIsRelativeToMirrorAxis: false,
+                mirrorEnabled: true);
+
+            Assert.That(resolvedAngle, Is.EqualTo(60f).Within(Tolerance));
+            Assert.That(mirrorBranchAngle, Is.EqualTo(BranchPlacement.MirrorAngle(60f, 90f)).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveBranchPlan_MirrorEnabled_RelativeTrue_AddsAxisToAngle()
+        {
+            var nodes = MakeStandardNodes();
+
+            var (_, _, resolvedAngle, mirrorBranchAngle) = BranchPlacement.ResolveBranchPlan(
+                nodes,
+                parentIndex: 1,
+                mirrorSourceOverrideIndex: BranchPlacement.NoMirrorSourceOverride,
+                angleDegrees: 30f,
+                mirrorAxisDegrees: 45f,
+                angleIsRelativeToMirrorAxis: true,
+                mirrorEnabled: true);
+
+            Assert.That(resolvedAngle, Is.EqualTo(75f).Within(Tolerance));
+            Assert.That(mirrorBranchAngle, Is.EqualTo(BranchPlacement.MirrorAngle(75f, 45f)).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveBranchPlan_OverrideValid_UsesOverrideForMirrorSource()
+        {
+            var nodes = MakeStandardNodes();
+
+            var (parentPos, mirrorSourcePos, _, _) = BranchPlacement.ResolveBranchPlan(
+                nodes,
+                parentIndex: 1,
+                mirrorSourceOverrideIndex: 2,
+                angleDegrees: 0f,
+                mirrorAxisDegrees: 0f,
+                angleIsRelativeToMirrorAxis: false,
+                mirrorEnabled: true);
+
+            Assert.That(parentPos.x, Is.EqualTo(2f).Within(Tolerance));
+            Assert.That(parentPos.y, Is.EqualTo(0f).Within(Tolerance));
+            Assert.That(mirrorSourcePos.x, Is.EqualTo(0f).Within(Tolerance));
+            Assert.That(mirrorSourcePos.y, Is.EqualTo(3f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveBranchPlan_OverrideOutOfRange_FallsBackToParentPos()
+        {
+            var nodes = MakeStandardNodes();
+
+            var (parentPos, mirrorSourcePos, _, _) = BranchPlacement.ResolveBranchPlan(
+                nodes,
+                parentIndex: 1,
+                mirrorSourceOverrideIndex: 99,
+                angleDegrees: 0f,
+                mirrorAxisDegrees: 0f,
+                angleIsRelativeToMirrorAxis: false,
+                mirrorEnabled: true);
+
+            Assert.That(mirrorSourcePos.x, Is.EqualTo(parentPos.x).Within(Tolerance));
+            Assert.That(mirrorSourcePos.y, Is.EqualTo(parentPos.y).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveBranchPlan_OverrideNoOverrideSentinel_FallsBackToParentPos()
+        {
+            var nodes = MakeStandardNodes();
+
+            var (parentPos, mirrorSourcePos, _, _) = BranchPlacement.ResolveBranchPlan(
+                nodes,
+                parentIndex: 1,
+                mirrorSourceOverrideIndex: BranchPlacement.NoMirrorSourceOverride,
+                angleDegrees: 0f,
+                mirrorAxisDegrees: 0f,
+                angleIsRelativeToMirrorAxis: false,
+                mirrorEnabled: true);
+
+            Assert.That(mirrorSourcePos.x, Is.EqualTo(parentPos.x).Within(Tolerance));
+            Assert.That(mirrorSourcePos.y, Is.EqualTo(parentPos.y).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveBranchPlan_RelativePlusAxis_WrapsAround360()
+        {
+            var nodes = MakeStandardNodes();
+
+            var (_, _, resolvedAngle, _) = BranchPlacement.ResolveBranchPlan(
+                nodes,
+                parentIndex: 1,
+                mirrorSourceOverrideIndex: BranchPlacement.NoMirrorSourceOverride,
+                angleDegrees: 90f,
+                mirrorAxisDegrees: 270f,
+                angleIsRelativeToMirrorAxis: true,
+                mirrorEnabled: true);
+
+            Assert.That(resolvedAngle, Is.EqualTo(0f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveBranchPlan_NullNodes_ReturnsZeroPositions()
+        {
+            var (parentPos, mirrorSourcePos, resolvedAngle, mirrorBranchAngle) = BranchPlacement.ResolveBranchPlan(
+                nodes: null,
+                parentIndex: 0,
+                mirrorSourceOverrideIndex: BranchPlacement.NoMirrorSourceOverride,
+                angleDegrees: 30f,
+                mirrorAxisDegrees: 45f,
+                angleIsRelativeToMirrorAxis: false,
+                mirrorEnabled: true);
+
+            Assert.That(parentPos, Is.EqualTo(Vector2.zero));
+            Assert.That(mirrorSourcePos, Is.EqualTo(Vector2.zero));
+            Assert.That(resolvedAngle, Is.EqualTo(30f).Within(Tolerance));
+            Assert.That(mirrorBranchAngle, Is.EqualTo(BranchPlacement.MirrorAngle(30f, 45f)).Within(Tolerance));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/BranchPlacementResolveBranchPlanTests.cs.meta
+++ b/Assets/Tests/EditMode/BranchPlacementResolveBranchPlanTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8705a5e3173f2794d937bcb24c7ee956

--- a/Assets/Tests/EditMode/BranchPlacementResolveMirrorSourceTests.cs
+++ b/Assets/Tests/EditMode/BranchPlacementResolveMirrorSourceTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Editor.Tools;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class BranchPlacementResolveMirrorSourceTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        private static SkillTreeData.SkillNodeEntry MakeNode(int id, Vector2 position)
+        {
+            return new SkillTreeData.SkillNodeEntry
+            {
+                id = id,
+                position = position,
+                connectedNodeIds = new List<int>(),
+                costType = SkillTreeData.CostType.Gold,
+                maxLevel = 1,
+                baseCost = 1,
+                costMultiplierOdd = 1f,
+                costMultiplierEven = 1f,
+                costAdditivePerLevel = 0,
+                statModifierType = StatType.Hp,
+                statModifierMode = SkillTreeData.StatModifierMode.Flat,
+                statModifierValuePerLevel = 1f
+            };
+        }
+
+        [Test]
+        public void ResolveMirrorSourcePosition_ValidOverride_ReturnsOverridePosition()
+        {
+            var nodes = new List<SkillTreeData.SkillNodeEntry>
+            {
+                MakeNode(0, Vector2.zero),
+                MakeNode(1, new Vector2(2f, 0f)),
+                MakeNode(2, new Vector2(0f, 3f))
+            };
+
+            Vector2 result = BranchPlacement.ResolveMirrorSourcePosition(nodes, parentIndex: 1, sourceOverrideIndex: 2);
+
+            Assert.That(result.x, Is.EqualTo(0f).Within(Tolerance));
+            Assert.That(result.y, Is.EqualTo(3f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveMirrorSourcePosition_OverrideMinusOne_FallsBackToParent()
+        {
+            var nodes = new List<SkillTreeData.SkillNodeEntry>
+            {
+                MakeNode(0, Vector2.zero),
+                MakeNode(1, new Vector2(2f, 0f))
+            };
+
+            Vector2 result = BranchPlacement.ResolveMirrorSourcePosition(nodes, parentIndex: 1, sourceOverrideIndex: -1);
+
+            Assert.That(result.x, Is.EqualTo(2f).Within(Tolerance));
+            Assert.That(result.y, Is.EqualTo(0f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveMirrorSourcePosition_OverrideOutOfRangeHigh_FallsBackToParent()
+        {
+            var nodes = new List<SkillTreeData.SkillNodeEntry>
+            {
+                MakeNode(0, Vector2.zero),
+                MakeNode(1, new Vector2(2f, 0f))
+            };
+
+            Vector2 result = BranchPlacement.ResolveMirrorSourcePosition(nodes, parentIndex: 1, sourceOverrideIndex: 99);
+
+            Assert.That(result.x, Is.EqualTo(2f).Within(Tolerance));
+            Assert.That(result.y, Is.EqualTo(0f).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveMirrorSourcePosition_BothInvalid_ReturnsZero()
+        {
+            var nodes = new List<SkillTreeData.SkillNodeEntry>
+            {
+                MakeNode(0, Vector2.zero)
+            };
+
+            Vector2 result = BranchPlacement.ResolveMirrorSourcePosition(nodes, parentIndex: 99, sourceOverrideIndex: 99);
+
+            Assert.That(result, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void ResolveMirrorSourcePosition_NullNodes_ReturnsZero()
+        {
+            Vector2 result = BranchPlacement.ResolveMirrorSourcePosition(null, parentIndex: 0, sourceOverrideIndex: 0);
+
+            Assert.That(result, Is.EqualTo(Vector2.zero));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/BranchPlacementResolveMirrorSourceTests.cs.meta
+++ b/Assets/Tests/EditMode/BranchPlacementResolveMirrorSourceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 44290fc32c66cea47a32d0d99494545d

--- a/Assets/Tests/EditMode/MirrorPairGeneratorTests.cs
+++ b/Assets/Tests/EditMode/MirrorPairGeneratorTests.cs
@@ -58,13 +58,15 @@ namespace RogueliteAutoBattler.Tests.EditMode
             _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
             int initialCount = _data.Nodes.Count;
 
-            var settings = BranchPreviewSettings.Defaults;
-            settings.distance = 2f;
-            settings.angleDegrees = 90f;
-            settings.mirrorEnabled = false;
-
             int parentIndex = 1;
-            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+            var result = MirrorPairGenerator.TryGenerate(
+                _data,
+                parentIndex,
+                distance: 2f,
+                resolvedAngleDegrees: 90f,
+                mirrorEnabled: false,
+                mirrorSourcePosition: parent.position,
+                mirrorBranchAngleDegrees: 90f);
 
             Assert.IsTrue(result.OriginalCreated);
             Assert.IsFalse(result.MirrorCreated);
@@ -80,22 +82,23 @@ namespace RogueliteAutoBattler.Tests.EditMode
             _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
             int initialCount = _data.Nodes.Count;
 
-            var settings = BranchPreviewSettings.Defaults;
-            settings.distance = 2f;
-            settings.angleDegrees = 60f;
-            settings.mirrorEnabled = true;
-            settings.mirrorAxisDegrees = 0f;
-
             int parentIndex = 1;
             int parentId = parent.id;
-            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+            float mirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
+            var result = MirrorPairGenerator.TryGenerate(
+                _data,
+                parentIndex,
+                distance: 2f,
+                resolvedAngleDegrees: 60f,
+                mirrorEnabled: true,
+                mirrorSourcePosition: parent.position,
+                mirrorBranchAngleDegrees: mirrorAngle);
 
             Assert.IsTrue(result.OriginalCreated);
             Assert.IsTrue(result.MirrorCreated);
             Assert.AreEqual(initialCount + 2, _data.Nodes.Count);
 
-            float expectedMirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
-            Vector2 expectedMirrorPos = SkillTreeGrid.Quantize(BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, expectedMirrorAngle));
+            Vector2 expectedMirrorPos = SkillTreeGrid.Quantize(BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, mirrorAngle));
             var lastNode = _data.Nodes[_data.Nodes.Count - 1];
             Assert.That(lastNode.position.x, Is.EqualTo(expectedMirrorPos.x).Within(Tolerance));
             Assert.That(lastNode.position.y, Is.EqualTo(expectedMirrorPos.y).Within(Tolerance));
@@ -117,21 +120,22 @@ namespace RogueliteAutoBattler.Tests.EditMode
             var parent = MakeNode(1, new Vector2(0f, 3f));
             _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
 
-            float expectedMirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
-            Vector2 expectedMirrorPos = BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, expectedMirrorAngle);
+            float mirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
+            Vector2 expectedMirrorPos = BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, mirrorAngle);
             var blocker = MakeNode(99, expectedMirrorPos);
             _data.AddBranchNode(blocker, SkillTreeData.CentralNodeId);
 
             int initialCount = _data.Nodes.Count;
 
-            var settings = BranchPreviewSettings.Defaults;
-            settings.distance = 2f;
-            settings.angleDegrees = 60f;
-            settings.mirrorEnabled = true;
-            settings.mirrorAxisDegrees = 0f;
-
             int parentIndex = 1;
-            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+            var result = MirrorPairGenerator.TryGenerate(
+                _data,
+                parentIndex,
+                distance: 2f,
+                resolvedAngleDegrees: 60f,
+                mirrorEnabled: true,
+                mirrorSourcePosition: parent.position,
+                mirrorBranchAngleDegrees: mirrorAngle);
 
             Assert.IsTrue(result.OriginalCreated);
             Assert.IsFalse(result.MirrorCreated);
@@ -147,21 +151,22 @@ namespace RogueliteAutoBattler.Tests.EditMode
             var parent = MakeNode(1, new Vector2(0f, 3f));
             _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
 
-            float expectedMirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
-            Vector2 expectedMirrorPos = BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, expectedMirrorAngle);
+            float mirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
+            Vector2 expectedMirrorPos = BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, mirrorAngle);
             var blocker = MakeNode(99, expectedMirrorPos + new Vector2(0.5f, 0f));
             _data.AddBranchNode(blocker, SkillTreeData.CentralNodeId);
 
             int initialCount = _data.Nodes.Count;
 
-            var settings = BranchPreviewSettings.Defaults;
-            settings.distance = 2f;
-            settings.angleDegrees = 60f;
-            settings.mirrorEnabled = true;
-            settings.mirrorAxisDegrees = 0f;
-
             int parentIndex = 1;
-            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+            var result = MirrorPairGenerator.TryGenerate(
+                _data,
+                parentIndex,
+                distance: 2f,
+                resolvedAngleDegrees: 60f,
+                mirrorEnabled: true,
+                mirrorSourcePosition: parent.position,
+                mirrorBranchAngleDegrees: mirrorAngle);
 
             Assert.IsTrue(result.OriginalCreated);
             Assert.IsFalse(result.MirrorCreated);
@@ -177,19 +182,20 @@ namespace RogueliteAutoBattler.Tests.EditMode
             var parent = MakeNode(1, new Vector2(0f, 3f));
             _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
 
-            float expectedMirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
-            Vector2 expectedMirrorPos = BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, expectedMirrorAngle);
+            float mirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
+            Vector2 expectedMirrorPos = BranchPlacement.ComputeBranchPosition(new Vector2(0f, 3f), 2f, mirrorAngle);
             var blocker = MakeNode(99, expectedMirrorPos + new Vector2(1.5f, 0f));
             _data.AddBranchNode(blocker, SkillTreeData.CentralNodeId);
 
-            var settings = BranchPreviewSettings.Defaults;
-            settings.distance = 2f;
-            settings.angleDegrees = 60f;
-            settings.mirrorEnabled = true;
-            settings.mirrorAxisDegrees = 0f;
-
             int parentIndex = 1;
-            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+            var result = MirrorPairGenerator.TryGenerate(
+                _data,
+                parentIndex,
+                distance: 2f,
+                resolvedAngleDegrees: 60f,
+                mirrorEnabled: true,
+                mirrorSourcePosition: parent.position,
+                mirrorBranchAngleDegrees: mirrorAngle);
 
             Assert.IsTrue(result.OriginalCreated);
             Assert.IsTrue(result.MirrorCreated);
@@ -204,14 +210,16 @@ namespace RogueliteAutoBattler.Tests.EditMode
             _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
             int initialCount = _data.Nodes.Count;
 
-            var settings = BranchPreviewSettings.Defaults;
-            settings.distance = 2f;
-            settings.angleDegrees = 0f;
-            settings.mirrorEnabled = true;
-            settings.mirrorAxisDegrees = 0f;
-
             int parentIndex = 1;
-            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+            float mirrorAngle = BranchPlacement.MirrorAngle(0f, 0f);
+            var result = MirrorPairGenerator.TryGenerate(
+                _data,
+                parentIndex,
+                distance: 2f,
+                resolvedAngleDegrees: 0f,
+                mirrorEnabled: true,
+                mirrorSourcePosition: parent.position,
+                mirrorBranchAngleDegrees: mirrorAngle);
 
             Assert.IsTrue(result.OriginalCreated);
             Assert.IsFalse(result.MirrorCreated);
@@ -227,14 +235,16 @@ namespace RogueliteAutoBattler.Tests.EditMode
             var parent = MakeNode(5, new Vector2(0f, 3f));
             _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central, parent });
 
-            var settings = BranchPreviewSettings.Defaults;
-            settings.distance = 2f;
-            settings.angleDegrees = 60f;
-            settings.mirrorEnabled = true;
-            settings.mirrorAxisDegrees = 0f;
-
             int parentIndex = 1;
-            var result = MirrorPairGenerator.TryGenerate(_data, parentIndex, settings);
+            float mirrorAngle = BranchPlacement.MirrorAngle(60f, 0f);
+            var result = MirrorPairGenerator.TryGenerate(
+                _data,
+                parentIndex,
+                distance: 2f,
+                resolvedAngleDegrees: 60f,
+                mirrorEnabled: true,
+                mirrorSourcePosition: parent.position,
+                mirrorBranchAngleDegrees: mirrorAngle);
 
             Assert.AreEqual(6, result.OriginalNewId);
             Assert.AreEqual(7, result.MirrorNewId);
@@ -243,7 +253,14 @@ namespace RogueliteAutoBattler.Tests.EditMode
         [Test]
         public void TryGenerate_DataNull_ReturnsInvalid()
         {
-            var result = MirrorPairGenerator.TryGenerate(null, 0, BranchPreviewSettings.Defaults);
+            var result = MirrorPairGenerator.TryGenerate(
+                null,
+                parentIndex: 0,
+                distance: 1f,
+                resolvedAngleDegrees: 0f,
+                mirrorEnabled: false,
+                mirrorSourcePosition: Vector2.zero,
+                mirrorBranchAngleDegrees: 0f);
 
             Assert.IsFalse(result.OriginalCreated);
             Assert.IsFalse(result.MirrorCreated);
@@ -256,7 +273,14 @@ namespace RogueliteAutoBattler.Tests.EditMode
             _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry> { central });
             int initialCount = _data.Nodes.Count;
 
-            var result = MirrorPairGenerator.TryGenerate(_data, 999, BranchPreviewSettings.Defaults);
+            var result = MirrorPairGenerator.TryGenerate(
+                _data,
+                parentIndex: 999,
+                distance: 1f,
+                resolvedAngleDegrees: 0f,
+                mirrorEnabled: false,
+                mirrorSourcePosition: Vector2.zero,
+                mirrorBranchAngleDegrees: 0f);
 
             Assert.IsFalse(result.OriginalCreated);
             Assert.IsFalse(result.MirrorCreated);

--- a/Assets/Tests/EditMode/SkillTreeDesignerMirrorStateIntegrationTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeDesignerMirrorStateIntegrationTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Editor.Tools;
+using RogueliteAutoBattler.Editor.Windows;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class SkillTreeDesignerMirrorStateIntegrationTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        private SkillTreeData _data;
+        private SkillTreeDesignerWindow _window;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _data = ScriptableObject.CreateInstance<SkillTreeData>();
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry>
+            {
+                MakeNode(0, Vector2.zero),
+                MakeNode(1, new Vector2(2f, 0f)),
+                MakeNode(2, new Vector2(0f, 3f))
+            });
+            _window = ScriptableObject.CreateInstance<SkillTreeDesignerWindow>();
+            _window.SetDataForTests(_data);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_window);
+            Object.DestroyImmediate(_data);
+        }
+
+        private static SkillTreeData.SkillNodeEntry MakeNode(int id, Vector2 position)
+        {
+            return new SkillTreeData.SkillNodeEntry
+            {
+                id = id,
+                position = position,
+                connectedNodeIds = new List<int>(),
+                costType = SkillTreeData.CostType.Gold,
+                maxLevel = 1,
+                baseCost = 1,
+                costMultiplierOdd = 1f,
+                costMultiplierEven = 1f,
+                costAdditivePerLevel = 0,
+                statModifierType = StatType.Hp,
+                statModifierMode = SkillTreeData.StatModifierMode.Flat,
+                statModifierValuePerLevel = 1f
+            };
+        }
+
+        [Test]
+        public void BeginBranchPreview_ProducesDefaultMirrorSourceAndRelativeFlag()
+        {
+            _window.MirrorSourceNodeIndexForTests = 2;
+
+            _window.BeginBranchPreview(parentIndex: 1);
+
+            Assert.AreEqual(-1, _window.MirrorSourceNodeIndexForTests);
+            Assert.IsFalse(_window.AngleRelativeToAxisForTests);
+        }
+
+        [Test]
+        public void SetMirrorEnabled_FalseToTrue_ResetsAngleRelativeToAxis()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.AngleRelativeToAxisForTests = true;
+
+            _window.SetMirrorEnabled(false);
+            _window.SetMirrorEnabled(true);
+
+            Assert.IsFalse(_window.AngleRelativeToAxisForTests);
+        }
+
+        [Test]
+        public void ComputeResolvedPreview_WithOverrideAndRelative_ProducesExpectedValues()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.MirrorSourceNodeIndexForTests = 2;
+            _window.BranchPreviewSettingsForTests.angleDegrees = 30f;
+            _window.BranchPreviewSettingsForTests.mirrorAxisDegrees = 45f;
+            _window.AngleRelativeToAxisForTests = true;
+
+            var (workingPos, mirrorSourcePos, resolvedAngle, mirrorAngle) = _window.ComputeResolvedPreview();
+
+            Assert.That(workingPos.x, Is.EqualTo(2f).Within(Tolerance));
+            Assert.That(workingPos.y, Is.EqualTo(0f).Within(Tolerance));
+            Assert.That(mirrorSourcePos.x, Is.EqualTo(0f).Within(Tolerance));
+            Assert.That(mirrorSourcePos.y, Is.EqualTo(3f).Within(Tolerance));
+            Assert.That(resolvedAngle, Is.EqualTo(75f).Within(Tolerance));
+            Assert.That(mirrorAngle, Is.EqualTo(BranchPlacement.MirrorAngle(75f, 45f)).Within(Tolerance));
+        }
+
+        [Test]
+        public void EndBranchPreview_ResetsMirrorSourceIndex()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.MirrorSourceNodeIndexForTests = 2;
+
+            _window.EndBranchPreview();
+
+            Assert.AreEqual(-1, _window.MirrorSourceNodeIndexForTests);
+        }
+
+        [Test]
+        public void ClampMirrorSourceIndex_OutOfRangeAfterShrink_ResetsToMinusOne()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.MirrorSourceNodeIndexForTests = 2;
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry>
+            {
+                MakeNode(0, Vector2.zero),
+                MakeNode(1, new Vector2(2f, 0f))
+            });
+
+            _window.ClampMirrorSourceIndex();
+
+            Assert.AreEqual(-1, _window.MirrorSourceNodeIndexForTests);
+        }
+
+        [Test]
+        public void ComputeResolvedPreview_OverrideOutOfRange_FallsBackToWorkingPos()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.MirrorSourceNodeIndexForTests = 99;
+
+            var (workingPos, mirrorSourcePos, _, _) = _window.ComputeResolvedPreview();
+
+            Assert.That(mirrorSourcePos.x, Is.EqualTo(workingPos.x).Within(Tolerance));
+            Assert.That(mirrorSourcePos.y, Is.EqualTo(workingPos.y).Within(Tolerance));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/SkillTreeDesignerMirrorStateIntegrationTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeDesignerMirrorStateIntegrationTests.cs
@@ -59,42 +59,51 @@ namespace RogueliteAutoBattler.Tests.EditMode
         public void BeginBranchPreview_ProducesDefaultMirrorSourceAndRelativeFlag()
         {
             _window.MirrorSourceNodeIndexForTests = 2;
+            _window.AngleIsRelativeToMirrorAxisForTests = true;
 
             _window.BeginBranchPreview(parentIndex: 1);
 
-            Assert.AreEqual(-1, _window.MirrorSourceNodeIndexForTests);
-            Assert.IsFalse(_window.AngleRelativeToAxisForTests);
+            Assert.AreEqual(BranchPlacement.NoMirrorSourceOverride, _window.MirrorSourceNodeIndexForTests);
+            Assert.IsFalse(_window.AngleIsRelativeToMirrorAxisForTests);
         }
 
         [Test]
         public void SetMirrorEnabled_FalseToTrue_ResetsAngleRelativeToAxis()
         {
             _window.BeginBranchPreview(parentIndex: 1);
-            _window.AngleRelativeToAxisForTests = true;
+            _window.AngleIsRelativeToMirrorAxisForTests = true;
 
             _window.SetMirrorEnabled(false);
             _window.SetMirrorEnabled(true);
 
-            Assert.IsFalse(_window.AngleRelativeToAxisForTests);
+            Assert.IsFalse(_window.AngleIsRelativeToMirrorAxisForTests);
         }
 
         [Test]
-        public void ComputeResolvedPreview_WithOverrideAndRelative_ProducesExpectedValues()
+        public void ResolveBranchPlan_WithOverrideAndRelative_ProducesExpectedValues()
         {
-            _window.BeginBranchPreview(parentIndex: 1);
-            _window.MirrorSourceNodeIndexForTests = 2;
-            _window.BranchPreviewSettingsForTests.angleDegrees = 30f;
-            _window.BranchPreviewSettingsForTests.mirrorAxisDegrees = 45f;
-            _window.AngleRelativeToAxisForTests = true;
+            var nodes = new List<SkillTreeData.SkillNodeEntry>
+            {
+                MakeNode(0, Vector2.zero),
+                MakeNode(1, new Vector2(2f, 0f)),
+                MakeNode(2, new Vector2(0f, 3f))
+            };
 
-            var (workingPos, mirrorSourcePos, resolvedAngle, mirrorAngle) = _window.ComputeResolvedPreview();
+            var (parentPos, mirrorSourcePos, resolvedAngle, mirrorBranchAngle) = BranchPlacement.ResolveBranchPlan(
+                nodes,
+                parentIndex: 1,
+                mirrorSourceOverrideIndex: 2,
+                angleDegrees: 30f,
+                mirrorAxisDegrees: 45f,
+                angleIsRelativeToMirrorAxis: true,
+                mirrorEnabled: true);
 
-            Assert.That(workingPos.x, Is.EqualTo(2f).Within(Tolerance));
-            Assert.That(workingPos.y, Is.EqualTo(0f).Within(Tolerance));
+            Assert.That(parentPos.x, Is.EqualTo(2f).Within(Tolerance));
+            Assert.That(parentPos.y, Is.EqualTo(0f).Within(Tolerance));
             Assert.That(mirrorSourcePos.x, Is.EqualTo(0f).Within(Tolerance));
             Assert.That(mirrorSourcePos.y, Is.EqualTo(3f).Within(Tolerance));
             Assert.That(resolvedAngle, Is.EqualTo(75f).Within(Tolerance));
-            Assert.That(mirrorAngle, Is.EqualTo(BranchPlacement.MirrorAngle(75f, 45f)).Within(Tolerance));
+            Assert.That(mirrorBranchAngle, Is.EqualTo(BranchPlacement.MirrorAngle(75f, 45f)).Within(Tolerance));
         }
 
         [Test]
@@ -105,11 +114,22 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             _window.EndBranchPreview();
 
-            Assert.AreEqual(-1, _window.MirrorSourceNodeIndexForTests);
+            Assert.AreEqual(BranchPlacement.NoMirrorSourceOverride, _window.MirrorSourceNodeIndexForTests);
         }
 
         [Test]
-        public void ClampMirrorSourceIndex_OutOfRangeAfterShrink_ResetsToMinusOne()
+        public void EndBranchPreview_ResetsAngleIsRelativeToMirrorAxis()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.AngleIsRelativeToMirrorAxisForTests = true;
+
+            _window.EndBranchPreview();
+
+            Assert.IsFalse(_window.AngleIsRelativeToMirrorAxisForTests);
+        }
+
+        [Test]
+        public void InvalidateMirrorSourceIfOutOfRange_OutOfRangeAfterShrink_ResetsToNoOverride()
         {
             _window.BeginBranchPreview(parentIndex: 1);
             _window.MirrorSourceNodeIndexForTests = 2;
@@ -119,21 +139,21 @@ namespace RogueliteAutoBattler.Tests.EditMode
                 MakeNode(1, new Vector2(2f, 0f))
             });
 
-            _window.ClampMirrorSourceIndex();
+            _window.InvalidateMirrorSourceIfOutOfRange();
 
-            Assert.AreEqual(-1, _window.MirrorSourceNodeIndexForTests);
+            Assert.AreEqual(BranchPlacement.NoMirrorSourceOverride, _window.MirrorSourceNodeIndexForTests);
         }
 
         [Test]
-        public void ComputeResolvedPreview_OverrideOutOfRange_FallsBackToWorkingPos()
+        public void ComputeResolvedPreview_OverrideOutOfRange_FallsBackToParentPos()
         {
             _window.BeginBranchPreview(parentIndex: 1);
             _window.MirrorSourceNodeIndexForTests = 99;
 
-            var (workingPos, mirrorSourcePos, _, _) = _window.ComputeResolvedPreview();
+            var (parentPos, mirrorSourcePos, _, _) = _window.ComputeResolvedPreview();
 
-            Assert.That(mirrorSourcePos.x, Is.EqualTo(workingPos.x).Within(Tolerance));
-            Assert.That(mirrorSourcePos.y, Is.EqualTo(workingPos.y).Within(Tolerance));
+            Assert.That(mirrorSourcePos.x, Is.EqualTo(parentPos.x).Within(Tolerance));
+            Assert.That(mirrorSourcePos.y, Is.EqualTo(parentPos.y).Within(Tolerance));
         }
     }
 }

--- a/Assets/Tests/EditMode/SkillTreeDesignerMirrorStateIntegrationTests.cs.meta
+++ b/Assets/Tests/EditMode/SkillTreeDesignerMirrorStateIntegrationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 59bedad55f978f5429c6792a94737de3

--- a/Assets/Tests/EditMode/SkillTreeDesignerPickMirrorSourceTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeDesignerPickMirrorSourceTests.cs
@@ -132,16 +132,5 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             Assert.IsFalse(_window.IsMirrorSourcePickModeActiveForTests);
         }
-
-        [Test]
-        public void StartMirrorSourcePickMode_DoesNotArmPendingDrag()
-        {
-            _window.BeginBranchPreview(parentIndex: 1);
-            _window.SetMirrorEnabled(true);
-
-            _window.StartMirrorSourcePickMode();
-
-            Assert.IsFalse(_window.PendingDragArmForTests);
-        }
     }
 }

--- a/Assets/Tests/EditMode/SkillTreeDesignerPickMirrorSourceTests.cs
+++ b/Assets/Tests/EditMode/SkillTreeDesignerPickMirrorSourceTests.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using RogueliteAutoBattler.Combat.Core;
+using RogueliteAutoBattler.Data;
+using RogueliteAutoBattler.Editor.Tools;
+using RogueliteAutoBattler.Editor.Windows;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class SkillTreeDesignerPickMirrorSourceTests
+    {
+        private SkillTreeData _data;
+        private SkillTreeDesignerWindow _window;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _data = ScriptableObject.CreateInstance<SkillTreeData>();
+            _data.InitializeForTest(new List<SkillTreeData.SkillNodeEntry>
+            {
+                MakeNode(0, Vector2.zero),
+                MakeNode(1, new Vector2(2f, 0f)),
+                MakeNode(2, new Vector2(0f, 3f))
+            });
+            _window = ScriptableObject.CreateInstance<SkillTreeDesignerWindow>();
+            _window.SetDataForTests(_data);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_window);
+            Object.DestroyImmediate(_data);
+        }
+
+        private static SkillTreeData.SkillNodeEntry MakeNode(int id, Vector2 position)
+        {
+            return new SkillTreeData.SkillNodeEntry
+            {
+                id = id,
+                position = position,
+                connectedNodeIds = new List<int>(),
+                costType = SkillTreeData.CostType.Gold,
+                maxLevel = 1,
+                baseCost = 1,
+                costMultiplierOdd = 1f,
+                costMultiplierEven = 1f,
+                costAdditivePerLevel = 0,
+                statModifierType = StatType.Hp,
+                statModifierMode = SkillTreeData.StatModifierMode.Flat,
+                statModifierValuePerLevel = 1f
+            };
+        }
+
+        [Test]
+        public void StartMirrorSourcePickMode_WhenMirrorEnabled_SetsActive()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.SetMirrorEnabled(true);
+
+            _window.StartMirrorSourcePickMode();
+
+            Assert.IsTrue(_window.IsMirrorSourcePickModeActiveForTests);
+        }
+
+        [Test]
+        public void StartMirrorSourcePickMode_WhenMirrorDisabled_RemainsInactive()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.SetMirrorEnabled(false);
+
+            _window.StartMirrorSourcePickMode();
+
+            Assert.IsFalse(_window.IsMirrorSourcePickModeActiveForTests);
+        }
+
+        [Test]
+        public void StartMirrorSourcePickMode_WhenPreviewInactive_RemainsInactive()
+        {
+            _window.StartMirrorSourcePickMode();
+
+            Assert.IsFalse(_window.IsMirrorSourcePickModeActiveForTests);
+        }
+
+        [Test]
+        public void CancelMirrorSourcePickMode_WhenActive_DeactivatesIt()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.SetMirrorEnabled(true);
+            _window.StartMirrorSourcePickMode();
+
+            _window.CancelMirrorSourcePickMode();
+
+            Assert.IsFalse(_window.IsMirrorSourcePickModeActiveForTests);
+        }
+
+        [Test]
+        public void EndBranchPreview_WhenPickModeActive_DeactivatesIt()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.SetMirrorEnabled(true);
+            _window.MirrorSourceNodeIndexForTests = 2;
+            _window.StartMirrorSourcePickMode();
+
+            _window.EndBranchPreview();
+
+            Assert.IsFalse(_window.IsMirrorSourcePickModeActiveForTests);
+            Assert.AreEqual(BranchPlacement.NoMirrorSourceOverride, _window.MirrorSourceNodeIndexForTests);
+        }
+
+        [Test]
+        public void SetMirrorEnabled_False_WhenPickModeActive_DeactivatesIt()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.SetMirrorEnabled(true);
+            _window.StartMirrorSourcePickMode();
+
+            _window.SetMirrorEnabled(false);
+
+            Assert.IsFalse(_window.IsMirrorSourcePickModeActiveForTests);
+        }
+
+        [Test]
+        public void BeginBranchPreview_ResetsPickMode()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.SetMirrorEnabled(true);
+            _window.StartMirrorSourcePickMode();
+
+            _window.BeginBranchPreview(parentIndex: 2);
+
+            Assert.IsFalse(_window.IsMirrorSourcePickModeActiveForTests);
+        }
+
+        [Test]
+        public void StartMirrorSourcePickMode_DoesNotArmPendingDrag()
+        {
+            _window.BeginBranchPreview(parentIndex: 1);
+            _window.SetMirrorEnabled(true);
+
+            _window.StartMirrorSourcePickMode();
+
+            Assert.IsFalse(_window.PendingDragArmForTests);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/SkillTreeDesignerPickMirrorSourceTests.cs.meta
+++ b/Assets/Tests/EditMode/SkillTreeDesignerPickMirrorSourceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 64c40e34054aa3248806d46418e3cc01


### PR DESCRIPTION
## Summary
- Inspector: "Pick Mirror Source" button (one-shot pick mode), status label, "Angle from mirror axis" toggle with resolved-absolute readout. Visible only when Mirror is enabled during branch creation.
- Canvas: pick-mode short-circuits MouseDown to designate a different node as the mirror anchor without disturbing selection or drag arming. Esc / outside-click / parent-click cancels.
- Visual: yellow-tinted ring on the picked source (drawn under the selection ring).
- Math: `BranchPlacement.ResolveBranchPlan` is the single source of truth for parent/source positions and resolved/mirror angles, consumed by both the preview draw path and `MirrorPairGenerator.TryGenerate` — preview and committed result cannot diverge.
- No EditorPrefs persistence (intentional). Resets on `BeginBranchPreview`, `EndBranchPreview`, and `SetMirrorEnabled(false)`.

Closes #292.

## Test plan
- [x] EditMode: 458/458 (29 new tests across BranchPlacementResolveAbsoluteAngleTests, BranchPlacementResolveMirrorSourceTests, BranchPlacementResolveBranchPlanTests, SkillTreeDesignerMirrorStateIntegrationTests, SkillTreeDesignerPickMirrorSourceTests; 11 retargeted call-sites in MirrorPairGeneratorTests)
- [x] PlayMode: 366/366
- [x] MirrorPartnerFinder.FindPartnerIndex invocation byte-identical (drag-flow partner discovery untouched by source-picking and relative-angle toggle)
- [ ] Manual: pick a non-working node as mirror source → axis line + cyan branch pivot on the picked node, working node still selected
- [ ] Manual: enable relative angle → slider becomes offset-from-axis, readout shows resolved absolute degrees

Generated with Claude Code