### PR TITLE
feat(skilltree-editor): persist branch creation form values (#296)

### DIFF
--- a/Assets/Scripts/Editor/Tools/BranchPreviewSettingsPersistence.cs
+++ b/Assets/Scripts/Editor/Tools/BranchPreviewSettingsPersistence.cs
@@ -1,0 +1,47 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Editor.Tools
+{
+    internal static class BranchPreviewSettingsPersistence
+    {
+        internal const string DistanceKey = "SkillTreeDesigner.BranchDistance";
+        internal const string AngleKey = "SkillTreeDesigner.BranchAngleDegrees";
+        internal const string MirrorEnabledKey = "SkillTreeDesigner.BranchMirrorEnabled";
+
+        public static BranchPreviewSettings Load()
+        {
+            BranchPreviewSettings settings = BranchPreviewSettings.Defaults;
+
+            if (EditorPrefs.HasKey(DistanceKey))
+                settings.distance = EditorPrefs.GetFloat(DistanceKey);
+
+            if (EditorPrefs.HasKey(AngleKey))
+                settings.angleDegrees = EditorPrefs.GetFloat(AngleKey);
+
+            if (EditorPrefs.HasKey(MirrorEnabledKey))
+                settings.mirrorEnabled = EditorPrefs.GetBool(MirrorEnabledKey);
+
+            MirrorAxisPersistence.ApplyTo(ref settings);
+
+            return settings;
+        }
+
+        public static void Save(in BranchPreviewSettings settings)
+        {
+            EditorPrefs.SetFloat(DistanceKey, settings.distance);
+            EditorPrefs.SetFloat(AngleKey, settings.angleDegrees);
+            EditorPrefs.SetBool(MirrorEnabledKey, settings.mirrorEnabled);
+        }
+
+        public static bool HasPersistedAngle()
+        {
+            return EditorPrefs.HasKey(AngleKey);
+        }
+
+        public static float ResolveInitialAngle(bool hasPersisted, float persisted, Vector2 parentPos)
+        {
+            return hasPersisted ? persisted : BranchPlacement.ComputeDefaultAngle(parentPos);
+        }
+    }
+}

--- a/Assets/Scripts/Editor/Tools/BranchPreviewSettingsPersistence.cs
+++ b/Assets/Scripts/Editor/Tools/BranchPreviewSettingsPersistence.cs
@@ -9,7 +9,7 @@ namespace RogueliteAutoBattler.Editor.Tools
         internal const string AngleKey = "SkillTreeDesigner.BranchAngleDegrees";
         internal const string MirrorEnabledKey = "SkillTreeDesigner.BranchMirrorEnabled";
 
-        public static BranchPreviewSettings Load()
+        internal static BranchPreviewSettings Load()
         {
             BranchPreviewSettings settings = BranchPreviewSettings.Defaults;
 
@@ -22,24 +22,28 @@ namespace RogueliteAutoBattler.Editor.Tools
             if (EditorPrefs.HasKey(MirrorEnabledKey))
                 settings.mirrorEnabled = EditorPrefs.GetBool(MirrorEnabledKey);
 
-            MirrorAxisPersistence.ApplyTo(ref settings);
-
             return settings;
         }
 
-        public static void Save(in BranchPreviewSettings settings)
+        internal static void Save(in BranchPreviewSettings settings)
         {
             EditorPrefs.SetFloat(DistanceKey, settings.distance);
             EditorPrefs.SetFloat(AngleKey, settings.angleDegrees);
             EditorPrefs.SetBool(MirrorEnabledKey, settings.mirrorEnabled);
         }
 
-        public static bool HasPersistedAngle()
+        internal static bool HasPersistedAngle()
         {
             return EditorPrefs.HasKey(AngleKey);
         }
 
-        public static float ResolveInitialAngle(bool hasPersisted, float persisted, Vector2 parentPos)
+        internal static float ResolveInitialAngle(Vector2 parentPos)
+        {
+            float persisted = EditorPrefs.GetFloat(AngleKey, BranchPreviewSettings.Defaults.angleDegrees);
+            return ResolveInitialAngle(HasPersistedAngle(), persisted, parentPos);
+        }
+
+        internal static float ResolveInitialAngle(bool hasPersisted, float persisted, Vector2 parentPos)
         {
             return hasPersisted ? persisted : BranchPlacement.ComputeDefaultAngle(parentPos);
         }

--- a/Assets/Scripts/Editor/Tools/BranchPreviewSettingsPersistence.cs.meta
+++ b/Assets/Scripts/Editor/Tools/BranchPreviewSettingsPersistence.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 747364b0cd7e0af4ea88cbd9a1d5de0d

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -182,8 +182,8 @@ namespace RogueliteAutoBattler.Editor.Windows
             var initialEntry = ResolveInitialTreeEntry();
             BindAsset(initialEntry);
             RefreshActivePointerCache();
-            MirrorAxisPersistence.ApplyTo(ref _branchPreviewSettings);
-            MirrorAxisPersistence.ApplyTo(ref _lastBranchPreviewSettings);
+            _lastBranchPreviewSettings = BranchPreviewSettingsPersistence.Load();
+            _branchPreviewSettings = _lastBranchPreviewSettings;
         }
 
         private void RefreshTreeList()
@@ -926,18 +926,25 @@ namespace RogueliteAutoBattler.Editor.Windows
             EditorGUI.BeginChangeCheck();
             _branchPreviewSettings.distance = EditorGUILayout.Slider("Distance", _branchPreviewSettings.distance, MinBranchPreviewDistance, MaxBranchPreviewDistance);
             if (EditorGUI.EndChangeCheck())
+            {
+                BranchPreviewSettingsPersistence.Save(_branchPreviewSettings);
                 Repaint();
+            }
 
             EditorGUI.BeginChangeCheck();
             _branchPreviewSettings.angleDegrees = EditorGUILayout.Slider(AngleSliderLabel, _branchPreviewSettings.angleDegrees, MinBranchAngleDegrees, MaxBranchAngleDegrees);
             if (EditorGUI.EndChangeCheck())
+            {
+                BranchPreviewSettingsPersistence.Save(_branchPreviewSettings);
                 Repaint();
+            }
 
             EditorGUI.BeginChangeCheck();
             bool newMirrorEnabled = EditorGUILayout.Toggle(MirrorEnabledLabel, _branchPreviewSettings.mirrorEnabled);
             if (EditorGUI.EndChangeCheck())
             {
                 SetMirrorEnabled(newMirrorEnabled);
+                BranchPreviewSettingsPersistence.Save(_branchPreviewSettings);
                 Repaint();
             }
 
@@ -1011,7 +1018,10 @@ namespace RogueliteAutoBattler.Editor.Windows
             _branchPreviewParentIndex = parentIndex;
             _branchPreviewSettings = _lastBranchPreviewSettings;
             if (_data != null && parentIndex >= 0 && parentIndex < _data.Nodes.Count)
-                _branchPreviewSettings.angleDegrees = BranchPlacement.ComputeDefaultAngle(_data.Nodes[parentIndex].position);
+                _branchPreviewSettings.angleDegrees = BranchPreviewSettingsPersistence.ResolveInitialAngle(
+                    BranchPreviewSettingsPersistence.HasPersistedAngle(),
+                    _lastBranchPreviewSettings.angleDegrees,
+                    _data.Nodes[parentIndex].position);
             _mirrorSourceNodeIndex = BranchPlacement.NoMirrorSourceOverride;
             _angleIsRelativeToMirrorAxis = false;
             _pickMirrorSourceMode = false;
@@ -1139,6 +1149,7 @@ namespace RogueliteAutoBattler.Editor.Windows
 
             _lastMirrorWarning = result.WarningMessage;
             _lastBranchPreviewSettings = _branchPreviewSettings;
+            BranchPreviewSettingsPersistence.Save(_branchPreviewSettings);
             _selectedNodeIndex = _data.Nodes.Count - 1;
             EndBranchPreview();
             InvalidateMirrorSourceIfOutOfRange();

--- a/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
+++ b/Assets/Scripts/Editor/Windows/SkillTreeDesignerWindow.cs
@@ -183,6 +183,7 @@ namespace RogueliteAutoBattler.Editor.Windows
             BindAsset(initialEntry);
             RefreshActivePointerCache();
             _lastBranchPreviewSettings = BranchPreviewSettingsPersistence.Load();
+            MirrorAxisPersistence.ApplyTo(ref _lastBranchPreviewSettings);
             _branchPreviewSettings = _lastBranchPreviewSettings;
         }
 
@@ -1019,8 +1020,6 @@ namespace RogueliteAutoBattler.Editor.Windows
             _branchPreviewSettings = _lastBranchPreviewSettings;
             if (_data != null && parentIndex >= 0 && parentIndex < _data.Nodes.Count)
                 _branchPreviewSettings.angleDegrees = BranchPreviewSettingsPersistence.ResolveInitialAngle(
-                    BranchPreviewSettingsPersistence.HasPersistedAngle(),
-                    _lastBranchPreviewSettings.angleDegrees,
                     _data.Nodes[parentIndex].position);
             _mirrorSourceNodeIndex = BranchPlacement.NoMirrorSourceOverride;
             _angleIsRelativeToMirrorAxis = false;

--- a/Assets/Tests/EditMode/BranchPreviewSettingsPersistenceTests.cs
+++ b/Assets/Tests/EditMode/BranchPreviewSettingsPersistenceTests.cs
@@ -116,5 +116,18 @@ namespace RogueliteAutoBattler.Tests.EditMode
             float mirrorAxis = EditorPrefs.GetFloat(MirrorAxisPersistence.EditorPrefKey);
             Assert.That(mirrorAxis, Is.EqualTo(99f).Within(Tolerance));
         }
+
+        [Test]
+        public void Save_RoundTrips_DoesNotMutateDefaults()
+        {
+            BranchPreviewSettings before = BranchPreviewSettings.Defaults;
+            BranchPreviewSettings toSave = new BranchPreviewSettings { distance = 13f, angleDegrees = 91f, mirrorEnabled = true, mirrorAxisDegrees = before.mirrorAxisDegrees };
+            BranchPreviewSettingsPersistence.Save(toSave);
+            BranchPreviewSettings after = BranchPreviewSettings.Defaults;
+            Assert.AreEqual(before.distance, after.distance);
+            Assert.AreEqual(before.angleDegrees, after.angleDegrees);
+            Assert.AreEqual(before.mirrorEnabled, after.mirrorEnabled);
+            Assert.AreEqual(before.mirrorAxisDegrees, after.mirrorAxisDegrees);
+        }
     }
 }

--- a/Assets/Tests/EditMode/BranchPreviewSettingsPersistenceTests.cs
+++ b/Assets/Tests/EditMode/BranchPreviewSettingsPersistenceTests.cs
@@ -9,17 +9,30 @@ namespace RogueliteAutoBattler.Tests.EditMode
     {
         private const float Tolerance = 1e-4f;
 
+        private const float RoundTripDistance = 7f;
+        private const float RoundTripAngle = 42f;
+        private const float ImmutabilityDistance = 13f;
+        private const float ImmutabilityAngle = 91f;
+        private const float SentinelPersistedAngle = 123.45f;
+        private const float SentinelMirrorAxisDegrees = 99f;
+        private const float MirrorAxisRoundTrip = 55f;
+
+        private static readonly Vector2 ArbitraryParentPos = new Vector2(1f, 1f);
+        private static readonly Vector2 NonOriginParentPos = new Vector2(3f, 4f);
+
         [SetUp]
         public void SetUp()
         {
-            EditorPrefs.DeleteKey(BranchPreviewSettingsPersistence.DistanceKey);
-            EditorPrefs.DeleteKey(BranchPreviewSettingsPersistence.AngleKey);
-            EditorPrefs.DeleteKey(BranchPreviewSettingsPersistence.MirrorEnabledKey);
-            EditorPrefs.DeleteKey(MirrorAxisPersistence.EditorPrefKey);
+            ClearPrefs();
         }
 
         [TearDown]
         public void TearDown()
+        {
+            ClearPrefs();
+        }
+
+        private static void ClearPrefs()
         {
             EditorPrefs.DeleteKey(BranchPreviewSettingsPersistence.DistanceKey);
             EditorPrefs.DeleteKey(BranchPreviewSettingsPersistence.AngleKey);
@@ -44,10 +57,10 @@ namespace RogueliteAutoBattler.Tests.EditMode
         {
             var settings = new BranchPreviewSettings
             {
-                distance = 7f,
-                angleDegrees = 42f,
+                distance = RoundTripDistance,
+                angleDegrees = RoundTripAngle,
                 mirrorEnabled = true,
-                mirrorAxisDegrees = BranchPreviewSettings.Defaults.mirrorAxisDegrees
+                mirrorAxisDegrees = MirrorAxisRoundTrip
             };
 
             BranchPreviewSettingsPersistence.Save(settings);
@@ -55,10 +68,11 @@ namespace RogueliteAutoBattler.Tests.EditMode
 
             BranchPreviewSettings result = BranchPreviewSettingsPersistence.Load();
 
-            Assert.That(result.distance, Is.EqualTo(7f).Within(Tolerance));
-            Assert.That(result.angleDegrees, Is.EqualTo(42f).Within(Tolerance));
+            Assert.That(result.distance, Is.EqualTo(RoundTripDistance).Within(Tolerance));
+            Assert.That(result.angleDegrees, Is.EqualTo(RoundTripAngle).Within(Tolerance));
             Assert.That(result.mirrorEnabled, Is.True);
-            Assert.That(result.mirrorAxisDegrees, Is.EqualTo(settings.mirrorAxisDegrees).Within(Tolerance));
+            // Load no longer touches the mirror axis: it stays at struct defaults regardless of EditorPrefs.
+            Assert.That(result.mirrorAxisDegrees, Is.EqualTo(BranchPreviewSettings.Defaults.mirrorAxisDegrees).Within(Tolerance));
         }
 
         [Test]
@@ -83,10 +97,9 @@ namespace RogueliteAutoBattler.Tests.EditMode
         [Test]
         public void ResolveInitialAngle_NoPersisted_FallsBackToComputeDefault()
         {
-            var parentPos = new Vector2(3f, 4f);
-            float expected = BranchPlacement.ComputeDefaultAngle(parentPos);
+            float expected = BranchPlacement.ComputeDefaultAngle(NonOriginParentPos);
 
-            float result = BranchPreviewSettingsPersistence.ResolveInitialAngle(false, 0f, parentPos);
+            float result = BranchPreviewSettingsPersistence.ResolveInitialAngle(false, 0f, NonOriginParentPos);
 
             Assert.That(result, Is.EqualTo(expected).Within(Tolerance));
         }
@@ -94,34 +107,40 @@ namespace RogueliteAutoBattler.Tests.EditMode
         [Test]
         public void ResolveInitialAngle_HasPersisted_ReturnsPersisted()
         {
-            float result = BranchPreviewSettingsPersistence.ResolveInitialAngle(true, 123.45f, new Vector2(1f, 1f));
+            float result = BranchPreviewSettingsPersistence.ResolveInitialAngle(true, SentinelPersistedAngle, ArbitraryParentPos);
 
-            Assert.That(result, Is.EqualTo(123.45f).Within(Tolerance));
+            Assert.That(result, Is.EqualTo(SentinelPersistedAngle).Within(Tolerance));
         }
 
         [Test]
         public void Save_DoesNotTouchMirrorAxisKey()
         {
-            EditorPrefs.SetFloat(MirrorAxisPersistence.EditorPrefKey, 99f);
+            EditorPrefs.SetFloat(MirrorAxisPersistence.EditorPrefKey, SentinelMirrorAxisDegrees);
 
             var settings = new BranchPreviewSettings
             {
                 distance = BranchPreviewSettings.Defaults.distance,
                 angleDegrees = BranchPreviewSettings.Defaults.angleDegrees,
                 mirrorEnabled = BranchPreviewSettings.Defaults.mirrorEnabled,
-                mirrorAxisDegrees = 55f
+                mirrorAxisDegrees = MirrorAxisRoundTrip
             };
             BranchPreviewSettingsPersistence.Save(settings);
 
             float mirrorAxis = EditorPrefs.GetFloat(MirrorAxisPersistence.EditorPrefKey);
-            Assert.That(mirrorAxis, Is.EqualTo(99f).Within(Tolerance));
+            Assert.That(mirrorAxis, Is.EqualTo(SentinelMirrorAxisDegrees).Within(Tolerance));
         }
 
         [Test]
         public void Save_RoundTrips_DoesNotMutateDefaults()
         {
             BranchPreviewSettings before = BranchPreviewSettings.Defaults;
-            BranchPreviewSettings toSave = new BranchPreviewSettings { distance = 13f, angleDegrees = 91f, mirrorEnabled = true, mirrorAxisDegrees = before.mirrorAxisDegrees };
+            BranchPreviewSettings toSave = new BranchPreviewSettings
+            {
+                distance = ImmutabilityDistance,
+                angleDegrees = ImmutabilityAngle,
+                mirrorEnabled = true,
+                mirrorAxisDegrees = before.mirrorAxisDegrees
+            };
             BranchPreviewSettingsPersistence.Save(toSave);
             BranchPreviewSettings after = BranchPreviewSettings.Defaults;
             Assert.AreEqual(before.distance, after.distance);

--- a/Assets/Tests/EditMode/BranchPreviewSettingsPersistenceTests.cs
+++ b/Assets/Tests/EditMode/BranchPreviewSettingsPersistenceTests.cs
@@ -1,0 +1,120 @@
+using NUnit.Framework;
+using RogueliteAutoBattler.Editor.Tools;
+using UnityEditor;
+using UnityEngine;
+
+namespace RogueliteAutoBattler.Tests.EditMode
+{
+    public class BranchPreviewSettingsPersistenceTests
+    {
+        private const float Tolerance = 1e-4f;
+
+        [SetUp]
+        public void SetUp()
+        {
+            EditorPrefs.DeleteKey(BranchPreviewSettingsPersistence.DistanceKey);
+            EditorPrefs.DeleteKey(BranchPreviewSettingsPersistence.AngleKey);
+            EditorPrefs.DeleteKey(BranchPreviewSettingsPersistence.MirrorEnabledKey);
+            EditorPrefs.DeleteKey(MirrorAxisPersistence.EditorPrefKey);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            EditorPrefs.DeleteKey(BranchPreviewSettingsPersistence.DistanceKey);
+            EditorPrefs.DeleteKey(BranchPreviewSettingsPersistence.AngleKey);
+            EditorPrefs.DeleteKey(BranchPreviewSettingsPersistence.MirrorEnabledKey);
+            EditorPrefs.DeleteKey(MirrorAxisPersistence.EditorPrefKey);
+        }
+
+        [Test]
+        public void Load_KeysAbsent_ReturnsDefaults()
+        {
+            BranchPreviewSettings result = BranchPreviewSettingsPersistence.Load();
+
+            BranchPreviewSettings defaults = BranchPreviewSettings.Defaults;
+            Assert.That(result.distance, Is.EqualTo(defaults.distance).Within(Tolerance));
+            Assert.That(result.angleDegrees, Is.EqualTo(defaults.angleDegrees).Within(Tolerance));
+            Assert.That(result.mirrorEnabled, Is.EqualTo(defaults.mirrorEnabled));
+            Assert.That(result.mirrorAxisDegrees, Is.EqualTo(defaults.mirrorAxisDegrees).Within(Tolerance));
+        }
+
+        [Test]
+        public void SaveThenLoad_RoundTripsAllFields()
+        {
+            var settings = new BranchPreviewSettings
+            {
+                distance = 7f,
+                angleDegrees = 42f,
+                mirrorEnabled = true,
+                mirrorAxisDegrees = BranchPreviewSettings.Defaults.mirrorAxisDegrees
+            };
+
+            BranchPreviewSettingsPersistence.Save(settings);
+            EditorPrefs.SetFloat(MirrorAxisPersistence.EditorPrefKey, settings.mirrorAxisDegrees);
+
+            BranchPreviewSettings result = BranchPreviewSettingsPersistence.Load();
+
+            Assert.That(result.distance, Is.EqualTo(7f).Within(Tolerance));
+            Assert.That(result.angleDegrees, Is.EqualTo(42f).Within(Tolerance));
+            Assert.That(result.mirrorEnabled, Is.True);
+            Assert.That(result.mirrorAxisDegrees, Is.EqualTo(settings.mirrorAxisDegrees).Within(Tolerance));
+        }
+
+        [Test]
+        public void HasPersistedAngle_KeyAbsent_ReturnsFalse()
+        {
+            bool result = BranchPreviewSettingsPersistence.HasPersistedAngle();
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void HasPersistedAngle_AfterSave_ReturnsTrue()
+        {
+            var settings = BranchPreviewSettings.Defaults;
+            BranchPreviewSettingsPersistence.Save(settings);
+
+            bool result = BranchPreviewSettingsPersistence.HasPersistedAngle();
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void ResolveInitialAngle_NoPersisted_FallsBackToComputeDefault()
+        {
+            var parentPos = new Vector2(3f, 4f);
+            float expected = BranchPlacement.ComputeDefaultAngle(parentPos);
+
+            float result = BranchPreviewSettingsPersistence.ResolveInitialAngle(false, 0f, parentPos);
+
+            Assert.That(result, Is.EqualTo(expected).Within(Tolerance));
+        }
+
+        [Test]
+        public void ResolveInitialAngle_HasPersisted_ReturnsPersisted()
+        {
+            float result = BranchPreviewSettingsPersistence.ResolveInitialAngle(true, 123.45f, new Vector2(1f, 1f));
+
+            Assert.That(result, Is.EqualTo(123.45f).Within(Tolerance));
+        }
+
+        [Test]
+        public void Save_DoesNotTouchMirrorAxisKey()
+        {
+            EditorPrefs.SetFloat(MirrorAxisPersistence.EditorPrefKey, 99f);
+
+            var settings = new BranchPreviewSettings
+            {
+                distance = BranchPreviewSettings.Defaults.distance,
+                angleDegrees = BranchPreviewSettings.Defaults.angleDegrees,
+                mirrorEnabled = BranchPreviewSettings.Defaults.mirrorEnabled,
+                mirrorAxisDegrees = 55f
+            };
+            BranchPreviewSettingsPersistence.Save(settings);
+
+            float mirrorAxis = EditorPrefs.GetFloat(MirrorAxisPersistence.EditorPrefKey);
+            Assert.That(mirrorAxis, Is.EqualTo(99f).Within(Tolerance));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/BranchPreviewSettingsPersistenceTests.cs.meta
+++ b/Assets/Tests/EditMode/BranchPreviewSettingsPersistenceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd3646fa67dc41b499ca76ea859c297b

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 Doc detaille : `Assets/doc/premier-jet-roguelite.html`
 
 # Project Structure
-Generated: 2026-05-03
+Generated: 2026-05-04
 
 .github/
   workflows/
@@ -149,6 +149,7 @@ Assets/
       Tools/
         BranchPlacement.cs
         BranchPreviewSettings.cs
+        BranchPreviewSettingsPersistence.cs
         EditorAssetFolders.cs
         HudIconsImporter.cs
         LevelDatabaseBackgroundMigrator.cs
@@ -240,6 +241,7 @@ Assets/
       BranchPlacementMirrorAngleTests.cs
       BranchPlacementTests.cs
       BranchPreviewSettingsDefaultsTests.cs
+      BranchPreviewSettingsPersistenceTests.cs
       HudIconAssetTests.cs
       MirrorAxisGeometryTests.cs
       MirrorAxisPersistenceTests.cs


### PR DESCRIPTION
## Summary
- New `BranchPreviewSettingsPersistence` helper persists branch creation form values (distance / angle / mirror enabled) across Unity sessions via `EditorPrefs`.
- Reuses `MirrorAxisPersistence.EditorPrefKey` for the mirror axis (orthogonal cohabitation, no duplication).
- `ResolveInitialAngle(parentPos)` overload reads `EditorPrefs` directly so the call site no longer relies on coincidental coupling with `_lastBranchPreviewSettings`.
- 8 EditMode tests cover round-trip, defaults, persistence/non-persistence of angle, and isolation from the mirror axis key.

Closes #296

## Test plan
- [x] EditMode suite 466/466 green (incl. 8 new `BranchPreviewSettingsPersistenceTests`, untouched `MirrorAxisPersistenceTests` 4/4, `MirrorAxisPersistenceWiringTests` 4/4, `BranchPreviewSettingsDefaultsTests` 3/3)
- [ ] Manual smoke (visual safety net, in addition to tests):
  - [ ] Modify distance/angle/mirror in branch preview, close + reopen window → values restored
  - [ ] Toggle `mirrorEnabled`, restart Unity, reopen window → toggle conserved across sessions
  - [ ] First branch preview after EditorPrefs reset on a non-origin parent → angle = `ComputeDefaultAngle(parentPos)` (default behavior preserved)
  - [ ] Mirror axis slider still persists across sessions (no regression on `MirrorAxisPersistence`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)